### PR TITLE
adjust cron line we use in pipeline_schedule update test

### DIFF
--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -59,7 +59,7 @@ func TestAccPipelineSchedule_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPipelineScheduleConfigBasic("bar", "* 0 * * *"),
+				Config: testAccPipelineScheduleConfigBasic("bar", "0 1 * * *"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Schedules need a pipeline
 					testAccCheckPipelineExists("buildkite_pipeline.foobar", &resourcePipeline),
@@ -68,7 +68,7 @@ func TestAccPipelineSchedule_update(t *testing.T) {
 					// Confirm the schedule has the updated values in Buildkite's system
 					testAccCheckPipelineScheduleRemoteValues(&resourcePipeline, &resourceSchedule, "Test Schedule bar"),
 					// Confirm the schedule has the updated values in terraform state
-					resource.TestCheckResourceAttr("buildkite_pipeline_schedule.foobar", "cronline", "* 0 * * *"),
+					resource.TestCheckResourceAttr("buildkite_pipeline_schedule.foobar", "cronline", "0 1 * * *"),
 					resource.TestCheckResourceAttr("buildkite_pipeline_schedule.foobar", "label", "Test Schedule bar"),
 					resource.TestCheckResourceAttr("buildkite_pipeline_schedule.foobar", "branch", "main"),
 				),


### PR DESCRIPTION
pipeline schedules are not permitted to run more frequently than every 10 minutes.

This test was updating the cronline to `* 0 * * *`, which is "every minute during hour 0". Apparently our server side validation only
detects that as an error when the update runs during UTC hour 0, so [this test fails when run during UTC hour 0](https://buildkite.com/buildkite/terraform-provider-buildkite-main/builds/43#c6ca85d2-9311-43c8-91a0-9290460242c0).

The test now updates the cronline to "daily at 1:00 UTC".