### PR TITLE
SUP-866 Add deletion protection for a pipeline

### DIFF
--- a/.buildkite/steps/annotate.sh
+++ b/.buildkite/steps/annotate.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -ueo pipefail
 
-go test -v -cover -json ./... | tee test_output
+annotate(){
+  go test -v -cover -json ./... | tee test_output
+  tparse -all -file test_output | tee tparse_output
+}
 
-tparse -all -file test_output | tee tparse_output
+exit_code="$(annotate 2>&1)" || ret=$?
+
+printf "Annotation exited with code $ret"
 
 printf '```term\n%b\n```' "$(cat tparse_output)" | buildkite-agent annotate --style info
 

--- a/.buildkite/steps/annotate.sh
+++ b/.buildkite/steps/annotate.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -ueo pipefail
 
-annotate(){
-  go test -v -cover -json ./... | tee test_output
-  tparse -all -file test_output | tee tparse_output
-}
+go test -v -cover -json ./... | tee test_output
 
-exit_code="$(annotate 2>&1)" || ret=$?
-
-printf "Annotation exited with code $ret"
+tparse -all -file test_output | tee tparse_output
 
 printf '```term\n%b\n```' "$(cat tparse_output)" | buildkite-agent annotate --style info
 

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -112,6 +112,12 @@ func resourcePipeline() *schema.Resource {
 				Default:  nil,
 				Type:     schema.TypeInt,
 			},
