### PR TITLE
Set User-Agent header in client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20@sha256:f7099345b8e4a93c62dc5102e7eb19a9cdbad12e7e322644eeaba355d70e616d
+FROM 445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/golang:1.20@sha256:f7099345b8e4a93c62dc5102e7eb19a9cdbad12e7e322644eeaba355d70e616d
 
 RUN apt-get update \
     && apt-get install -y unzip \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: build
 
 build:
-	go build -o terraform-provider-buildkite .
+	go build -o terraform-provider-buildkite -ldflags="-s -w -X main.version=$(shell git describe --tag)" .
 
 fmt:
 	go fmt ./...

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -52,7 +52,7 @@ func (client *Client) makeRequest(method string, path string, postData interface
 	if postData != nil {
 		jsonPayload, err := json.Marshal(postData)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to marshal request: %w", err)
 		}
 		bodyBytes = bytes.NewBuffer(jsonPayload)
 	}
@@ -61,27 +61,27 @@ func (client *Client) makeRequest(method string, path string, postData interface
 
 	req, err := http.NewRequest(method, url, bodyBytes)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Add("User-Agent", client.userAgent)
 
 	resp, err := client.http.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to send request: %w", err)
 	}
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("Buildkite API request failed: %s %s (status: %d)", method, url, resp.StatusCode)
 	}
-
 	defer resp.Body.Close()
+
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read response: %w", err)
 	}
 
 	if err := json.Unmarshal(responseBody, responseObject); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
 	return nil

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -21,10 +21,11 @@ type Client struct {
 	http         *http.Client
 	organization string
 	restUrl      string
+	userAgent    string
 }
 
 // NewClient creates a client to use for interacting with the Buildkite API
-func NewClient(org, apiToken, graphqlUrl, restUrl string) *Client {
+func NewClient(org, apiToken, graphqlUrl, restUrl, userAgent string) *Client {
 	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiToken})
 	httpClient := oauth2.NewClient(context.Background(), token)
 
@@ -34,6 +35,7 @@ func NewClient(org, apiToken, graphqlUrl, restUrl string) *Client {
 		http:         httpClient,
 		organization: org,
 		restUrl:      restUrl,
+		userAgent:    userAgent,
 	}
 }
 
@@ -53,6 +55,8 @@ func (client *Client) makeRequest(method string, path string, postData interface
 	if err != nil {
 		return err
 	}
+
+	req.Header.Add("User-Agent", client.userAgent)
 
 	resp, err := client.http.Do(req)
 	if err != nil {

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -24,18 +24,26 @@ type Client struct {
 	userAgent    string
 }
 
+type clientConfig struct {
+	org        string
+	apiToken   string
+	graphqlURL string
+	restURL    string
+	userAgent  string
+}
+
 // NewClient creates a client to use for interacting with the Buildkite API
-func NewClient(org, apiToken, graphqlUrl, restUrl, userAgent string) *Client {
-	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiToken})
+func NewClient(config *clientConfig) *Client {
+	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.apiToken})
 	httpClient := oauth2.NewClient(context.Background(), token)
 
 	return &Client{
-		graphql:      graphql.NewClient(graphqlUrl, httpClient),
-		genqlient:    genqlient.NewClient(graphqlUrl, httpClient),
+		graphql:      graphql.NewClient(config.graphqlURL, httpClient),
+		genqlient:    genqlient.NewClient(config.graphqlURL, httpClient),
 		http:         httpClient,
-		organization: org,
-		restUrl:      restUrl,
-		userAgent:    userAgent,
+		organization: config.org,
+		restUrl:      config.restURL,
+		userAgent:    config.userAgent,
 	}
 }
 

--- a/buildkite/provider_test.go
+++ b/buildkite/provider_test.go
@@ -16,7 +16,7 @@ var testAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
 
 func init() {
-	testAccProvider = Provider()
+	testAccProvider = Provider("")
 	testAccProviders = map[string]*schema.Provider{
 		"buildkite": testAccProvider,
 	}
@@ -24,13 +24,13 @@ func init() {
 
 // TestProvider just does basic validation to ensure the schema is defined and supporting functions exist
 func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
+	if err := Provider("").InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
-	var _ *schema.Provider = Provider()
+	var _ *schema.Provider = Provider("")
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -7,7 +7,16 @@ import (
 
 func TestGetOrganizationIDMissing(t *testing.T) {
 	slug := "doesnt match API key"
-	client := NewClient(slug, os.Getenv("BUILDKITE_API_TOKEN"), graphqlEndpoint, restEndpoint, "test-user-agent")
+
+	config := &clientConfig{
+		org:        slug,
+		apiToken:   os.Getenv("BUILDKITE_API_TOKEN"),
+		graphqlURL: defaultGraphqlEndpoint,
+		restURL:    defaultRestEndpoint,
+		userAgent:  "test-user-agent",
+	}
+
+	client := NewClient(config)
 
 	id, err := GetOrganizationID(slug, client.graphql)
 	if err == nil {

--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGetOrganizationIDMissing(t *testing.T) {
 	slug := "doesnt match API key"
-	client := NewClient(slug, os.Getenv("BUILDKITE_API_TOKEN"), graphqlEndpoint, restEndpoint)
+	client := NewClient(slug, os.Getenv("BUILDKITE_API_TOKEN"), graphqlEndpoint, restEndpoint, "test-user-agent")
 
 	id, err := GetOrganizationID(slug, client.graphql)
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -2,11 +2,19 @@ package main
 
 import (
 	"github.com/buildkite/terraform-provider-buildkite/buildkite"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+)
+
+// Set at compile time from ldflags
+var (
+	version string
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: buildkite.Provider,
+		ProviderFunc: func() *schema.Provider {
+			return buildkite.Provider(version)
+		},
 	})
 }


### PR DESCRIPTION
This sets the user agent for api client.

Using [Provider.UserAgent](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema#Provider.UserAgent) to set the header.

Also, this can now take a `version` coming from ldflags which is added as a suffix.

Rendered example:
```
Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.0.3 buildkite/v0.14.0-1-g3539448
```
