### PR TITLE
remove hard coded org slug from the PipelineSchedule acceptance tests

### DIFF
--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -257,7 +258,7 @@ func testAccCheckPipelineScheduleRemoteValues(resourcePipeline *PipelineNode, re
 
 func testAccGetImportPipelineScheduleSlug(resourceSchedule *PipelineScheduleNode) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		slug := fmt.Sprintf("%s/%s/%s", "buildkite-terraform-provider-test-org", "test-pipeline-foo", resourceSchedule.UUID)
+		slug := fmt.Sprintf("%s/%s/%s", os.Getenv("BUILDKITE_ORGANIZATION"), "test-pipeline-foo", resourceSchedule.UUID)
 		return slug, nil
 	}
 }


### PR DESCRIPTION
We accidentally left a hard coded slug in here, which means this test fails when run against any other organization. That wasn't our intention - all contributors should be able to run the tests against their own test organization.

Fixes #121