### PR TITLE
Add team data source

### DIFF
--- a/buildkite/data_source_team.go
+++ b/buildkite/data_source_team.go
@@ -1,0 +1,91 @@
+package buildkite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/shurcooL/graphql"
+)
+
+func dataSourceTeam() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTeamRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"slug": {
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"uuid": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"name": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"privacy": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"description": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"default_team": {
+				Computed: true,
+				Type:     schema.TypeBool,
+			},
+			"default_member_role": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"members_can_create_pipelines": {
+				Computed: true,
+				Type:     schema.TypeBool,
+			},
+		},
+	}
+}
+
+// ReadTeam retrieves a Buildkite team
+func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	client := m.(*Client)
+	var query struct {
+		Team TeamNode `graphql:"team(slug: $slug)"`
+	}
+	orgTeamSlug := fmt.Sprintf("%s/%s", client.organization, d.Get("slug").(string))
+	vars := map[string]interface{}{
+		"slug": graphql.ID(orgTeamSlug),
+	}
+
+	err := client.graphql.Query(context.Background(), &query, vars)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if query.Team.ID == "" {
+		return diag.FromErr(errors.New("Team not found"))
+	}
+
+	d.SetId(string(query.Team.ID))
+	d.Set("slug", string(query.Team.Slug))
+	d.Set("uuid", string(query.Team.UUID))
+	d.Set("name", string(query.Team.Name))
+	d.Set("privacy", string(query.Team.Privacy))
+	d.Set("default_team", bool(query.Team.IsDefaultTeam))
+	d.Set("description", string(query.Team.Description))
+	d.Set("default_member_role", string(query.Team.DefaultMemberRole))
+	d.Set("members_can_create_pipelines", bool(query.Team.MembersCanCreatePipelines))
+
+	return diags
+}

