### PR TITLE
Add build step for subset of acctests that will work with a non-admin API token

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,20 @@ steps:
       - docker-compose#v2.2.0:
           run: go
 
+  - label: acceptance tests - non-admin
+    key: testacc-nonadmin
+    if: build.branch == "main"
+    concurrency: 1
+    concurrency_group: terraform-provider-acceptance-tests
+    command: "make testacc-nonadmin"
+    plugins:
+      - zacharymctague/aws-ssm#v1.0.0:
+          parameters:
+            BUILDKITE_ORGANIZATION: /pipelines/terraform-provider-buildkite-main/buildkite_organization
+            BUILDKITE_API_TOKEN: /pipelines/terraform-provider-buildkite-main/buildkite_api_token_nonadmin
+      - docker-compose#v2.2.0:
+          run: go
+
   - label: build
     command: "make"
     plugins:
@@ -43,4 +57,5 @@ steps:
       - fmt
       - test
       - testacc
+      - testacc-nonadmin
       - vet

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,11 @@ test:
 # Buildkite organization!
 testacc:
 	TF_ACC=1 go test -v ./...
+
+# Acceptance tests, but only the ones that can pass with a non-admin API token. Non-admins can manage
+# pipelines and pipeline schedules, but only if they use teams. The API token must also belong to a user
+# who is a maintainer of the team.
+#
+# This will create, manage and delete real resources in a real Buildkite organization!
+testacc-nonadmin:
+	TF_ACC=1 go test -v -run "TestAccPipeline(Schedule)?_.*withteams" ./...


### PR DESCRIPTION
In PR #112 we fixed the pipeline resource so it can be created and updated by non-admin API tokens.

To prevent regressions, this adds a new acceptance test step to the build pipeline that will run only the subset of acceptance tests that will work with a non-admin API token.

Non-admins can manage pipelines and pipeline schedules, but only if the pipeline belongs to a team where the user is a team maintainer.

Before this we had no acctests with teams declared on a pipeline, so none of them would work for non-admins. This has added a couple of basic tests that use teams.

The new tests will also run in the normal acctest step (using an admin token), which is a nice bonus.