### PR TITLE
Add provider_settings to pipeline resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Buildkite Terraform Provider
+
 [![Build status](https://badge.buildkite.com/7224047dadf711cab2facd75939ea39848850d7c5c5a765acd.svg?branch=main)](https://buildkite.com/buildkite/terraform-provider-buildkite-main)
 
 This is the official Terraform provider for [Buildkite](https://buildkite.com). The provider is listed in the [Terraform Registry](https://registry.terraform.io/) and supports terraform >= 0.13.
@@ -7,10 +8,10 @@ The provider allows you to manage resources in your Buildkite organization.
 
 Two configuration values are required:
 
-* An API token, generated at https://buildkite.com/user/api-access-tokens. The
-  token must have the `write_pipelines` REST API scope and be enabled for GraphQL
-* A Buildkite organization slug, available by signing into buildkite.com and
-  examining the URL: https://buildkite.com/<org-slug>
+-   An API token, generated at https://buildkite.com/user/api-access-tokens. The
+    token must have the `write_pipelines, read_pipelines` REST API scopes and be enabled for GraphQL
+-   A Buildkite organization slug, available by signing into buildkite.com and
+    examining the URL: https://buildkite.com/<org-slug>
 
 ## Documentation
 
@@ -71,24 +72,32 @@ The repo contains a tf-proj/ directory that can be used to quickly test a compil
 1. Update tf-proj/main.tf to use the resource or property you're developing
 2. Compile the provider and copy it into the filesystem cache in tf-proj
 
+    ```bash
     go build -o terraform-provider-buildkite_v0.0.18 . && \
       mkdir -p tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.0.18/linux_amd64/ && \
       mv terraform-provider-buildkite_v0.0.18 tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.0.18/linux_amd64/
+    ```
 
 3. Ensure the version number in the above command and in tf-proj/main.tf match
 4. Run `terraform plan` in the tf-proj directory
 
+    ```bash
     BUILDKITE_API_TOKEN=<api-token> BUILDKITE_ORGANIZATION=<org-slug> terraform plan
+    ```
 
 ## Acceptance tests
 
 Acceptance tests that test the provider works against the live Buildkite API can be executed like this:
 
-    make testacc
+```bash
+make testacc
+```
 
 These tests require two environment variables to run correctly:
 
-    BUILDKITE_ORGANIZATION=<org-slug> BUILDKITE_API_TOKEN=<token> make testacc
+```bash
+BUILDKITE_ORGANIZATION=<org-slug> BUILDKITE_API_TOKEN=<token> make testacc
+```
 
 Note that these tests make live changes to an organization and probably
 shouldn't be run against organizations with real data. Anyone actively

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -44,8 +45,11 @@ func (client *Client) makeRequest(method string, url string, postData interface{
 	}
 
 	resp, err := client.http.Do(req)
-	if err != nil && resp.StatusCode >= 400 {
+	if err != nil {
 		return err
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("Buildkite API request failed: %s %s (status: %d)", method, url, resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -25,7 +25,7 @@ func Provider() *schema.Provider {
 			},
 			"api_token": &schema.Schema{
 				DefaultFunc: schema.EnvDefaultFunc("BUILDKITE_API_TOKEN", nil),
-				Description: "API token with GraphQL access and `write_pipelines` scope",
+				Description: "API token with GraphQL access and `write_pipelines, read_pipelines` scopes",
 				Required:    true,
 				Type:        schema.TypeString,
 			},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -60,6 +60,21 @@ func TestAccPipeline_add_remove_complex(t *testing.T) {
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "skip_intermediate_builds_branch_filter", "main"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "cancel_intermediate_builds", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "cancel_intermediate_builds_branch_filter", "!main"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.trigger_mode", "code"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_branches", "false"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_request_forks", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_request_ready_for_review", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_requests", "false"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_tags", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.cancel_deleted_branch_builds", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.prefix_pull_request_fork_branch_names", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.publish_blocked_as_pending", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.publish_commit_status", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.publish_commit_status_per_step", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.pull_request_branch_filter_configuration", "features/*"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.pull_request_branch_filter_enabled", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.separate_pull_request_statuses", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "false"),
 				),
 			},
 		},
@@ -302,6 +317,23 @@ func testAccPipelineConfigComplex(name string, steps string) string {
             skip_intermediate_builds_branch_filter = "main"
             cancel_intermediate_builds = true
             cancel_intermediate_builds_branch_filter = "!main"
+			provider_settings {
+				trigger_mode = "code"
+				build_branches = false
+				build_pull_request_forks = true
+				build_pull_request_ready_for_review = true
+				build_pull_requests = false
+				build_tags = true
+				cancel_deleted_branch_builds = true
+				prefix_pull_request_fork_branch_names = true
+				publish_blocked_as_pending = true
+				publish_commit_status = true
+				publish_commit_status_per_step = true
+				pull_request_branch_filter_configuration = "features/*"
+				pull_request_branch_filter_enabled = true
+				separate_pull_request_statuses = true
+				skip_pull_request_builds_for_existing_commits = false
+			}
         }
 	`
 	return fmt.Sprintf(config, name, steps)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,10 @@ This provider can be used to manage resources on [buildkite.com](https://buildki
 
 Two configuration values are required:
 
-* An API token, generated at https://buildkite.com/user/api-access-tokens. The
-  token must have the `write_pipelines` REST API scope and be enabled for GraphQL
-* A Buildkite organization slug, available by signing into buildkite.com and
-  examining the URL: https://buildkite.com/<org-slug>
+-   An API token, generated at https://buildkite.com/user/api-access-tokens. The
+    token must have the `write_pipelines, read_pipelines` REST API scopes and be enabled for GraphQL
+-   A Buildkite organization slug, available by signing into buildkite.com and
+    examining the URL: https://buildkite.com/<org-slug>
 
 ## Example Usage
 
@@ -29,5 +29,5 @@ provider "buildkite" {
 
 ## Argument Reference
 
-* `api_token` - (Required) This is the Buildkite API Access Token. It must be provided but can also be sourced from the `BUILDKITE_API_TOKEN` environment variable.
-* `organization` - (Required) This is the Buildkite organization slug. It must be provided, but can also be sourced from the `BUILDKITE_ORGANIZATION` environment variable. The token requires GraphQL access and the `write_pipelines` scope.
+-   `api_token` - (Required) This is the Buildkite API Access Token. It must be provided but can also be sourced from the `BUILDKITE_API_TOKEN` environment variable.
+-   `organization` - (Required) This is the Buildkite organization slug. It must be provided, but can also be sourced from the `BUILDKITE_ORGANIZATION` environment variable. The token requires GraphQL access and the `write_pipelines, read_pipelines` scopes.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -24,33 +24,96 @@ resource "buildkite_pipeline" "repo2" {
 }
 ```
 
+## Example Usage with GitHub Provider Settings
+
+```hcl
+# Pipeline that should not be triggered from a GitHub webhook
+resource "buildkite_pipeline" "repo2-deploy" {
+    name = "repo2"
+    repository = "git@github.com:org/repo2"
+    steps = file("./deploy-steps.yml")
+
+    provider_settings {
+        trigger_mode = "none"
+    }
+}
+
+# Release pipeline (triggered only when tags are pushed)
+resource "buildkite_pipeline" "repo2-release" {
+    name = "repo2"
+    repository = "git@github.com:org/repo2"
+    steps = file("./release-steps.yml")
+
+    provider_settings {
+        build_branches      = false
+        build_tags          = true
+        build_pull_requests = false
+        trigger_mode        = "code"
+    }
+}
+```
+
 ## Argument Reference
 
-* `name` - (Required) The name of the pipeline.
-* `repository` - (Required) The git URL of the repository.
-* `steps` - (Required) The string YAML steps to run the pipeline.
-* `description` - (Optional) A description of the pipeline.
+-   `name` - (Required) The name of the pipeline.
+-   `repository` - (Required) The git URL of the repository.
+-   `steps` - (Required) The string YAML steps to run the pipeline.
+-   `description` - (Optional) A description of the pipeline.
+-   `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
+-   `branch_configuration` - (Optional) Limit which branches and tags cause new builds to be created, either via a code push or via the Builds REST API.
+-   `skip_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically skipping any unstarted builds on the same branch when a new build is created.
+-   `skip_intermediate_builds_branch_filter` - (Optional) Limit which branches build skipping applies to, for example `!master` will ensure that the master branch won't have it's builds automatically skipped.
+-   `cancel_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically cancelling any running builds on the same branch when a new build is created.
+-   `cancel_intermediate_builds_branch_filter` - (Optional) Limit which branches build cancelling applies to, for example !master will ensure that the master branch won't have it's builds automatically cancelled.
+-   `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. See [Teams Configuration](#team) below for details.
+-   `provider_settings` - (Optional) Source control provider settings for the pipeline. See [Provider Settings Configuration](#provider-settings-configuration) below for details.
 
-* `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
-* `branch_configuration` - (Optional) Limit which branches and tags cause new builds to be created, either via a code push or via the Builds REST API.
-* `skip_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically skipping any unstarted builds on the same branch when a new build is created.    
-* `skip_intermediate_builds_branch_filter` - (Optional) Limit which branches build skipping applies to, for example !master will ensure that the master branch won't have it's builds automatically skipped.
-* `cancel_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automtically cancelling any running builds on the same branch when a new build is created.   
-* `cancel_intermediate_builds_branch_filter` - (Optional) Limit which branches build cancelling applies to, for example !master will ensure that the master branch won't have it's builds automatically cancelled.
-* `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team.
-
-### Team
+### Teams Configuration
 
 The `team` block supports:
 
-* `slug` - (Required) The buildkite slug of the team.
-* `access_level` - (Required) The level of access to grant. Must be one of `READ_ONLY`, `BUILD_AND_READ` or `MANAGE_BUILD_AND_READ`.
+-   `slug` - (Required) The buildkite slug of the team.
+-   `access_level` - (Required) The level of access to grant. Must be one of `READ_ONLY`, `BUILD_AND_READ` or `MANAGE_BUILD_AND_READ`.
+
+### Provider Settings Configuration
+
+-> **Note:** Supported provider settings depend on a source version control provider used by your organization.
+
+Properties available for Bitbucket Server:
+
+-   `build_pull_requests` - (Optional) Whether to create builds for commits that are part of a Pull Request.
+-   `build_tags` - (Optional) Whether to create builds when tags are pushed.
+
+Properties available for Bitbucket Cloud, GitHub, and GitHub Enterprise:
+
+-   `build_pull_requests` - (Optional) Whether to create builds for commits that are part of a Pull Request.
+-   `build_tags` - (Optional) Whether to create builds when tags are pushed.
+-   `pull_request_branch_filter_enabled` - (Optional) Whether to limit the creation of builds to specific branches or patterns.
+-   `pull_request_branch_filter_configuration` - (Optional) The branch filtering pattern. Only pull requests on branches matching this pattern will cause builds to be created.
+-   `skip_pull_request_builds_for_existing_commits` - (Optional) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.
+-   `publish_commit_status` - (Optional) Whether to update the status of commits in Bitbucket or GitHub.
+-   `publish_commit_status_per_step` - (Optional) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.
+-   `publish_commit_status`
+-   `publish_commit_status_per_step`
+
+Additional properties available for GitHub:
+
+-   `trigger_mode` - (Optional) What type of event to trigger builds on. Must be one of:
+
+    -   `code` will create builds when code is pushed to GitHub.
+    -   `deployment` will create builds when a deployment is created with the GitHub Deployments API.
+    -   `fork` will create builds when the GitHub repository is forked.
+    -   `none` will not create any builds based on GitHub activity.
+
+-   `build_pull_request_forks` - (Optional) Whether to create builds for pull requests from third-party forks.
+-   `prefix_pull_request_fork_branch_names` - (Optional) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the `master` branch from `some-user` will become `some-user:master`.
+-   `separate_pull_request_statuses` - (Optional) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
+-   `publish_blocked_as_pending` - (Optional) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.
 
 ## Attribute Reference
 
-* `webhook_url` - The Buildkite webhook URL to configure on the repository to trigger builds on this pipeline.
-* `slug` - The slug of the created pipeline.
-
+-   `webhook_url` - The Buildkite webhook URL to configure on the repository to trigger builds on this pipeline.
+-   `slug` - The slug of the created pipeline.
 
 ## Import
 


### PR DESCRIPTION
## provider_settings

1. `provider_settings` block is `Optional` for backward-compatibility reasons. Also it is `Computed` (so default values are set by buildkite backend, while it is still possible to override the values by specifying custom values for each property in terraform resource configuration).

1. all `provider_settings` are provider-agnostic (the user should know which attributes are supported by the provider they use)

## Few examples:

- to disable build triggers:

  ```hcl
  provider_settings {
    trigger_mode = "none"
  }
  ```
- trigger builds for tags:
  ```hcl
  provider_settings {
    trigger_mode = "code" # default value, so could be omitted (not recommended though) 
    build_tags = true
  }
  ```

## Other changes

1. Removed `ReadPipeline` calls at the end of `CreatePipeline` and `UpdatePipeline` methods, as we already set attribute values for underlying terraform resource directly in these methods (based on a result of GraphQL mutation and response from  PATCH request). I know that according to [best practices](https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#update-state-after-modification) we should call `READ` at the end of `CREATE` and `UPDATE`, but it feels like we're doing unnecessary API calls to Buildkite backend here.  I can drop this change from this PR if you want, or create a new PR with this change only if you think this is the right thing to do.


## TODO

- [x] update docs
- [x] acceptance tests