### PR TITLE
Fixes typo in pipeline Docs

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -118,7 +118,7 @@ Additional properties available for GitHub:
 -   `id` - The GraphQL ID of the pipeline
 -   `webhook_url` - The Buildkite webhook URL to configure on the repository to trigger builds on this pipeline.
 -   `slug` - The slug of the created pipeline.
--   `bagde_url` - The pipeline's last build status so you can display build status badge.
+-   `badge_url` - The pipeline's last build status so you can display build status badge.
 
 ## Import
 


### PR DESCRIPTION
The actual property is `badge`, this just looks like a misspelling.

https://github.com/buildkite/terraform-provider-buildkite/blob/7117eb3866171b60189f42c65651668557da0458/buildkite/resource_pipeline.go#L257-L260