### PR TITLE
SUP-819 Retrieve org id only once in provider configuration

### DIFF
--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -80,6 +80,6 @@ func providerConfigure(userAgent string) func(d *schema.ResourceData) (interface
 			userAgent:  userAgent,
 		}
 
-		return NewClient(config), nil
+		return NewClient(config)
 	}
 }

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -49,10 +49,6 @@ func resourceAgentToken() *schema.Resource {
 // CreateToken creates a Buildkite agent token
 func CreateToken(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
-	id, err := GetOrganizationID(client.organization, client.graphql)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	var mutation struct {
 		AgentTokenCreate struct {
@@ -63,11 +59,11 @@ func CreateToken(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	}
 
 	vars := map[string]interface{}{
-		"org":  id,
+		"org":  client.organizationId,
 		"desc": graphql.String(d.Get("description").(string)),
 	}
 
-	err = client.graphql.Mutate(context.Background(), &mutation, vars)
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -318,10 +318,7 @@ func resourcePipeline() *schema.Resource {
 // CreatePipeline creates a Buildkite pipeline
 func CreatePipeline(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
-	orgID, err := GetOrganizationID(client.organization, client.graphql)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	var err error
 
 	teamPipelines := getTeamPipelinesFromSchema(d)
 	var mutation struct {
@@ -352,7 +349,7 @@ func CreatePipeline(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		"maximum_timeout_in_minutes":               graphql.Int(d.Get("maximum_timeout_in_minutes").(int)),
 		"desc":                                     graphql.String(d.Get("description").(string)),
 		"name":                                     graphql.String(d.Get("name").(string)),
-		"org":                                      orgID,
+		"org":                                      client.organizationId,
 		"repository_url":                           graphql.String(d.Get("repository").(string)),
 		"skip_intermediate_builds":                 graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
 		"skip_intermediate_builds_branch_filter":   graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),

--- a/buildkite/resource_team.go
+++ b/buildkite/resource_team.go
@@ -98,10 +98,6 @@ func resourceTeam() *schema.Resource {
 // CreateTeam creates a Buildkite team
 func CreateTeam(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
-	id, err := GetOrganizationID(client.organization, client.graphql)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	var mutation struct {
 		TeamCreate struct {
@@ -112,7 +108,7 @@ func CreateTeam(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 	}
 
 	vars := map[string]interface{}{
-		"org":                          id,
+		"org":                          client.organizationId,
 		"name":                         graphql.String(d.Get("name").(string)),
 		"desc":                         graphql.String(d.Get("description").(string)),
 		"privacy":                      TeamPrivacy(d.Get("privacy").(string)),
@@ -121,7 +117,7 @@ func CreateTeam(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		"members_can_create_pipelines": graphql.Boolean(d.Get("members_can_create_pipelines").(bool)),
 	}
 
-	err = client.graphql.Mutate(context.Background(), &mutation, vars)
+	err := client.graphql.Mutate(context.Background(), &mutation, vars)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -16,16 +16,12 @@ func TestGetOrganizationIDMissing(t *testing.T) {
 		userAgent:  "test-user-agent",
 	}
 
+	// NewClient calls GetOrganizationId so we can test the output
 	client, err := NewClient(config)
 	if err == nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	id, err := GetOrganizationID(slug, client.graphql)
-	if err == nil {
-		t.Fatalf("err: %s", err)
-	}
-	if id != "" {
+	if client != nil {
 		t.Fatalf("Nonexistent organization found")
 	}
 }

--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -16,7 +16,10 @@ func TestGetOrganizationIDMissing(t *testing.T) {
 		userAgent:  "test-user-agent",
 	}
 
-	client := NewClient(config)
+	client, err := NewClient(config)
+	if err == nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	id, err := GetOrganizationID(slug, client.graphql)
 	if err == nil {


### PR DESCRIPTION
To improve performance, move the retrieval of organization ID to the provider configuration/startup instead of each time it is required by a resource operation