+			"deletion_protection": {
+				Optional:    true,
+				Default:     false,
+				Type:        schema.TypeBool,
+				Description: "If set to 'true', deletion of a pipeline via `terraform destroy` will fail, until set to 'false'.",
+			},
 			"maximum_timeout_in_minutes": {
 				Computed: true,
 				Optional: true,
@@ -499,6 +505,10 @@ func DeletePipeline(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 	vars := map[string]interface{}{
 		"id": graphql.ID(d.Id()),
+	}
+
+	if d.Get("deletion_protection") == true {
+		return diag.Errorf("Deletion protection is enabled for pipeline: %s", d.Get("name"))
 	}
 
 	log.Printf("Deleting pipeline %s ...", d.Get("name"))

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -263,6 +263,7 @@ func TestAccPipeline_import(t *testing.T) {
 				ResourceName:      "buildkite_pipeline.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -381,6 +382,7 @@ func TestAccPipelineDeletionProtection_import(t *testing.T) {
 				// re-import the resource (using the graphql token of the existing resource) and confirm they match
 				ResourceName:            resourceName,
 				ImportState:             true,
+				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -379,9 +379,9 @@ func TestAccPipelineDeletionProtection_import(t *testing.T) {
 			},
 			{
 				// re-import the resource (using the graphql token of the existing resource) and confirm they match
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -293,7 +293,7 @@ func TestAccPipeline_disappears(t *testing.T) {
 }
 
 // Testing for deletion protection on pipeline
-func TestAccPipelineDeletionProtection_created(t *testing.T) {
+func TestAccPipelineDeletionProtection_create(t *testing.T) {
 	var node PipelineNode
 	resourceName := "buildkite_pipeline.foobar"
 
@@ -315,7 +315,7 @@ func TestAccPipelineDeletionProtection_created(t *testing.T) {
 	})
 }
 
-func TestAccPipelineDeletionProtection_updated(t *testing.T) {
+func TestAccPipelineDeletionProtection_update(t *testing.T) {
 	var node PipelineNode
 
 	resource.Test(t, resource.TestCase{
@@ -345,9 +345,8 @@ func TestAccPipelineDeletionProtection_updated(t *testing.T) {
 	})
 }
 
-func TestAccPipelineDeletionProtection_imports(t *testing.T) {
+func TestAccPipelineDeletionProtection_import(t *testing.T) {
 	var node PipelineNode
-	resourceName := "buildkite_pipeline.foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -358,9 +357,9 @@ func TestAccPipelineDeletionProtection_imports(t *testing.T) {
 				Config: testAccPipelineDeletionProtectionConfig("this_should_pass", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the pipeline exists in the buildkite API
-					testAccCheckPipelineExists(resourceName, &node),
+					testAccCheckPipelineExists("buildkite_pipeline.foobar", &node),
 					// Ensure deletion_protection is present in the config
-					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "deletion_protection", "false"),
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "name", "this_should_pass"),
 				),
 			},
 			{
@@ -373,7 +372,7 @@ func TestAccPipelineDeletionProtection_imports(t *testing.T) {
 	})
 }
 
-func TestAccPipelineDeletionProtection_fails(t *testing.T) {
+func TestAccPipelineDeletionProtection_fail(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -260,9 +260,9 @@ func TestAccPipeline_import(t *testing.T) {
 			},
 			{
 				// re-import the resource (using the graphql token of the existing resource) and confirm they match
-				ResourceName:      "buildkite_pipeline.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "buildkite_pipeline.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
@@ -382,7 +382,7 @@ func TestAccPipelineDeletionProtection_import(t *testing.T) {
 				// re-import the resource (using the graphql token of the existing resource) and confirm they match
 				ResourceName:            resourceName,
 				ImportState:             true,
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -458,7 +458,7 @@ func testAccPipelineConfigBasic(name string) string {
 func testAccPipelineDeletionProtectionConfig(name string, deletion_protection bool) string {
 	config := `
 		resource "buildkite_pipeline" "foobar" {
-			name = "Test Pipeline %s"
+			name = "%s"
 			repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 			steps = ""
 			deletion_protection = %t

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -372,19 +372,21 @@ func TestAccPipelineDeletionProtection_import(t *testing.T) {
 	})
 }
 
-func TestAccPipelineDeletionProtection_fail(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPipelineResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccPipelineDeletionProtectionConfig("this_should_fail", true),
-				ExpectError: regexp.MustCompile("Deletion protection is enabled for pipeline: this_should_fail"),
-			},
-		},
-	})
-}
+// func TestAccPipelineDeletionProtection_fail(t *testing.T) {
+// AT THE MOMENT, TESTING THAT DESTROY FAILS ISN'T POSSIBLE
+// Closed PR is here: https://github.com/hashicorp/terraform-plugin-sdk/pull/976
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckPipelineResourceDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config:      testAccPipelineDeletionProtectionConfig("this_should_fail", true),
+// 				ExpectError: regexp.MustCompile("Deletion protection is enabled for pipeline: this_should_fail"),
+// 			},
+// 		},
+// 	})
+// }
 
 func testAccCheckPipelineExists(resourceName string, resourcePipeline *PipelineNode) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     buildkite = {
       source = "buildkite/buildkite"
-      version = "0.11.1"
+      version = "0.14.0"
     }
   }
 }

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -41,6 +41,22 @@ resource "buildkite_pipeline" "test_new" {
 
 Currently, the `default_timeout_in_minutes` and `maximum_timeout_in_minutes` will be retained in state even if removed from the configuration. In order to remove them, you must set them to `0` in either the configuration or the web UI.
 
+## Example Usage with Deletion Protection
+
+```hcl
+resource "buildkite_pipeline" "test_new" {
+    name       = "Testing Timeouts"
+    repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+
+    steps = file("./deploy-steps.yml")
+
+    deletion_protection = true
+}
+}
+```
+
+`deletion_protection` will block `destroy` actions on the **pipeline**. Attached resources, such as `schedules` will still be destroyed.
+
 ## Example Usage with GitHub Provider Settings
 
 ```hcl
@@ -88,6 +104,7 @@ resource "buildkite_pipeline" "repo2-release" {
 -   `cluster_id` - (Optional) The GraphQL ID of the cluster you want to use for the pipeline.
 -   `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. See [Teams Configuration](#team) below for details.
 -   `provider_settings` - (Optional) Source control provider settings for the pipeline. See [Provider Settings Configuration](#provider-settings-configuration) below for details.
+-   `deletion_protection` - (Optional) Set to either `true` or `false`. When set to `true`, `destroy` actions on a pipeline will be blocked and fail with a message "Deletion protection is enabled for pipeline: <pipeline name>"
 
 ### Teams Configuration
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -17,6 +17,8 @@ resource "buildkite_pipeline" "repo2" {
         slug = buildkite_team.test.slug
         access_level = "READ_ONLY"
     }
+
+    deletion_protection = true
 }
 
 resource "buildkite_agent_token" "fleet" {

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     buildkite = {
       source  = "buildkite/buildkite"
-      version = "0.11.1"
+      version = "0.12.1"
     }
   }
 }
@@ -16,9 +16,6 @@ resource "buildkite_pipeline" "test_new" {
   repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 
   steps = ""
-
-  default_timeout_in_minutes = 5
-  maximum_timeout_in_minutes = 20
 }
 
 resource "buildkite_pipeline_schedule" "test_scheduled" {

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -18,8 +18,6 @@ resource "buildkite_pipeline" "test_new" {
   steps = ""
   default_timeout_in_minutes = 15
   maximum_timeout_in_minutes = 60
-
-  deletion_protection = false
 }
 
 resource "buildkite_pipeline_schedule" "test_scheduled" {

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -16,6 +16,10 @@ resource "buildkite_pipeline" "test_new" {
   repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 
   steps = ""
+  default_timeout_in_minutes = 15
+  maximum_timeout_in_minutes = 60
+
+  deletion_protection = false
 }
 
 resource "buildkite_pipeline_schedule" "test_scheduled" {


### PR DESCRIPTION
This came in as a request from Slack and seems like a reasonable ask given the authority that Terraform can have over an organisation.

### Changes

- Add `delete_protection` as an option on a pipeline (defaults to `false`)
- Add tests around the `deletion_protection` config
- Add nice messaging for error when user tries to destroy pipeline with `deletion_protection` enabled