### PR TITLE
feat: extended the Pipeline Extra Info to include the badge_url as an output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ terraform.rc
 tf-proj/terraform.d/*
 tf-proj/*.tfstate
 tf-proj/*.tfstate.backup
+tf-proj/.terraform.lock.hcl

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -244,6 +244,10 @@ func resourcePipeline() *schema.Resource {
 				Computed: true,
 				Type:     schema.TypeString,
 			},
+			"badge_url": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
 		},
 	}
 }
@@ -412,14 +416,16 @@ func DeletePipeline(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	return nil
 }
 
-// As of March 16, 2021, GraphQL Pipeline is lacking support for the following properties:
+// As of May 21, 2021, GraphQL Pipeline is lacking support for the following properties:
 // - branch_configuration
+// - badge_url
 // - provider_settings
 // We fallback to REST API
 
 // PipelineExtraInfo is used to manage pipeline attributes that are not exposed via GraphQL API.
 type PipelineExtraInfo struct {
 	BranchConfiguration string `json:"branch_configuration"`
+	BadgeUrl            string `json:"badge_url"`
 	Provider            struct {
 		Settings struct {
 			TriggerMode                             string `json:"trigger_mode"`
@@ -663,6 +669,7 @@ func updatePipelineResource(d *schema.ResourceData, pipeline *PipelineNode) {
 // updatePipelineResourceExtraInfo updates the terraform resource with data received from Buildkite REST API
 func updatePipelineResourceExtraInfo(d *schema.ResourceData, pipeline *PipelineExtraInfo) {
 	d.Set("branch_configuration", pipeline.BranchConfiguration)
+	d.Set("badge_url", pipeline.BadgeUrl)
 
 	s := &pipeline.Provider.Settings
 	providerSettings := make([]map[string]interface{}, 1, 1)

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -114,6 +114,7 @@ Additional properties available for GitHub:
 
 -   `webhook_url` - The Buildkite webhook URL to configure on the repository to trigger builds on this pipeline.
 -   `slug` - The slug of the created pipeline.
+-   `bagde_url` - The pipeline's last build status so you can display build status badge.
 
 ## Import
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -26,3 +26,7 @@ resource "buildkite_agent_token" "fleet" {
 output "agent_token" {
     value = buildkite_agent_token.fleet.token
 }
+
+output "badge_url" {
+    value = buildkite_pipeline.test.badge_url
+}

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -24,3 +24,6 @@ resource "buildkite_pipeline_schedule" "foo" {
   branch      = "master"
 }
 
+output "badge_url" {
+  value = buildkite_pipeline.test.badge_url
+}


### PR DESCRIPTION
Extended the PipelineExtraInfo so that it includes the badge_url as a readonly property. So that it can be returned as an output attribute when a new pipeline is created. 

Resolves [Issue](https://github.com/buildkite/terraform-provider-buildkite/issues/148)