--- a/buildkite/data_source_team_test.go
+++ b/buildkite/data_source_team_test.go
@@ -1,0 +1,53 @@
+package buildkite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Confirm that we can create a new agent token, and then delete it without error
+func TestAccDataTeam_read(t *testing.T) {
+	var resourceTeam TeamNode
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTeamResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTeamConfigBasic("foo"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the team exists in the buildkite API
+					testAccCheckTeamExists("buildkite_team.foobar", &resourceTeam),
+					// Confirm the team data source has the correct values in terraform state
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "name", "Test Team foo"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "description", "A test team foo"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "privacy", "VISIBLE"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "default_team", "true"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "default_member_role", "MEMBER"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "slug", "test-team-foo"),
+					resource.TestCheckResourceAttr("data.buildkite_team.foobar", "members_can_create_pipelines", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTeamConfigBasic(name string) string {
+	config := `
+		resource "buildkite_team" "foobar" {
+			name = "Test Team %s"
+			description = "A test team %s"
+			privacy = "VISIBLE"
+			default_team = true
+			default_member_role = "MEMBER"
+		}
+
+		data "buildkite_team" "foobar" {
+			slug = buildkite_team.foobar.slug
+		}
+	`
+	return fmt.Sprintf(config, name, name)
+}

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -17,6 +17,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"buildkite_meta":     dataSourceMeta(),
 			"buildkite_pipeline": dataSourcePipeline(),
+			"buildkite_team":     dataSourceTeam(),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization": &schema.Schema{

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -1,0 +1,27 @@
+# Data Source: Team
+
+Use this data source to look up properties of a team. This can be used to
+validate that a team exists before setting the team slug on a pipeline.
+
+## Example Usage
+
+```hcl
+data "buildkite_team" "my_team" {
+    slug = "my_team"
+}
+```
+
+## Argument Reference
+
+* `slug` - (Required) The slug of the team, available in the URL of the team on buildkite.com
+
+## Attribute Reference
+
+* `id` - The GraphQL ID of the team
+* `uuid` - The UUID of the team
+* `name` - The name of the team
+* `privacy` - Whether the team is visible to org members outside this team
+* `description` - A description of the team
+* `default_team` - Whether new org members will be automatically added to this team
+* `default_member_role` - Default role to assign to a team member
+* `members_can_create_pipelines` - Whether team members can create new pipelines and add them to the team

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -1,7 +1,9 @@
-# Data Source: Team
+# Data Source: team
 
 Use this data source to look up properties of a team. This can be used to
 validate that a team exists before setting the team slug on a pipeline.
+
+Buildkite documentation: https://buildkite.com/docs/pipelines/permissions
 
 ## Example Usage
 


### PR DESCRIPTION
This PR adds a team data source that uses the team slug to look up the team.

I felt this would be useful for validating the team slug passed to the `pipeline` resource, because if an invalid team name is supplied it can cause the pipeline to be created with no team which then needs cleaning up by admins.

This is my first terraform provider change so I shamelessly copied from https://github.com/buildkite/terraform-provider-buildkite/pull/106 as suggested in #139. I'm open to whatever feedback you want to give, as well as commits directly to the branch :)

## Testing

### Running terraform

I compiled the provider as instructed in the README and ran  `terraform plan` for the following:
```hcl
data "buildkite_team" "this" {
    slug = "everyone"
}

output "team" {
    value = data.buildkite_team.this
}
```

This was the output:

```
Changes to Outputs:
  + team = {
      + default_member_role          = "MEMBER"
      + default_team                 = true
      + description                  = "hi!"
      + id                           = "<redacted>"
      + members_can_create_pipelines = true
      + name                         = "Everyone"
      + privacy                      = "VISIBLE"
      + slug                         = "everyone"
      + uuid                         = "<redacted>"
    }
```

### Integration tests

As the README suggests, I set up a test organization to run the acceptance tests. The tests did not all pass but I don't think it was because of my change. I've included the test output below for you to look over.

<summary><details>

```
TF_ACC=1 go test -v ./...
?       github.com/buildkite/terraform-provider-buildkite       [no test files]
=== RUN   TestAccDataMeta_read
--- PASS: TestAccDataMeta_read (2.43s)
=== RUN   TestAccDataPipeline_read
--- PASS: TestAccDataPipeline_read (3.64s)
=== RUN   TestAccDataTeam_read
--- PASS: TestAccDataTeam_read (2.68s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAgentToken_add_remove
--- PASS: TestAccAgentToken_add_remove (2.24s)
=== RUN   TestAccAgentToken_update
--- PASS: TestAccAgentToken_update (8.19s)
=== RUN   TestAccAgentToken_import
--- PASS: TestAccAgentToken_import (2.38s)
=== RUN   TestAccPipelineSchedule_add_remove
--- PASS: TestAccPipelineSchedule_add_remove (10.31s)
=== RUN   TestAccPipelineSchedule_add_remove_withteams
    resource_pipeline_schedule_test.go:47: Step 1/1 error: Error running post-apply refresh:
        Error: Failed to read module directory

        Module directory
        ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest2962235257/work702429585/config4151149384
        does not exist or cannot be read.

--- FAIL: TestAccPipelineSchedule_add_remove_withteams (36.97s)
=== RUN   TestAccPipelineSchedule_update
--- PASS: TestAccPipelineSchedule_update (6.45s)
=== RUN   TestAccPipelineSchedule_update_withteams
--- PASS: TestAccPipelineSchedule_update_withteams (29.69s)
=== RUN   TestAccPipelineSchedule_import
--- PASS: TestAccPipelineSchedule_import (21.40s)
=== RUN   TestAccPipelineSchedule_disappears
--- PASS: TestAccPipelineSchedule_disappears (3.19s)
=== RUN   TestAccPipeline_add_remove
--- PASS: TestAccPipeline_add_remove (3.04s)
=== RUN   TestAccPipeline_add_remove_complex
--- PASS: TestAccPipeline_add_remove_complex (2.75s)
=== RUN   TestAccPipeline_add_remove_withteams
--- PASS: TestAccPipeline_add_remove_withteams (8.00s)
=== RUN   TestAccPipeline_update
--- PASS: TestAccPipeline_update (6.21s)
=== RUN   TestAccPipeline_update_withteams
    resource_pipeline_test.go:149: Step 1/2 error: Error running post-apply plan:
        Error: No configuration files

        Plan requires configuration to be present. Planning without a configuration
        would mark everything for destruction, which is normally not what is desired.
        If you would like to destroy everything, run plan with the -destroy option.
        Otherwise, create a Terraform configuration file (.tf file) and try again.

--- FAIL: TestAccPipeline_update_withteams (2.65s)
=== RUN   TestAccPipeline_import
--- PASS: TestAccPipeline_import (3.71s)
=== RUN   TestAccPipeline_disappears
    resource_pipeline_test.go:211: Step 1/1 error: Error running pre-apply refresh:
        Error: Failed to read module directory

        Module directory
        ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest3444086201/work2193893536/config2005749734
        does not exist or cannot be read.

--- FAIL: TestAccPipeline_disappears (0.90s)
=== RUN   TestAccTeamMember_add_remove
    resource_team_member_test.go:16: Step 1/1 error: Error running apply:
        Error: No user found

          on ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest566765774/work3937775510/config404199418/terraform_plugin_test.tf line 9, in resource "buildkite_team_member" "test":
           9:           resource "buildkite_team_member" "test" {


--- FAIL: TestAccTeamMember_add_remove (2.93s)
=== RUN   TestAccTeamMember_add_remove_non_default_role
    resource_team_member_test.go:39: Step 1/1 error: Error running apply:
        Error: No user found

          on ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest3814395568/work922268804/config3222774665/terraform_plugin_test.tf line 9, in resource "buildkite_team_member" "test":
           9:           resource "buildkite_team_member" "test" {


--- FAIL: TestAccTeamMember_add_remove_non_default_role (2.27s)
=== RUN   TestAccTeamMember_update
    resource_team_member_test.go:62: Step 1/2 error: Error running apply:
        Error: No user found

          on ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest1482233069/work185194963/config3976249596/terraform_plugin_test.tf line 9, in resource "buildkite_team_member" "test":
           9:           resource "buildkite_team_member" "test" {


--- FAIL: TestAccTeamMember_update (9.10s)
=== RUN   TestAccTeamMember_import
    resource_team_member_test.go:93: Step 1/2 error: Error running apply:
        Error: No user found

          on ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest2042808744/work4048729272/config396973937/terraform_plugin_test.tf line 9, in resource "buildkite_team_member" "test":
           9:           resource "buildkite_team_member" "test" {


--- FAIL: TestAccTeamMember_import (1.38s)
=== RUN   TestAccTeamMember_disappears
    resource_team_member_test.go:121: Step 1/1 error: Error running apply:
        Error: No user found

          on ../../../../../../../../var/folders/c2/3_j_m7ts5699kn50j5vwn2jc0000gq/T/tftest1152283695/work892642718/config2337637950/terraform_plugin_test.tf line 9, in resource "buildkite_team_member" "test":
           9:           resource "buildkite_team_member" "test" {


--- FAIL: TestAccTeamMember_disappears (2.67s)
=== RUN   TestAccTeam_add_remove
--- PASS: TestAccTeam_add_remove (2.80s)
=== RUN   TestAccTeam_update
--- PASS: TestAccTeam_update (7.74s)
=== RUN   TestAccTeam_import
--- PASS: TestAccTeam_import (2.74s)
=== RUN   TestAccTeam_disappears
--- PASS: TestAccTeam_disappears (2.15s)
FAIL
FAIL    github.com/buildkite/terraform-provider-buildkite/buildkite     190.955s
FAIL
make: *** [testacc] Error 1
```
</details></summary>

Here is the output from running `go test -v -run '.*TestAccDataTeam.*' ./...` to match just the test case I added:

```
?       github.com/buildkite/terraform-provider-buildkite       [no test files]
=== RUN   TestAccDataTeam_read
--- PASS: TestAccDataTeam_read (4.31s)
PASS
ok      github.com/buildkite/terraform-provider-buildkite/buildkite     4.691s
```

Closes #139 