### PR TITLE
Update version and tag so that documentation is merged in to provider…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.11.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.5.0...v0.11.1)
+
+* Documentation had fallen out of sync due to lack of tag use. This change in the version includes a tag bump in order to merge documentation changes/improvements in to the provider page.
+
 ## [v0.5.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.4.0...v0.5.0)
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     buildkite = {
       source = "buildkite/buildkite"
-      version = "0.5.0"
+      version = "0.11.1"
     }
   }
 }

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     buildkite = {
       source  = "buildkite/buildkite"
-      version = "0.0.18"
+      version = "0.11.1"
     }
   }
 }


### PR DESCRIPTION
We have had some documentation updates, for example regarding `allow_rebuilds` but these aren't reflected in the provider due to inconsistent `tag` use.