### PR TITLE
remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @jradtilbrook


### PR DESCRIPTION
Multiple engineers at Buildkite will support this repo now, no need for every PR to dob @jradtilbrook in for reviews