### PR TITLE
Add arm64 command for agnostic support of architecture in build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ The repo contains a tf-proj/ directory that can be used to quickly test a compil
 2. Compile the provider and copy it into the filesystem cache in tf-proj
 
     ```bash
-    go build -o terraform-provider-buildkite_v0.0.18 . && \
-      mkdir -p tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.0.18/linux_amd64/ && \
-      mv terraform-provider-buildkite_v0.0.18 tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.0.18/linux_amd64/
+      go build -o terraform-provider-buildkite . && \
+        mkdir -p tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.5.0/$(arch)/ && \
+        mv terraform-provider-buildkite tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.5.0/$(arch)/
     ```
 
 3. Ensure the version number in the above command and in tf-proj/main.tf match


### PR DESCRIPTION
The current command is incorrect if the user isn't using Linux AMD 64 architecture. This command will use the output of `arch` and fill the dir.

```shell
❯ arch
arm64

go build -o terraform-provider-buildkite . && \                                
  mkdir -p tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.5.0/$(arch)/ && \
  mv terraform-provider-buildkite tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.5.0/$(arch)/

ls -al tf-proj/terraform.d/plugins/registry.terraform.io/buildkite/buildkite/0.5.0/      
drwxr-xr-x - ben 15 Mar 09:58 arm64

```