### PR TITLE
Expand the README to mention the scopes required on the API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Buildkite Terraform Provider
 
-This is the official Terraform provider for Buildkite.
+This is the official Terraform provider for [Buildkite](https://buildkite.com).
 
 The provider allows you to manage resources in your Buildkite organization.
+
+Two configuration values are required:
+
+* An API token, generated at https://buildkite.com/user/api-access-tokens. The
+  token must have the `write_pipelines` REST API scope and be enabled for GraphQL
+* A Buildkite organization slug, available by signing into buildkite.com and
+  examining the URL: https://buildkite.com/<org-slug>
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,26 @@
 # Buildkite Provider
 
-This provider can be used to manage resources on `buildkite.com` via Terraform.
+This provider can be used to manage resources on [buildkite.com](https://buildkite.com) via Terraform.
 
-Create an API Access Token in Buildkite at https://buildkite.com/user/api-access-tokens/new.
+Two configuration values are required:
+
+* An API token, generated at https://buildkite.com/user/api-access-tokens. The
+  token must have the `write_pipelines` REST API scope and be enabled for GraphQL
+* A Buildkite organization slug, available by signing into buildkite.com and
+  examining the URL: https://buildkite.com/<org-slug>
 
 ## Example Usage
 
 ```hcl
+terraform {
+  required_providers {
+    buildkite = {
+      source = "jradtilbrook/buildkite"
+      version = "0.0.15"
+    }
+  }
+}
+
 provider "buildkite" {
     api_token = "token" # can also be set from env: BUILDKITE_API_TOKEN
     organization = "slug" # can also be set from env: BUILDKITE_ORGANIZATION


### PR DESCRIPTION
This detail is already in the provider docs in the Argument Reference, however I didn't notice them and ended up looking in the code first.

I assume we'll want to mostly point to the docs hosted by the registry as the best place to learn how to use the provider, but I reckon the API token requirements are important enough to also list in the README.