### PR TITLE
feat: pipeline_schedule resource type

### DIFF
--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -8,9 +8,10 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"buildkite_agent_token": resourceAgentToken(),
-			"buildkite_pipeline":    resourcePipeline(),
-			"buildkite_team":        resourceTeam(),
+			"buildkite_agent_token":       resourceAgentToken(),
+			"buildkite_pipeline":          resourcePipeline(),
+			"buildkite_pipeline_schedule": resourcePipelineSchedule(),
+			"buildkite_team":              resourceTeam(),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization": &schema.Schema{

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/shurcooL/graphql"
 )
 

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -1,0 +1,222 @@
+package buildkite
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/shurcooL/graphql"
+)
+
+// PipelineScheduleNode represents a pipeline schedule as returned from the GraphQL API
+type PipelineScheduleNode struct {
+	Branch   graphql.String
+	Commit   graphql.String
+	Cronline graphql.String
+	Enabled  graphql.Boolean
+	Env      []graphql.String
+	ID       graphql.String
+	Label    graphql.String
+	Message  graphql.String
+	Pipeline struct {
+		ID graphql.String
+	}
+}
+
+// resourcePipelineSchedule represents the terraform pipeline_schedule resource schema
+func resourcePipelineSchedule() *schema.Resource {
+	return &schema.Resource{
+		Create: CreatePipelineSchedule,
+		Read:   ReadPipelineSchedule,
+		Update: UpdatePipelineSchedule,
+		Delete: DeletePipelineSchedule,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"pipeline_id": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"label": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"cronline": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"commit": {
+				Optional: true,
+				Default:  "HEAD",
+				Type:     schema.TypeString,
+			},
+			"branch": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"message": {
+				Optional: true,
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"env": {
+				Optional: true,
+				Type:     schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"enabled": {
+				Optional: true,
+				Default:  true,
+				Type:     schema.TypeBool,
+			},
+		},
+	}
+}
+
+// CreatePipelineSchedule creates a Buildkite pipeline schedule
+func CreatePipelineSchedule(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	var mutation struct {
+		PipelineScheduleCreatePayload struct {
+			Pipeline             PipelineNode
+			PipelineScheduleEdge struct {
+				Node PipelineScheduleNode
+			}
+		} `graphql:"pipelineScheduleCreate(input: {pipelineID: $pipeline_id, branch: $branch, commit: $commit, cronline: $cronline, enabled: $enabled, env: $env, label: $label, message: $message})"`
+	}
+	vars := map[string]interface{}{
+		"pipeline_id": graphql.ID(d.Get("pipeline_id").(string)),
+		"label":       graphql.String(d.Get("label").(string)),
+		"cronline":    graphql.String(d.Get("cronline").(string)),
+		"commit":      graphql.String(d.Get("commit").(string)),
+		"branch":      graphql.String(d.Get("branch").(string)),
+		"message":     graphql.String(d.Get("message").(string)),
+		"env":         graphql.String(envVarsToString(d.Get("env").(map[string]interface{}))),
+		"enabled":     graphql.Boolean(d.Get("enabled").(bool)),
+	}
+
+	log.Printf("Creating pipeline %s ...", vars["label"])
+	var err = client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		log.Printf("Unable to create pipeline schedule %s", d.Get("label"))
+		return err
+	}
+	log.Printf("Successfully created pipeline schedule with id '%s'.", mutation.PipelineScheduleCreatePayload.PipelineScheduleEdge.Node.ID)
+
+	updatePipelineScheduleResource(d, &mutation.PipelineScheduleCreatePayload.PipelineScheduleEdge.Node)
+	return ReadPipelineSchedule(d, m)
+}
+
+// ReadPipelineSchedule retrieves a Buildkite pipeline schedule
+func ReadPipelineSchedule(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+	var query struct {
+		Node struct {
+			PipelineSchedule PipelineScheduleNode `graphql:"... on PipelineSchedule"`
+		} `graphql:"node(id: $id)"`
+	}
+	vars := map[string]interface{}{
+		"id": graphql.ID(d.Id()),
+	}
+
+	err := client.graphql.Query(context.Background(), &query, vars)
+	if err != nil {
+		return err
+	}
+
+	updatePipelineScheduleResource(d, &query.Node.PipelineSchedule)
+	return nil
+}
+
+// UpdatePipelineSchedule updates a Buildkite pipeline schedule
+func UpdatePipelineSchedule(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+	var mutation struct {
+		PipelineScheduleUpdate struct {
+			PipelineSchedule PipelineScheduleNode
+		} `graphql:"pipelineScheduleUpdate(input: {id: $id, branch: $branch, commit: $commit, cronline: $cronline, enabled: $enabled, env: $env, label: $label, message: $message})"`
+	}
+	vars := map[string]interface{}{
+		"id":       graphql.ID(d.Id()),
+		"label":    graphql.String(d.Get("label").(string)),
+		"cronline": graphql.String(d.Get("cronline").(string)),
+		"commit":   graphql.String(d.Get("commit").(string)),
+		"branch":   graphql.String(d.Get("branch").(string)),
+		"message":  graphql.String(d.Get("message").(string)),
+		"env":      graphql.String(envVarsToString(d.Get("env").(map[string]interface{}))),
+		"enabled":  graphql.Boolean(d.Get("enabled").(bool)),
+	}
+
+	log.Printf("Updating pipeline schedule %s ...", vars["label"])
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		log.Printf("Unable to update pipeline schedule %s", d.Get("label"))
+		return err
+	}
+
+	updatePipelineScheduleResource(d, &mutation.PipelineScheduleUpdate.PipelineSchedule)
+	return ReadPipelineSchedule(d, m)
+}
+
+// DeletePipelineSchedule removes a Buildkite pipeline schedule
+func DeletePipelineSchedule(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	var mutation struct {
+		PipelineScheduleDelete struct {
+			Pipeline PipelineNode
+		} `graphql:"pipelineScheduleDelete(input: {id: $id})"`
+	}
+	vars := map[string]interface{}{
+		"id": graphql.ID(d.Id()),
+	}
+
+	log.Printf("Deleting pipeline schedule %s ...", d.Get("label"))
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		log.Printf("Unable to delete pipeline %s", d.Get("label"))
+		return err
+	}
+
+	return nil
+}
+
+// updatePipelineScheduleResource updates the terraform resource data for the pipeline_schedule resource
+func updatePipelineScheduleResource(d *schema.ResourceData, pipelineSchedule *PipelineScheduleNode) {
+	d.SetId(string(pipelineSchedule.ID))
+	d.Set("pipeline_id", string(pipelineSchedule.Pipeline.ID))
+	d.Set("label", string(pipelineSchedule.Label))
+	d.Set("cronline", string(pipelineSchedule.Cronline))
+	d.Set("message", string(pipelineSchedule.Message))
+	d.Set("commit", string(pipelineSchedule.Commit))
+	d.Set("branch", string(pipelineSchedule.Branch))
+	d.Set("env", envVarsArrayToMap(pipelineSchedule.Env))
+	d.Set("enabled", bool(pipelineSchedule.Enabled))
+}
+
+// converts env vars map to a newline-separated string
+func envVarsToString(m map[string]interface{}) string {
+	b := new(bytes.Buffer)
+	for key, value := range m {
+		fmt.Fprintf(b, "%s=%s\n", key, value.(string))
+	}
+	return b.String()
+}
+
+// converts env vars array of Strings to a map
+func envVarsArrayToMap(envVarsArray []graphql.String) map[string]string {
+	result := make(map[string]string)
+	for _, envVar := range envVarsArray {
+		tuple := strings.Split(string(envVar), "=")
+		result[tuple[0]] = tuple[1]
+	}
+	return result
+}

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -28,8 +28,8 @@ resource "buildkite_pipeline_schedule" "repo2_nightly" {
 
 ## Import
 
-Pipeline schedules can be imported using the `GraphQL ID` (not UUID), e.g.
+Pipeline schedules can be imported using a slug (which consists of `$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_SLUG/$PIPELINE_SCHEDULE_UUID`), e.g.
 
 ```
-$ terraform import buildkite_pipeline_schedule.test UGlwZWxpbmUtLS00MzVjYWQ1OC1lODFkLTQ1YWYtODYzNy1iMWNmODA3MDIzOGQ=
+$ terraform import buildkite_pipeline_schedule.test myorg/test/1be3e7c7-1e03-4011-accf-b2d8eec90222
 ```

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -21,7 +21,7 @@ resource "buildkite_pipeline_schedule" "repo2_nightly" {
 * `label` - (Required) Schedule label.
 * `cronline` - (Required) Schedule interval (see [docs](https://buildkite.com/docs/pipelines/scheduled-builds#schedule-intervals)).
 * `branch` - (Required) The branch to use for the build.
-* `commit` - (Optional, Default: `HEAD`) The commit ref to use for the build..
+* `commit` - (Optional, Default: `HEAD`) The commit ref to use for the build.
 * `message` - (Optional, Default: `Scheduled build`) The message to use for the build.
 * `env` - (Optional) A map of environment variables to use for the build.
 * `enabled` - (Optional, Default: `true`) Whether the schedule should run.

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -1,4 +1,4 @@
-# Resource: pipeline
+# Resource: pipeline_schedule
 
 This resource allows you to create and manage pipeline schedules.
 

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -1,0 +1,35 @@
+# Resource: pipeline
+
+This resource allows you to create and manage pipeline schedules.
+
+Buildkite Documentation: https://buildkite.com/docs/pipelines/scheduled-builds
+
+## Example Usage
+
+```hcl
+resource "buildkite_pipeline_schedule" "repo2_nightly" {
+  pipeline_id = buildkite_pipeline.repo2.id
+  label       = "Nightly build"
+  cronline    = "@midnight"
+  branch      = buildkite_pipeline.repo2.default_branch
+}
+```
+
+## Argument Reference
+
+* `pipeline_id` - (Required) Terraform resource ID of a buildkite pipeline (Buildkite GraphQL ID).
+* `label` - (Required) Schedule label.
+* `cronline` - (Required) Schedule interval (see [docs](https://buildkite.com/docs/pipelines/scheduled-builds#schedule-intervals)).
+* `branch` - (Required) The branch to use for the build.
+* `commit` - (Optional, Default: `HEAD`) The commit ref to use for the build..
+* `message` - (Optional, Default: `Scheduled build`) The message to use for the build.
+* `env` - (Optional) A map of environment variables to use for the build.
+* `enabled` - (Optional, Default: `true`) Whether the schedule should run.
+
+## Import
+
+Pipeline schedules can be imported using the `GraphQL ID` (not UUID), e.g.
+
+```
+$ terraform import buildkite_pipeline_schedule.test UGlwZWxpbmUtLS00MzVjYWQ1OC1lODFkLTQ1YWYtODYzNy1iMWNmODA3MDIzOGQ=
+```


### PR DESCRIPTION
Closes #58

Example: 
```hcl-terraform
resource "buildkite_pipeline_schedule" "my-schedule" {
  pipeline_id = buildkite_pipeline.<resource_name>.id
  cronline    = "0 *  * * *"
  label       = "My schedule"
}
```
I did some manual testing locally and it works fine, however, this is the first time I'm writing `golang` code so some obvious bugs are probably still there.

Also, I'm not sure how to write automated tests for this...

TODOs:
- [x] Update docs