### PR TITLE
drop dependabot frequency from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
We don't need to update to every new docker image with the same version, we're mostly interested in getting the golang version bumps. Getting them only once per month is fine.