### PR TITLE
Return a better user visible error when pipeline references an unrecognised team slug

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -272,8 +272,7 @@ func CreatePipeline(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		log.Printf("converting team slug '%s' to an ID", string(team.Team.Slug))
 		teamID, err := GetTeamID(string(team.Team.Slug), client)
 		if err != nil {
-			log.Printf("Unable to get ID for team slug %s", team.Team.Slug)
-			return diag.FromErr(err)
+			return diag.FromErr(fmt.Errorf("Unable to get ID for team slug %s (%v)", team.Team.Slug, err))
 		}
 		teamsData = append(teamsData, PipelineTeamAssignmentInput{
 			Id:          teamID,
@@ -576,8 +575,7 @@ func createTeamPipelines(teamPipelines []TeamPipelineNode, pipelineID string, cl
 		log.Printf("Granting teamPipeline %s %s access to pipeline id '%s'...", teamPipeline.Team.Slug, teamPipeline.AccessLevel, pipelineID)
 		teamID, err := GetTeamID(string(teamPipeline.Team.Slug), client)
 		if err != nil {
-			log.Printf("Unable to get ID for team slug %s", teamPipeline.Team.Slug)
-			return err
+			return fmt.Errorf("Unable to get ID for team slug %s (%v)", teamPipeline.Team.Slug, err)
 		}
 		params := map[string]interface{}{
 			"team":        graphql.ID(teamID),


### PR DESCRIPTION
In #117 @keith reported that we return a particularly unhelpful error to users when a pipeline references a team slug that doesn't exist:

    resource "buildkite_pipeline" "repo2" {
        name = "repo2"
        repository = "git@github.com:org/repo2"
        steps = file("./steps.yml")

        team {
            slug = "not valid"
            access_level = "READ_ONLY"
        }
    }

The error was:

> Error: No ID was supplied

I'm not 100% sure this error handling is where the error @keith saw was from, but it seems pretty likely. Even if it's not, this seems like a good change to make.

The Printf() is only visible to users when debug mode is on, which will almost never be true. Moving that message to an error that will be displayed to the user (and can be searched in this codebase while debugging) seems like a win.