### PR TITLE
Add statement regarding teams expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ is the recommended location for guidance on using this provider.
 
 ## Installation
 
+**NOTE**: This provider is built with the assumption that Buildkite Teams are enabled for your organisation. Most resources should work without, but we can't guarantee compatibility. Check out our [documentation regarding Teams](https://buildkite.com/docs/pipelines/permissions#permissions-with-teams) for more information.
+
 To use the provider, add the following terraform:
 
 ```hcl


### PR DESCRIPTION
There are some [implications for enabling Teams](https://buildkite.com/docs/pipelines/permissions) in an organization, and in order to support useful Teams features in this Terraform provider, we should acceptance test them. Our current acceptance tests function without Teams enabled in our test organization (`buildkite-terraform-provider-test-org`) and it's a barrier at the moment for writing further acceptance tests that consider them. Should we consider a broad recommendation that users enable Teams and switch it ON for all acceptance tests?

### Motivation
- Maintaining multiple sets of acceptance tests to support the case of teams not being enabled adds significantly to our overall test coverage requirements
- Supporting gear such as a secondary organization or function to toggle teams for tests adds to cognitive complexity and testing for contributors
- The above two problems might discourage contributors and add to development time
- Most (present and future) consumers of this Terraform provider for managing Buildkite are probably already using Teams, or would be willing to enable Teams in order to use this provider
- Teams is free for any of our customers to use (barring some features regarding member permissions reserved for enterprise organizations)
- We would not stop anyone from using the provider without Teams enabled, and if they did, it's likely that the provider will still work fine (i.e. we support "at your own risk" usage and deprioritize support for issues relating to use without Teams)