### PR TITLE
Add allow_rebuilds documentation. Grammar.

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -62,9 +62,10 @@ resource "buildkite_pipeline" "repo2-release" {
 -   `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
 -   `branch_configuration` - (Optional) Limit which branches and tags cause new builds to be created, either via a code push or via the Builds REST API.
 -   `skip_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically skipping any unstarted builds on the same branch when a new build is created.
--   `skip_intermediate_builds_branch_filter` - (Optional) Limit which branches build skipping applies to, for example `!master` will ensure that the master branch won't have it's builds automatically skipped.
+-   `skip_intermediate_builds_branch_filter` - (Optional) Limit which branches build skipping applies to, for example `!master` will ensure that the master branch won't have its builds automatically skipped.
 -   `cancel_intermediate_builds` - (Optional, Default: `false` ) A boolean to enable automatically cancelling any running builds on the same branch when a new build is created.
--   `cancel_intermediate_builds_branch_filter` - (Optional) Limit which branches build cancelling applies to, for example !master will ensure that the master branch won't have it's builds automatically cancelled.
+-   `cancel_intermediate_builds_branch_filter` - (Optional) Limit which branches build cancelling applies to, for example !master will ensure that the master branch won't have its builds automatically cancelled.
+-   `allow_rebuilds` - (Optional, Default: `true` ) A boolean on whether or not to allow rebuilds for the pipeline.
 -   `cluster_id` - (Optional) The GraphQL ID of the cluster you want to use for the pipeline.
 -   `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. See [Teams Configuration](#team) below for details.
 -   `provider_settings` - (Optional) Source control provider settings for the pipeline. See [Provider Settings Configuration](#provider-settings-configuration) below for details.


### PR DESCRIPTION
`allow_rebuilds` was added with [this PR](https://github.com/buildkite/terraform-provider-buildkite/pull/193).

Adds documentation for `allow_rebuilds`.