### PR TITLE
SUP-838 Ensure CI passes/fails correctly

### DIFF
--- a/.buildkite/steps/annotate.sh
+++ b/.buildkite/steps/annotate.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -ueo pipefail
 
 go test -v -cover -json ./... | tee test_output
 


### PR DESCRIPTION
I'm not sure if it was originally intentional that it didn't error out early so that we could get the annotation and test analytics stuff still executed. But doing it that way has lost trust in the state of CI so failing fast is preferred