### PR TITLE
enable dependabot for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: /
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Some of the direct and indirect dependencies in gomod are looking a bit out of date. This configures dependabot to occasionally bump them, but only up to 2 PRs at a time. We want to slowly keep them updated and avoid bitrot, without being overwhelmed by the rate of PRs.