### PR TITLE
Ensure all resources are destroyed after tests

### DIFF
--- a/buildkite/resource_agent_token_test.go
+++ b/buildkite/resource_agent_token_test.go
@@ -184,7 +184,6 @@ func testAccCheckAgentTokenResourceDestroy(s *terraform.State) error {
 			"id": rs.Primary.ID,
 		}
 
-		fmt.Println("woofwoof test")
 		err := provider.graphql.Query(context.Background(), &query, vars)
 		if err == nil {
 			if string(query.Node.AgentToken.ID) != "" &&
@@ -193,7 +192,6 @@ func testAccCheckAgentTokenResourceDestroy(s *terraform.State) error {
 			}
 		}
 
-		fmt.Printf("Error is: %+v\n", err)
 		if !strings.Contains(err.Error(), "This agent registration token was already revoked") {
 			return err
 		}

--- a/buildkite/resource_agent_token_test.go
+++ b/buildkite/resource_agent_token_test.go
@@ -3,9 +3,10 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
 // Confirm that we can create a new agent token, and then delete it without error
@@ -15,7 +16,7 @@ func TestAccAgentToken_add_remove(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckAgentTokenResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAgentTokenConfigBasic("foo"),
@@ -40,7 +41,7 @@ func TestAccAgentToken_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckAgentTokenResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAgentTokenConfigBasic("foo"),
@@ -73,7 +74,7 @@ func TestAccAgentToken_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckAgentTokenResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAgentTokenConfigBasic("foo"),
@@ -161,4 +162,10 @@ func testAccAgentTokenConfigBasic(description string) string {
 		}
 	`
 	return fmt.Sprintf(config, description)
+}
+
+// verifies the Pipeline has been destroyed
+func testAccCheckAgentTokenResourceDestroy(s *terraform.State) error {
+	// TODO manually check that all resources created during acceptance tests have been cleaned up
+	return nil
 }

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -17,7 +17,7 @@ func TestAccPipelineSchedule_add_remove(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPipelineScheduleResourceDestroy,
+		CheckDestroy: testAccCheckAllPipelineScheduleResourcesDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPipelineScheduleConfigBasic("foo", "0 * * * *"),
@@ -46,7 +46,7 @@ func TestAccPipelineSchedule_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPipelineResourceDestroy,
+		CheckDestroy: testAccCheckAllPipelineScheduleResourcesDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPipelineScheduleConfigBasic("foo", "0 * * * *"),
@@ -84,7 +84,7 @@ func TestAccPipelineSchedule_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPipelineScheduleResourceDestroy,
+		CheckDestroy: testAccCheckAllPipelineScheduleResourcesDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPipelineScheduleConfigBasic("foo", "0 * * * *"),
@@ -102,6 +102,29 @@ func TestAccPipelineSchedule_import(t *testing.T) {
 				ImportStateIdFunc: testAccGetImportPipelineScheduleSlug(&resourceSchedule),
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPipelineSchedule_disappears(t *testing.T) {
+	var node PipelineScheduleNode
+	resourceName := "buildkite_pipeline_schedule.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAllPipelineScheduleResourcesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPipelineScheduleConfigBasic("foo", "0 * * * *"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the pipeline schedule exists in the buildkite API
+					testAccCheckPipelineScheduleExists(resourceName, &node),
+					// Check that the schedule can be removed from the plan
+					testAccCheckResourceDisappears(testAccProvider, resourcePipelineSchedule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -189,8 +212,54 @@ func testAccPipelineScheduleConfigBasic(label string, cronline string) string {
 	return fmt.Sprintf(config, label, cronline, label)
 }
 
-// verifies the Pipeline has been destroyed
+// verifies the pipeline schedule has been destroyed
 func testAccCheckPipelineScheduleResourceDestroy(s *terraform.State) error {
-	// TODO manually check that all resources created during acceptance tests have been cleaned up
+	provider := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "buildkite_pipeline_schedule" {
+			continue
+		}
+
+		// Try to find the resource remotely
+		var query struct {
+			Node struct {
+				PipelineSchedule PipelineScheduleNode `graphql:"... on PipelineSchedule"`
+			} `graphql:"node(id: $id)"`
+		}
+
+		vars := map[string]interface{}{
+			"id": rs.Primary.ID,
+		}
+
+		err := provider.graphql.Query(context.Background(), &query, vars)
+		if err == nil {
+			if string(query.Node.PipelineSchedule.ID) != "" &&
+				string(query.Node.PipelineSchedule.ID) == rs.Primary.ID {
+				return fmt.Errorf("Schedule still exists")
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAllPipelineScheduleResourcesDestroyed(s *terraform.State) error {
+	var err error
+
+	// Should destroy the schedule
+	err = testAccCheckPipelineScheduleResourceDestroy(s)
+	if err != nil {
+		return err
+	}
+
+	// Should destroy the test pipeline
+	err = testAccCheckPipelineResourceDestroy(s)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -84,7 +84,7 @@ func TestAccPipelineSchedule_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckPipelineScheduleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPipelineScheduleConfigBasic("foo", "0 * * * *"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -106,7 +106,7 @@ func TestAccPipeline_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckPipelineResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPipelineConfigBasic("foo"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -127,6 +127,30 @@ func TestAccPipeline_import(t *testing.T) {
 	})
 }
 
+// Confirm that this resource can be removed
+func TestAccPipeline_disappears(t *testing.T) {
+	var node PipelineNode
+	resourceName := "buildkite_pipeline.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPipelineResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPipelineConfigBasic("foo"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the pipeline exists in the buildkite API
+					testAccCheckPipelineExists(resourceName, &node),
+					// Ensure its removal from the spec
+					testAccCheckResourceDisappears(testAccProvider, resourcePipeline(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckPipelineExists(resourceName string, resourcePipeline *PipelineNode) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[resourceName]

--- a/buildkite/resource_team_test.go
+++ b/buildkite/resource_team_test.go
@@ -87,7 +87,7 @@ func TestAccTeam_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckExampleResourceDestroy,
+		CheckDestroy: testAccCheckTeamResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamConfigBasic("important"),


### PR DESCRIPTION
Resolve #110 by adding concrete cleanup checks for resource destroy and acceptance tests to all resources to ensure that Terraform can generate a plan to remove a resource (except agent tokens, as they are revoked rather than destroyed).

`testAccCheck*ResourceDestroy` unfortunately can't easily be tested unless Terraform hadn't cleaned up the resource. Hopefully, all the same, this gives us some good meaningful logging if something does break in the future. Plus we shedded TODOs.