### PR TITLE
Examples and documentation fix: pipeline subcommand was missing

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -10,7 +10,7 @@ Buildkite Documentation: https://buildkite.com/docs/pipelines
 # in ./steps.yml:
 # steps:
 #   - label: ':pipeline:'
-#     command: buildkite-agent upload
+#     command: buildkite-agent pipeline upload
 
 resource "buildkite_pipeline" "repo2" {
     name = "repo2"

--- a/examples/steps.yml
+++ b/examples/steps.yml
@@ -1,3 +1,3 @@
 steps:
   - label: ':pipeline:'
-    command: buildkite-agent upload
+    command: buildkite-agent pipeline upload


### PR DESCRIPTION
I was setting up my terraform integration and noticed I was missing the `pipeline` subcommand with the steps I'd taken from the docs.

Hope this helps.