### PR TITLE
Add documentation around plugin override for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You'll need to add a provider override to your `~/.terraformrc`. Documentation a
 provider_installation {
 
         dev_overrides {
-                "buildkite/buildkite" = "/Path/to/terraform-provider-buildkite/"
+                "buildkite/buildkite" = "/Path/to/this/repo/directory/"
         }
 
         direct {}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ The repo contains a tf-proj/ directory that can be used to quickly test a compil
     BUILDKITE_API_TOKEN=<api-token> BUILDKITE_ORGANIZATION=<org-slug> terraform plan
     ```
 
+### Overriding the provider for local development
+
+You'll need to add a provider override to your `~/.terraformrc`. Documentation around using this file can be found [here](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers). See below for an example of a `.terraformrc` file set up for plugin override.
+
+```hcl
+provider_installation {
+
+        dev_overrides {
+                "buildkite/buildkite" = "/Path/to/terraform-provider-buildkite/"
+        }
+
+        direct {}
+}
+
+```
+
+When you run `terraform` commands, you will now be using the local plugin, rather than the remote.
+
 ## Acceptance tests
 
 Acceptance tests that test the provider works against the live Buildkite API can be executed like this:


### PR DESCRIPTION
Added some context around using local plugins via setting overrides in the `.terraformrc` file.