### PR TITLE
Add the build_pull_request_labels_changed property

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -192,6 +192,11 @@ func resourcePipeline() *schema.Resource {
 							Optional: true,
 							Type:     schema.TypeBool,
 						},
+						"build_pull_request_labels_changed": {
+							Computed: true,
+							Optional: true,
+							Type:     schema.TypeBool,
+						},
 						"build_pull_request_forks": {
 							Computed: true,
 							Optional: true,
@@ -443,6 +448,7 @@ type PipelineExtraInfo struct {
 			PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration"`
 			SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits"`
 			BuildPullRequestReadyForReview          bool   `json:"build_pull_request_ready_for_review"`
+			BuildPullRequestLabelsChanged           bool   `json:"build_pull_request_labels_changed"`
 			BuildPullRequestForks                   bool   `json:"build_pull_request_forks"`
 			PrefixPullRequestForkBranchNames        bool   `json:"prefix_pull_request_fork_branch_names"`
 			BuildBranches                           bool   `json:"build_branches"`
@@ -690,6 +696,7 @@ func updatePipelineResourceExtraInfo(d *schema.ResourceData, pipeline *PipelineE
 		"pull_request_branch_filter_configuration":      s.PullRequestBranchFilterConfiguration,
 		"skip_pull_request_builds_for_existing_commits": s.SkipPullRequestBuildsForExistingCommits,
 		"build_pull_request_ready_for_review":           s.BuildPullRequestReadyForReview,
+		"build_pull_request_labels_changed":             s.BuildPullRequestLabelsChanged,
 		"build_pull_request_forks":                      s.BuildPullRequestForks,
 		"filter_enabled":                                s.FilterEnabled,
 		"filter_condition":                              s.FilterCondition,

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -65,11 +65,12 @@ func TestAccPipeline_add_remove_complex(t *testing.T) {
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_branches", "false"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_request_forks", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_request_ready_for_review", "true"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_request_labels_changed", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_pull_requests", "false"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.build_tags", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.cancel_deleted_branch_builds", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.filter_enabled", "true"),
-					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.filter_condition", "build.pull_request.id == 123"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.filter_condition", "build.pull_request.labels includes \"CI: yes\""),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.prefix_pull_request_fork_branch_names", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.publish_blocked_as_pending", "true"),
 					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "provider_settings.0.publish_commit_status", "true"),
@@ -327,11 +328,12 @@ func testAccPipelineConfigComplex(name string, steps string) string {
 				build_branches = false
 				build_pull_request_forks = true
 				build_pull_request_ready_for_review = true
+				build_pull_request_labels_changed = true
 				build_pull_requests = false
 				build_tags = true
 				cancel_deleted_branch_builds = true
 				filter_enabled = true
-				filter_condition = "build.pull_request.id == 123"
+				filter_condition = "build.pull_request.labels includes \"CI: yes\""
 				prefix_pull_request_fork_branch_names = true
 				publish_blocked_as_pending = true
 				publish_commit_status = true

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -109,6 +109,7 @@ Additional properties available for GitHub:
     -   `none` will not create any builds based on GitHub activity.
 
 -   `build_pull_request_forks` - (Optional) Whether to create builds for pull requests from third-party forks.
+-   `build_pull_request_labels_changed` - (Optional) Whether to create builds for pull requests when labels are added or removed.
 -   `prefix_pull_request_fork_branch_names` - (Optional) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the `master` branch from `some-user` will become `some-user:master`.
 -   `separate_pull_request_statuses` - (Optional) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
 -   `publish_blocked_as_pending` - (Optional) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.


### PR DESCRIPTION
Add the `build_pull_request_labels_changed` property to the pipeline module.
This property is written in the example response of  https://buildkite.com/docs/apis/rest-api/pipelines#create-a-yaml-pipeline.