### PR TITLE
Fill in docs for some missing attributes

### DIFF
--- a/docs/resources/agent_token.md
+++ b/docs/resources/agent_token.md
@@ -22,6 +22,7 @@ resource "buildkite_agent_token" "fleet" {
 
 ## Attribute Reference
 
+* `id` - The Graphql ID of the created agent token.
 * `token` - The value of the created agent token.
 * `uuid` - The UUID of the token.
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -112,6 +112,7 @@ Additional properties available for GitHub:
 
 ## Attribute Reference
 
+-   `id` - The GraphQL ID of the pipeline
 -   `webhook_url` - The Buildkite webhook URL to configure on the repository to trigger builds on this pipeline.
 -   `slug` - The slug of the created pipeline.
 -   `bagde_url` - The pipeline's last build status so you can display build status badge.

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -26,6 +26,11 @@ resource "buildkite_pipeline_schedule" "repo2_nightly" {
 * `env` - (Optional) A map of environment variables to use for the build.
 * `enabled` - (Optional, Default: `true`) Whether the schedule should run.
 
+## Attribute Reference
+
+* `id` - The GraphQL ID of the pipeline schedule
+* `uuid` - The UUID of the pipeline schedule
+
 ## Import
 
 Pipeline schedules can be imported using a slug (which consists of `$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_SLUG/$PIPELINE_SCHEDULE_UUID`), e.g.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -28,5 +28,6 @@ resource "buildkite_team" "team" {
 
 ## Attribute Reference
 
+* `id`   - The GraphQL ID of the team.
 * `slug` - The name of the team.
-* `uuid` - The GraphQL UUID for the team.
+* `uuid` - The UUID for the team.


### PR DESCRIPTION
In #117 @keith noticed our docs weren't documenting the ID attribute of some resources. While fixing that, I noticed a handful of other read-only resource attributes that weren't documented as well.