### PR TITLE
Add a release pipeline

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: release
+    command: ".buildkite/steps/release.sh"
+    plugins:
+      docker-compose#v2.2.0:
+        run: go
+    agents:
+      queue: "deploy"
+

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# TODO: exit if HEAD isn't tagged with a release
+# TODO: exit if the tagger release is already on GitHub
+
+if [[ ${BUILDKITE_BRANCH} != "main" ]]; then
+    echo
+    echo "Releases can only happen on the main branch"
+    echo
+    exit 0
+fi
+
+echo "--- importing GPG Secret Key"
+
+if [ -z "$GPG_SECRET_KEY_BASE64" ]
+then
+      echo "\$GPG_SECRET_KEY_BASE64 env variable must contain a base64 encoded GPG secret key"
+      exit 1
+fi
+
+echo "${GPG_SECRET_KEY_BASE64}" | base64 -d | gpg --import --no-tty --batch --yes
+
+gpg --list-secret-keys
+
+# GPG_FINGERPRINT is read by goreleaser
+export GPG_FINGERPRINT="$(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5)"
+
+echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}"
+
+echo "--- Checking GitHub Token"
+if [ -z "$GITHUB_TOKEN" ]
+then
+      echo "\$GITHUB_TOKEN env variable must contain a Github API token with permission to create releases in buildkite/terraform-provider-buildkite"
+      exit 1
+fi
+
+echo "--- installing goreleaser"
+
+curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.149.0/goreleaser_Linux_x86_64.tar.gz
+
+cd /tmp && echo "a227362d734cda47f7ebed9762e6904edcd115a65084384ecfbad2baebc4c775  goreleaser_Linux_x86_64.tar.gz" | sha256sum -c
+
+tar -zxvf goreleaser_Linux_x86_64.tar.gz
+
+cp goreleaser /work
+
+cd /work
+
+echo "--- running goreleaser"
+
+./goreleaser release --rm-dist

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ vendor/
 # GoReleaser dist
 dist/
 
+# goreleaser bin
+goreleaser
+
 # IDE files
 .idea
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ signs:
       # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
+      - "--no-tty"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,6 @@ services:
     volumes:
       - .:/work
     working_dir: /work
+    environment:
+      - GPG_SECRET_KEY_BASE64
+      - GITHUB_TOKEN


### PR DESCRIPTION
Releasing to Github requires a private GPG key and GitHub token, so we run the pipeline in a different context to the main build pipeline.

This is a  slightly awkward process compared to our normal create-a-gh-release pipeline because terraform recommend using goreleaser and I wanted to follow their golden path to avoid any surprises.

I'm reasonably confident this will work great, however so far I've only run it in dry mode. I'll do a for-reals test after it merges to master.