### PR TITLE
Add a pipeline data source

### DIFF
--- a/buildkite/data_source_pipeline.go
+++ b/buildkite/data_source_pipeline.go
@@ -1,0 +1,77 @@
+package buildkite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/shurcooL/graphql"
+)
+
+func dataSourcePipeline() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePipelineRead,
+		Schema: map[string]*schema.Schema{
+			"default_branch": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"description": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"name": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"repository": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"slug": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"webhook_url": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}
+
+// ReadPipeline retrieves a Buildkite pipeline
+func dataSourcePipelineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	client := m.(*Client)
+	var query struct {
+		Pipeline PipelineNode `graphql:"pipeline(slug: $slug)"`
+	}
+	orgPipelineSlug := fmt.Sprintf("%s/%s", client.organization, d.Get("slug").(string))
+	vars := map[string]interface{}{
+		"slug": graphql.ID(orgPipelineSlug),
+	}
+
+	err := client.graphql.Query(context.Background(), &query, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if query.Pipeline.ID == "" {
+		return diag.FromErr(errors.New("Pipeline not found"))
+	}
+
+	d.SetId(string(query.Pipeline.ID))
+	d.Set("default_branch", string(query.Pipeline.DefaultBranch))
+	d.Set("description", string(query.Pipeline.Description))
+	d.Set("name", string(query.Pipeline.Name))
+	d.Set("repository", string(query.Pipeline.Repository.URL))
+	d.Set("slug", string(query.Pipeline.Slug))
+	d.Set("webhook_url", string(query.Pipeline.WebhookURL))
+
+	return diags
+}

--- a/buildkite/data_source_pipeline_test.go
+++ b/buildkite/data_source_pipeline_test.go
@@ -1,0 +1,52 @@
+package buildkite
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Confirm that we can create a new agent token, and then delete it without error
+func TestAccDataPipeline_read(t *testing.T) {
+	var resourcePipeline PipelineNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPipelineResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPipelineConfigBasic("foo"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the pipeline exists in the buildkite API
+					testAccCheckPipelineExists("buildkite_pipeline.foobar", &resourcePipeline),
+					// Confirm the pipeline data source has the correct values in terraform state
+					resource.TestCheckResourceAttr("data.buildkite_pipeline.foobar", "name", "Test Pipeline foo"),
+					resource.TestCheckResourceAttr("data.buildkite_pipeline.foobar", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+					resource.TestCheckResourceAttr("data.buildkite_pipeline.foobar", "default_branch", "main"),
+					resource.TestCheckResourceAttr("data.buildkite_pipeline.foobar", "description", "A test pipeline foo"),
+					resource.TestMatchResourceAttr("data.buildkite_pipeline.foobar", "webhook_url", regexp.MustCompile("^https://webhook.buildkite.com/deliver/.+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPipelineConfigBasic(name string) string {
+	config := `
+		resource "buildkite_pipeline" "foobar" {
+			name = "Test Pipeline %s"
+			repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+			default_branch = "main"
+			description = "A test pipeline %s"
+			steps = ""
+		}
+
+		data "buildkite_pipeline" "foobar" {
+			slug = buildkite_pipeline.foobar.slug
+		}
+	`
+	return fmt.Sprintf(config, name, name)
+}

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -13,6 +13,9 @@ func Provider() *schema.Provider {
 			"buildkite_pipeline_schedule": resourcePipelineSchedule(),
 			"buildkite_team":              resourceTeam(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"buildkite_pipeline": dataSourcePipeline(),
+		},
 		Schema: map[string]*schema.Schema{
 			"organization": &schema.Schema{
 				DefaultFunc: schema.EnvDefaultFunc("BUILDKITE_ORGANIZATION", nil),

--- a/docs/data-sources/pipeline.md
+++ b/docs/data-sources/pipeline.md
@@ -20,7 +20,7 @@ data "buildkite_pipeline" "repo2" {
 ## Attributes Reference
 
 * `description` - A description of the pipeline.
-* `default_branch` - The default branch to prefill when new builds are created or triggered.
+* `default_branch` - The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
 * `name` - The name of the pipeline.
 * `repository` - The git URL of the repository.
 * `webhook_url` - The default branch to prefill when new builds are created or triggered.

--- a/docs/data-sources/pipeline.md
+++ b/docs/data-sources/pipeline.md
@@ -1,0 +1,26 @@
+# Data Source: pipeline
+
+Use this data source to look up properties on a specific pipeline. This is
+particularly useful for looking up the webhook URL for each pipeline.
+
+Buildkite Documentation: https://buildkite.com/docs/pipelines
+
+## Example Usage
+
+```hcl
+data "buildkite_pipeline" "repo2" {
+    slug = "repo2"
+}
+```
+
+## Argument Reference
+
+* `slug` - (Required) The slug of the pipeline, available in the URL of the pipeline on buildkite.com
+
+## Attributes Reference
+
+* `description` - A description of the pipeline.
+* `default_branch` - The default branch to prefill when new builds are created or triggered.
+* `name` - The name of the pipeline.
+* `repository` - The git URL of the repository.
+* `webhook_url` - The default branch to prefill when new builds are created or triggered.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -31,7 +31,7 @@ resource "buildkite_pipeline" "repo2" {
 * `steps` - (Required) The string YAML steps to run the pipeline.
 * `description` - (Optional) A description of the pipeline.
 
-* `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered.
+* `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
 * `branch_configuration` - (Optional) Limit which branches and tags cause new builds to be created, either via a code push or via the Builds REST API.
 * `skip_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically skipping any unstarted builds on the same branch when a new build is created.    
 * `skip_intermediate_builds_branch_filter` - (Optional) Limit which branches build skipping applies to, for example !master will ensure that the master branch won't have it's builds automatically skipped.


### PR DESCRIPTION
This adds a data source for fetching the properties of a single pipeline. The pipeline is specified using a slug, available in the
pipeline URL on buildkite.com.

This could be particularly useful for folks who want to lookup the webhook URL and set it on a GitHub repo (using the  GitHub terraform provider).

Closes #93