### PR TITLE
Set User-Agent header on both REST and graphql requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Khan/genqlient v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
-	golang.org/x/oauth2 v0.7.0
 )
 
 require (
@@ -17,6 +16,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
+	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 )
 


### PR DESCRIPTION
In #256 we starting setting a custom User-Agent header on REST API calls, to help us understand the ways our API is used. It looks like this:

    Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.0.3 buildkite/0.15.0

This builds on that work and sets the same User-Agent on graphql API requests as well.

It drops the unnecessary use of golang.org/x/oauth2 to set a static bearer token header, and uses the [tripperware pattern](https://dev.to/stevenacoffman/tripperwares-http-client-middleware-chaining-roundtrippers-3o00) to set both headers we care about:

1. the static bearer token for auth
2. the user agent

The same http.Client is used for both REST and graphql, so we'll get identical behaviour on both APIs.