### PR TITLE
Add buildkite_ip_ranges data source

### DIFF
--- a/buildkite/data_source_meta.go
+++ b/buildkite/data_source_meta.go
@@ -1,0 +1,51 @@
+package buildkite
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetaResponse struct {
+	WebhookIps []string `json:"webhook_ips"`
+}
+
+func dataSourceMeta() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMetaRead,
+		Schema: map[string]*schema.Schema{
+			"webhook_ips": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceMetaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+	meta := MetaResponse{}
+	err := client.makeRequest("GET", "https://api.buildkite.com/v2/meta", nil, &meta)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// a consistent order will ensure a change in ordering from the server won't trigger
+	// changes in a terraform plan
+	sort.Strings(meta.WebhookIps)
+
+	if err := d.Set("webhook_ips", meta.WebhookIps); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// It seems we need to set an ID for a data source, so pick a stable one that won't change
+	d.SetId("https://api.buildkite.com/v2/meta")
+
+	return nil
+}

--- a/buildkite/data_source_meta_test.go
+++ b/buildkite/data_source_meta_test.go
@@ -1,0 +1,64 @@
+package buildkite
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Confirm that we can create a new agent token, and then delete it without error
+func TestAccDataMeta_read(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMetaConfigBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the meta data source has the correct values in terraform state
+					testAccBuildkiteMetaCheckWebhookIps("data.buildkite_meta.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBuildkiteMetaCheckWebhookIps(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		attributes := resourceState.Primary.Attributes
+
+		if !ok {
+			return fmt.Errorf("Not found in state: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("No ID is set in state")
+		}
+
+		var (
+			webhookIpsSize int
+			err            error
+		)
+		if webhookIpsSize, err = strconv.Atoi(attributes["webhook_ips.#"]); err != nil {
+			return err
+		}
+
+		if webhookIpsSize == 0 {
+			return fmt.Errorf("webhook_ips attribute should have more than 0 items (len: %d)", webhookIpsSize)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataMetaConfigBasic() string {
+	config := `
+		data "buildkite_meta" "foobar" {
+		}
+	`
+	return config
+}

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -14,6 +14,7 @@ func Provider() *schema.Provider {
 			"buildkite_team":              resourceTeam(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"buildkite_meta":     dataSourceMeta(),
 			"buildkite_pipeline": dataSourcePipeline(),
 		},
 		Schema: map[string]*schema.Schema{

--- a/docs/data-sources/meta.md
+++ b/docs/data-sources/meta.md
@@ -1,0 +1,36 @@
+# Data Source: meta
+
+Use this data source to look up the source IP addresses that Buildkite may use
+to send external requests, including webhooks and API calls to source control
+systems (like GitHub Enterprise Server and BitBucket Server).
+
+Buildkite Documentation: https://buildkite.com/docs/apis/rest-api/meta
+
+## Example Usage
+
+This is intended to be used in other terraform projects to dynamically
+set firewall and ingress rules to allow traffic from Buildkite. For
+customers that use AWS, that might look like this:
+
+```hcl
+data "buildkite_meta" "ips" { }
+
+resource "aws_security_group" "from_buildkite" {
+    name = "from_buildkite"
+
+    ingress {
+        from_port        = "*"
+        to_port          = "443"
+        protocol         = "tcp"
+        cidr_blocks      = data.buildkite_meta.ips.webhook_ips
+    }
+}
+```
+
+## Argument Reference
+
+None.
+
+## Attributes Reference
+
+* `webhook_ips` - A list of strings, each one an IP address (x.x.x.x) or CIDR address (x.x.x.x/32) that Buildkite may use to send webhooks and other external requests.


### PR DESCRIPTION
This adds a new data source for listing the IP addresses that Buildkite uses to send webhooks and other external requests (like commit status API calls to GitHub Enterprise and BitBucket Server).

It takes no parameters, and can be used like this:

```hcl
    data "buildkite_ip_ranges" "ips" { }

    output "cidrs" {
      value = data.buildkite_ip_ranges.ips.webhook_ips
    }
```

This is intended to be used in other terraform projects to dynamically set firewall and ingress rules to allow traffic from Buildkite. For customers that use AWS, that might look like this:

```hcl
    data "buildkite_ip_ranges" "ips" { }

    resource "aws_security_group" "from_buildkite" {
      name = "from_buildkite"

      ingress {
        from_port        = "*"
        to_port          = "443"
        protocol         = "tcp"
        cidr_blocks      = data.buildkite_ip_ranges.ips.webhook_ips
      }
    }
```

Closes #105