### PR TITLE
SUP-312 Build fork PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,6 @@ steps:
 
   - label: acceptance tests
     key: testacc
-    if: build.branch == "main"
     concurrency: 1
     concurrency_group: terraform-provider-acceptance-tests
     command: "make testacc"
@@ -36,7 +35,6 @@ steps:
 
   - label: acceptance tests - non-admin
     key: testacc-nonadmin
-    if: build.branch == "main"
     concurrency: 1
     concurrency_group: terraform-provider-acceptance-tests
     command: "make testacc-nonadmin"


### PR DESCRIPTION
This removes the conditional on the acceptance test steps so that we can run them for every PR. These are the critical tests that provide so much value and would rather have them automated than manual.