### PR TITLE
SUP-106 Add `buildkite_team_member` resource

### DIFF
--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -12,6 +12,7 @@ func Provider() *schema.Provider {
 			"buildkite_pipeline":          resourcePipeline(),
 			"buildkite_pipeline_schedule": resourcePipelineSchedule(),
 			"buildkite_team":              resourceTeam(),
+			"buildkite_team_member":       resourceTeamMember(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"buildkite_meta":     dataSourceMeta(),

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -172,5 +172,5 @@ func updateTeamMember(d *schema.ResourceData, t *TeamMemberNode) {
 	d.Set("role", string(t.Role))
 	d.Set("uuid", string(t.UUID))
 	d.Set("team_id", string(t.Team.ID))
-	d.Set("user_id", t.User.ID.(string))
+	d.Set("user_id", t.User.ID)
 }

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -28,7 +28,7 @@ func resourceTeamMember() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"role": &schema.Schema{
 				Optional: true,
-				Type:     schema.TypeSet,
+				Type:     schema.TypeString,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					switch v {
@@ -68,8 +68,8 @@ func CreateTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}
 	}
 
 	vars := map[string]interface{}{
-		"teamID": graphql.String(d.Get("team_id").(string)),
-		"userId": graphql.String(d.Get("user_id").(string)),
+		"teamId": graphql.ID(d.Get("team_id").(string)),
+		"userId": graphql.ID(d.Get("user_id").(string)),
 	}
 
 	err := client.graphql.Mutate(context.Background(), &mutation, vars)

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -141,7 +141,7 @@ func DeleteTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}
 	client := m.(*Client)
 	var mutation struct {
 		TeamDelete struct {
-			DeletedTeamMemberId graphql.String
+			DeletedTeamMemberId graphql.String `graphql:"deletedTeamMemberID"`
 		} `graphql:"teamMemberDelete(input: {id: $id})"`
 	}
 

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -14,6 +14,9 @@ type TeamMemberNode struct {
 	Role TeamMemberRole
 	UUID graphql.String
 	Team TeamNode
+	User struct {
+		ID graphql.ID
+	}
 }
 
 func resourceTeamMember() *schema.Resource {
@@ -168,4 +171,6 @@ func updateTeamMember(d *schema.ResourceData, t *TeamMemberNode) {
 	d.SetId(string(t.ID))
 	d.Set("role", string(t.Role))
 	d.Set("uuid", string(t.UUID))
+	d.Set("team_id", string(t.Team.ID))
+	d.Set("user_id", t.User.ID.(string))
 }

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -1,0 +1,164 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/shurcooL/graphql"
+)
+
+type TeamMemberNode struct {
+	ID   graphql.String
+	Role TeamMemberRole
+	UUID graphql.String
+}
+
+func resourceTeamMember() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreateTeamMember,
+		ReadContext:   ReadTeamMember,
+		UpdateContext: UpdateTeamMember,
+		DeleteContext: DeleteTeamMember,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeSet,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					switch v {
+					case "MEMBER":
+					case "MAINTAINER":
+						return
+					default:
+						errs = append(errs, fmt.Errorf("%q must be either MEMBER or MAINTAINER, got: %s", key, v))
+						return
+					}
+					return
+				},
+			},
+			"team_id": &schema.Schema{
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"user_id": &schema.Schema{
+				Required: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}
+
+// CreateTeamMember adds a user to a Buildkite team
+func CreateTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+
+	var mutation struct {
+		TeamMemberCreate struct {
+			Team           TeamNode
+			TeamMemberEdge struct {
+				Node TeamMemberNode
+			}
+		} `graphql:"teamMemberCreate(input: {teamID: $teamId, userID: $userId})"`
+	}
+
+	vars := map[string]interface{}{
+		"teamID": graphql.String(d.Get("team_id").(string)),
+		"userId": graphql.String(d.Get("user_id").(string)),
+	}
+
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateTeamMember(d, &mutation.TeamMemberCreate.TeamMemberEdge.Node)
+
+	// make a separate call to change the role if necessary
+	if mutation.TeamMemberCreate.Team.DefaultMemberRole != graphql.String(d.Get("role").(string)) {
+		UpdateTeamMember(ctx, d, m)
+	}
+
+	return nil
+}
+
+// ReadTeamMember retrieves a Buildkite team
+func ReadTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+
+	var query struct {
+		Node struct {
+			TeamMember TeamMemberNode `graphql:"... on TeamMember"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	vars := map[string]interface{}{
+		"id": d.Id(),
+	}
+
+	err := client.graphql.Query(context.Background(), &query, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateTeamMember(d, &query.Node.TeamMember)
+
+	return nil
+}
+
+// UpdateTeamMember a team members role within a Buildkite team
+func UpdateTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+
+	var mutation struct {
+		TeamMemberUpdate struct {
+			TeamMember TeamMemberNode
+		} `graphql:"teamMemberUpdate(input: {id: $id, role: $role})"`
+	}
+
+	vars := map[string]interface{}{
+		"id":   d.Id(),
+		"role": graphql.String(d.Get("role").(string)),
+	}
+
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateTeamMember(d, &mutation.TeamMemberUpdate.TeamMember)
+
+	return nil
+}
+
+// DeleteTeamMember removes a user from a Buildkite team
+func DeleteTeamMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+	var mutation struct {
+		TeamDelete struct {
+			DeletedTeamMemberId graphql.String
+		} `graphql:"teamMemberDelete(input: {id: $id})"`
+	}
+
+	vars := map[string]interface{}{
+		"id": graphql.ID(d.Id()),
+	}
+
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func updateTeamMember(d *schema.ResourceData, t *TeamMemberNode) {
+	d.SetId(string(t.ID))
+	d.Set("role", string(t.Role))
+	d.Set("uuid", string(t.UUID))
+}

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -50,6 +50,10 @@ func resourceTeamMember() *schema.Resource {
 				Required: true,
 				Type:     schema.TypeString,
 			},
+			"uuid": &schema.Schema{
+				Computed: true,
+				Type:     schema.TypeString,
+			},
 		},
 	}
 }

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -149,7 +149,7 @@ func testAccTeamMemberConfigBasic(role string) string {
 		resource "buildkite_team_member" "test" {
 		    role = "%s"
 			team_id = buildkite_team.test.id
-			user_id = "VXNlci0tLWRlOTdmMjBiLWJkZmMtNGNjOC1hOTcwLTY1ODNiZTk2ZGEyYQ=="
+			user_id = "VXNlci0tLThkYjI5MjBlLTNjNjAtNDhhNy1hM2Y4LTI1ODRiZTM3NGJhYw=="
 		}
 	`
 	return fmt.Sprintf(config, role)

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -155,7 +155,7 @@ func testAccTeamMemberConfigBasic(role string) string {
 	return fmt.Sprintf(config, role)
 }
 
-func testAccChecKTeamMemberExists(resourceName string, resourceTeamMember *TeamMemberNode) resource.TestCheckFunc {
+func testAccCheckTeamMemberExists(resourceName string, resourceTeamMember *TeamMemberNode) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[resourceName]
 

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -1,0 +1,134 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Confirm we can add and remove a team member
+func TestAccTeamMember_add_remove(t *testing.T) {
+	var resourceTeamMember TeamMemberNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTeamMemberResourceRemoved,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfigBasic("MEMBER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					// Confirm the team has the correct values in Buildkite's system
+					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
+					// Confirm the team member has the correct values in terraform state
+					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MEMBER"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTeamMemberConfigBasic(role string) string {
+	config := `
+		resource "buildkite_team" "test" {
+			name = "acceptance testing"
+			description = "a cool team for testing"
+			privacy = "VISIBLE"
+			default_team = true
+			default_member_role = "MEMBER"
+		}
+		resource "buildkite_team_member" "test" {
+		    role = "%s"
+			team_id = buildkite_team.test.id
+			user_id = "VXNlci0tLWRlOTdmMjBiLWJkZmMtNGNjOC1hOTcwLTY1ODNiZTk2ZGEyYQ=="
+		}
+	`
+	return fmt.Sprintf(config, role)
+}
+
+func testAccChecKTeamMemberExists(resourceName string, resourceTeamMember *TeamMemberNode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("Not found in state: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("No ID is set in state")
+		}
+
+		provider := testAccProvider.Meta().(*Client)
+		var query struct {
+			Node struct {
+				TeamMember TeamMemberNode `graphql:"... on TeamMember"`
+			} `graphql:"node(id: $id)"`
+		}
+
+		vars := map[string]interface{}{
+			"id": resourceState.Primary.ID,
+		}
+
+		err := provider.graphql.Query(context.Background(), &query, vars)
+		if err != nil {
+			return fmt.Errorf("Error fetching team from graphql API: %v", err)
+		}
+
+		if string(query.Node.TeamMember.ID) == "" {
+			return fmt.Errorf("No team found with graphql id: %s", resourceState.Primary.ID)
+		}
+
+		*resourceTeamMember = query.Node.TeamMember
+
+		return nil
+	}
+}
+
+// verify the team member has been removed
+func testCheckTeamMemberResourceRemoved(s *terraform.State) error {
+	provider := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "buildkite_team_member" {
+			continue
+		}
+
+		// Try to find the resource remotely
+		var query struct {
+			Node struct {
+				TeamMember TeamMemberNode `graphql:"... on TeamMember"`
+			} `graphql:"node(id: $id)"`
+		}
+
+		vars := map[string]interface{}{
+			"id": rs.Primary.ID,
+		}
+
+		err := provider.graphql.Query(context.Background(), &query, vars)
+		if err == nil {
+			if string(query.Node.TeamMember.ID) != "" &&
+				string(query.Node.TeamMember.ID) == rs.Primary.ID {
+				return fmt.Errorf("Team still exists")
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckTeamMemberRemoteValues(resourceTeamMember *TeamMemberNode, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if string(resourceTeamMember.Role) != name {
+			return fmt.Errorf("remote team member role (%s) doesn't match expected value (%s)", resourceTeamMember.Role, name)
+		}
+		return nil
+	}
+}

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -86,6 +86,34 @@ func TestAccTeamMember_update(t *testing.T) {
 	})
 }
 
+// Confirm that this resource can be imported
+func TestAccTeamMember_import(t *testing.T) {
+	var resourceTeamMember TeamMemberNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTeamMemberResourceRemoved,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfigBasic("MEMBER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					// Confirm the team has the correct values in Buildkite's system
+					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MEMBER"),
+				),
+			},
+			{
+				// re-import the resource and confirm they match
+				ResourceName:      "buildkite_team_member.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccTeamMemberConfigBasic(role string) string {
 	config := `
 		resource "buildkite_team" "test" {

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -113,7 +113,7 @@ func testCheckTeamMemberResourceRemoved(s *terraform.State) error {
 		if err == nil {
 			if string(query.Node.TeamMember.ID) != "" &&
 				string(query.Node.TeamMember.ID) == rs.Primary.ID {
-				return fmt.Errorf("Team still exists")
+				return fmt.Errorf("Team member still exists")
 			}
 		}
 

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -22,7 +22,7 @@ func TestAccTeamMember_add_remove(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MEMBER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team member has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
 					// Confirm the team member has the correct values in terraform state
@@ -45,7 +45,7 @@ func TestAccTeamMember_add_remove_non_default_role(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MAINTAINER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team member has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MAINTAINER"),
 					// Confirm the team member has the correct values in terraform state
@@ -68,7 +68,7 @@ func TestAccTeamMember_update(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MEMBER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
 				),
@@ -77,7 +77,7 @@ func TestAccTeamMember_update(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MAINTAINER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MAINTAINER"),
 				),
@@ -99,7 +99,7 @@ func TestAccTeamMember_import(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MEMBER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team has the correct values in Buildkite's system
 					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MEMBER"),
 				),
@@ -127,7 +127,7 @@ func TestAccTeamMember_disappears(t *testing.T) {
 				Config: testAccTeamMemberConfigBasic("MEMBER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
-					testAccChecKTeamMemberExists("buildkite_team_member.test", &teamMember),
+					testAccCheckTeamMemberExists("buildkite_team_member.test", &teamMember),
 					// Ensure its removed
 					testAccCheckResourceDisappears(testAccProvider, resourceTeamMember(), "buildkite_team_member.test"),
 				),

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -23,7 +23,7 @@ func TestAccTeamMember_add_remove(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
 					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
-					// Confirm the team has the correct values in Buildkite's system
+					// Confirm the team member has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
 					// Confirm the team member has the correct values in terraform state
 					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MEMBER"),
@@ -46,7 +46,7 @@ func TestAccTeamMember_add_remove_non_default_role(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the team member exists in the buildkite API
 					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
-					// Confirm the team has the correct values in Buildkite's system
+					// Confirm the team member has the correct values in Buildkite's system
 					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MAINTAINER"),
 					// Confirm the team member has the correct values in terraform state
 					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MAINTAINER"),
@@ -79,7 +79,7 @@ func TestAccTeamMember_update(t *testing.T) {
 					// Confirm the team member exists in the buildkite API
 					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
 					// Confirm the team has the correct values in Buildkite's system
-					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
+					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MAINTAINER"),
 				),
 			},
 		},
@@ -133,7 +133,7 @@ func testAccChecKTeamMemberExists(resourceName string, resourceTeamMember *TeamM
 		}
 
 		if string(query.Node.TeamMember.ID) == "" {
-			return fmt.Errorf("No team found with graphql id: %s", resourceState.Primary.ID)
+			return fmt.Errorf("No team member found with graphql id: %s", resourceState.Primary.ID)
 		}
 
 		*resourceTeamMember = query.Node.TeamMember
@@ -176,11 +176,11 @@ func testCheckTeamMemberResourceRemoved(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTeamMemberRemoteValues(resourceTeamMember *TeamMemberNode, name string) resource.TestCheckFunc {
+func testAccCheckTeamMemberRemoteValues(resourceTeamMember *TeamMemberNode, role string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if string(resourceTeamMember.Role) != name {
-			return fmt.Errorf("remote team member role (%s) doesn't match expected value (%s)", resourceTeamMember.Role, name)
+		if string(resourceTeamMember.Role) != role {
+			return fmt.Errorf("remote team member role (%s) doesn't match expected value (%s)", resourceTeamMember.Role, role)
 		}
 		return nil
 	}

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -33,6 +33,59 @@ func TestAccTeamMember_add_remove(t *testing.T) {
 	})
 }
 
+func TestAccTeamMember_add_remove_non_default_role(t *testing.T) {
+	var resourceTeamMember TeamMemberNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTeamMemberResourceRemoved,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfigBasic("MAINTAINER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					// Confirm the team has the correct values in Buildkite's system
+					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MAINTAINER"),
+					// Confirm the team member has the correct values in terraform state
+					resource.TestCheckResourceAttr("buildkite_team_member.test", "role", "MAINTAINER"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTeamMember_update(t *testing.T) {
+	var resourceTeamMember TeamMemberNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTeamMemberResourceRemoved,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfigBasic("MEMBER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					// Confirm the team has the correct values in Buildkite's system
+					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
+				),
+			},
+			{
+				Config: testAccTeamMemberConfigBasic("MAINTAINER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &resourceTeamMember),
+					// Confirm the team has the correct values in Buildkite's system
+					testAccCheckTeamMemberRemoteValues(&resourceTeamMember, "MEMBER"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTeamMemberConfigBasic(role string) string {
 	config := `
 		resource "buildkite_team" "test" {

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -114,6 +114,29 @@ func TestAccTeamMember_import(t *testing.T) {
 	})
 }
 
+// Confirm that this resource can be removed
+func TestAccTeamMember_disappears(t *testing.T) {
+	var teamMember TeamMemberNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTeamMemberResourceRemoved,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfigBasic("MEMBER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team member exists in the buildkite API
+					testAccChecKTeamMemberExists("buildkite_team_member.test", &teamMember),
+					// Ensure its removed
+					testAccCheckResourceDisappears(testAccProvider, resourceTeamMember(), "buildkite_team_member.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccTeamMemberConfigBasic(role string) string {
 	config := `
 		resource "buildkite_team" "test" {

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -4,6 +4,8 @@ This resource allows you to create and manage teams.
 
 Buildkite Documentation: https://buildkite.com/docs/pipelines/permissions
 
+Note: You must first enable Teams on your organization.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -2,6 +2,8 @@
 
 This resource allows manage team membership for existing organization users.
 
+The user must already be part of the organization to which you are managing team membership. This will not invite a new user to the organization.
+
 Buildkite Documentation: https://buildkite.com/docs/pipelines/permissions
 
 Note: You must first enable Teams on your organization.

--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -1,0 +1,69 @@
+# Resource: team_member
+
+This resource allows manage team membership for existing organization users.
+
+Buildkite Documentation: https://buildkite.com/docs/pipelines/permissions
+
+Note: You must first enable Teams on your organization.
+
+## Example Usage
+
+```hcl
+resource "buildkite_team" "team" {
+    name = "developers"
+
+    privacy = "VISIBLE"
+
+    default_team = true
+    default_member_role = "MEMBER"
+}
+
+resource "buildkite_team_member" "a_smith" {
+    role = "MEMBER"
+    team_id = buildkite_team.team.id
+    user_id = "VXNlci0tLWRlOTdmMjBiLWJkZmMtNGNjOC1hOTcwLTY1ODNiZTk2ZGEyYQ=="
+}
+```
+
+## Argument Reference
+
+* `role` - (Required) Either MEMBER or MAINTAINER.
+* `team_id` - (Required) The GraphQL ID of the team to add to/remove from.
+* `user_id` - (Required) The GraphQL ID of the user to add/remove.
+
+## Attribute Reference
+
+* `id`   - The GraphQL ID of the team membership.
+* `uuid` - The UUID for the team membership.
+
+## Import
+
+Team members can be imported using the GraphQL ID of the membership. Note this is different to the ID of the user.
+
+```
+$ terraform import buildkite_team_member.a_smith VGVhbU1lbWJlci0tLTVlZDEyMmY2LTM2NjQtNDI1MS04YzMwLTc4NjRiMDdiZDQ4Zg==
+```
+
+To find the ID of a team member you are trying to import you can use the GraphQL snippet below. A link to this snippet can also be found at https://buildkite.com/user/graphql/console/c6a2cc65-dc59-49df-95c6-7167b68dbd5d.
+
+You will need fo fill in the organization slug and search terms for teams and members. Both search terms work on the name of the associated object.
+
+```graphql
+query {
+  organization(slug: "") {
+    teams(first: 2, search: "") {
+      edges {
+        node {
+          members(first: 2, search: "") {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
This PR adds the `buildkite_team_member` resource to manage connecting organisation users to teams.

The basic stuff should work since I've tested it manually although I haven't written unit tests just yet.  
Since teams have a notion of "default role", the role attribute on this resource is optional. However, if you specify it, apply, then remove it and apply it will break. I think we need to store the teams default role or look it up for instances where the role is not supplied.

That leads to the following to do items:

- [x] unit tests
- [x] maybe even integration test in `tf-proj`
- [x] fix bug when specifying then removing role attribute