### PR TITLE
Allow release pipeline to pull from private ECR registry

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -2,8 +2,10 @@ steps:
   - label: release
     command: ".buildkite/steps/release.sh"
     plugins:
-      docker-compose#v2.2.0:
-        run: go
+      - ecr#v2.3.0:
+          account-ids: "445615400570"
+          login: true
+      - docker-compose#v2.2.0:
+          run: go
     agents:
       queue: "deploy"
-


### PR DESCRIPTION
After reconfiguring our Docker images to be retrieved via a pull-through cache we need to allow the release step (which runs on agents in a completely different AWS account) pull access to the cached golang images.