### PR TITLE
update goreleaser from v0.149.0 to v0.157.0

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -45,9 +45,9 @@ fi
 
 echo "--- installing goreleaser"
 
-curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.149.0/goreleaser_Linux_x86_64.tar.gz
+curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.157.0/goreleaser_Linux_x86_64.tar.gz
 
-cd /tmp && echo "a227362d734cda47f7ebed9762e6904edcd115a65084384ecfbad2baebc4c775  goreleaser_Linux_x86_64.tar.gz" | sha256sum -c
+cd /tmp && echo "a03082c770d0966db434c8d355b7df337698f7dc669b4ac40db5d3927426308f  goreleaser_Linux_x86_64.tar.gz" | sha256sum -c
 
 tar -zxvf goreleaser_Linux_x86_64.tar.gz
 


### PR DESCRIPTION
[v0.156.x adds support for compiling a native binary for Apple Silicon systems](https://github.com/goreleaser/goreleaser/releases/tag/v0.156.2):

> GOOS=darwin GOARCH=arm64 was ignored before this release, since it was
> a build for iOS that most people didn't care about and required more
> than just go to build.
>
> On Go 1.16, this target is now the macOS on Apple Silicon. GoReleaser
> v0.156.0+ is built for Go 1.16+ and will try to build the darwin arm64
> target if the config allows it

This is hard to test, we might just have to wait until we're ready to make an actual release.

Closes #94 (probably).