### PR TITLE
Update version and referencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     buildkite = {
       source = "buildkite/buildkite"
-      version = "0.5.0"
+      version = "0.11.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     buildkite = {
       source = "buildkite/buildkite"
-      version = "0.5.0"
+      version = "0.11.1"
     }
   }
 }

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     buildkite = {
       source  = "buildkite/buildkite"
-      version = "0.0.18"
+      version = "0.11.1"
     }
   }
 }


### PR DESCRIPTION
We haven't changed the version for some time, it needs to be so we can add a new tag and include the already written docs for `allow_rebuilds`.

This will update the version to 0.11.1, which is a patch bump. Patch bump because it's an error fix; the errors is inconsistent version updates. This will also allow us to push tag v0.11.1 and provide clear support for allow_rebuilds. Given it has a default of `true` it's not a breaking change and folks will see the diff in their `terraform plan/apply` output if they are using `^` in their versioning.