### PR TITLE
Update go module name to use the new home on GitHub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jradtilbrook/terraform-provider-buildkite
+module github.com/buildkite/terraform-provider-buildkite
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/jradtilbrook/terraform-provider-buildkite/buildkite"
+	"github.com/buildkite/terraform-provider-buildkite/buildkite"
 )
 
 func main() {


### PR DESCRIPTION
This ensures building the plugin uses the code in this repo:

    $ go build -o buildkite-terraform .