### PR TITLE
SUP-707: Pipeline resource's steps made optional, default pipeline upload step  

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -153,7 +153,7 @@ func resourcePipeline() *schema.Resource {
 			},
 			"steps": {
 				Optional: true,
-				Default:  "buildkite-agent pipeline upload",
+				Default: "    steps:\n    - label: ':pipeline: Pipeline Upload'\n      command: buildkite-agent pipeline upload\n",
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -10,6 +10,10 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
+const DefaultSteps = `steps:
+- label: ':pipeline: Pipeline Upload'
+  command: buildkite-agent pipeline upload`
+
 // PipelineNode represents a pipeline as returned from the GraphQL API
 type PipelineNode struct {
 	AllowRebuilds                        graphql.Boolean
@@ -153,9 +157,7 @@ func resourcePipeline() *schema.Resource {
 			},
 			"steps": {
 				Optional: true,
-				Default: `steps:
-				- label: ':pipeline: Pipeline Upload
-				  command: buildkite-agent pipeline upload`,
+				Default:  DefaultSteps,
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -152,7 +152,8 @@ func resourcePipeline() *schema.Resource {
 				Type:     schema.TypeString,
 			},
 			"steps": {
-				Required: true,
+				Optional: true,
+				Default:  "buildkite-agent pipeline upload",
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -153,7 +153,7 @@ func resourcePipeline() *schema.Resource {
 			},
 			"steps": {
 				Optional: true,
-				Default: "    steps:\n    - label: ':pipeline: Pipeline Upload'\n      command: buildkite-agent pipeline upload\n",
+				Default:  "    steps:\n    - label: ':pipeline: Pipeline Upload'\n      command: buildkite-agent pipeline upload\n",
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -10,7 +10,7 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
-const DefaultSteps = `steps:
+const defaultSteps = `steps:
 - label: ':pipeline: Pipeline Upload'
   command: buildkite-agent pipeline upload`
 
@@ -157,7 +157,7 @@ func resourcePipeline() *schema.Resource {
 			},
 			"steps": {
 				Optional: true,
-				Default:  DefaultSteps,
+				Default:  defaultSteps,
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -153,7 +153,9 @@ func resourcePipeline() *schema.Resource {
 			},
 			"steps": {
 				Optional: true,
-				Default:  "    steps:\n    - label: ':pipeline: Pipeline Upload'\n      command: buildkite-agent pipeline upload\n",
+				Default: `steps:
+				- label: ':pipeline: Pipeline Upload
+				  command: buildkite-agent pipeline upload`,
 				Type:     schema.TypeString,
 			},
 			"team": {

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -208,7 +208,7 @@ func TestAccPipeline_add_remove_withdefinedsteps(t *testing.T) {
 		CheckDestroy: testAccCheckPipelineResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPipelineConfigComplex("bar", steps),
+				Config: testAccPipelineConfigBasicWithSteps("bar", steps),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Confirm the pipeline exists in the buildkite API
 					testAccCheckPipelineExists("buildkite_pipeline.foobar", &resourcePipeline),
@@ -582,10 +582,10 @@ func testAccPipelineConfigBasicWithSteps(name string, steps string) string {
 		resource "buildkite_pipeline" "foobar" {
 		    name = "Test Pipeline %s"
 		    repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
-			steps = %s
+		    steps = %s
 		}
 	`
-	return fmt.Sprintf(config, name)
+	return fmt.Sprintf(config, name, steps)
 }
 
 func testAccPipelineConfigComplex(name string, steps string) string {

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -175,6 +175,29 @@ func TestAccPipeline_add_remove_withtimeouts(t *testing.T) {
 	})
 }
 
+func TestAccPipeline_add_remove_withdefaultsteps(t *testing.T) {
+	var resourcePipeline PipelineNode
+	
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPipelineResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPipelineConfigBasicWithNoSteps("foo"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Confirm the pipeline exists in the buildkite API
+					testAccCheckPipelineExists("buildkite_pipeline.foobar", &resourcePipeline),
+					// Confirm the pipeline has the correct values in Buildkite's system
+					testAccCheckPipelineRemoteValues(&resourcePipeline, "Test Pipeline foo"),
+					// Confirm the pipeline has the correct values in Buildkite's system
+					resource.TestCheckResourceAttr("buildkite_pipeline.foobar", "steps", "steps:\n- label: ':pipeline: Pipeline Upload'\n  command: buildkite-agent pipeline upload"),
+				),
+			},
+		},
+	})
+}
+
 // Confirm that we can create a new pipeline, and then update the description
 func TestAccPipeline_update(t *testing.T) {
 	var resourcePipeline PipelineNode
@@ -515,6 +538,16 @@ func testAccPipelineConfigBasicWithTimeouts(name string) string {
 
 			default_timeout_in_minutes = 10
 			maximum_timeout_in_minutes = 20
+		}
+	`
+	return fmt.Sprintf(config, name)
+}
+
+func testAccPipelineConfigBasicWithNoSteps(name string) string {
+	config := `
+		resource "buildkite_pipeline" "foobar" {
+		    name = "Test Pipeline %s"
+		    repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 		}
 	`
 	return fmt.Sprintf(config, name)

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -177,7 +177,7 @@ func TestAccPipeline_add_remove_withtimeouts(t *testing.T) {
 
 func TestAccPipeline_add_remove_withdefaultsteps(t *testing.T) {
 	var resourcePipeline PipelineNode
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -221,7 +221,6 @@ func TestAccPipeline_add_remove_withdefinedsteps(t *testing.T) {
 		},
 	})
 }
-
 
 // Confirm that we can create a new pipeline, and then update the description
 func TestAccPipeline_update(t *testing.T) {


### PR DESCRIPTION
Amended the Pipeline resource's step parameter to be Optional with a default of `buildkite-agent pipeline upload` if not defined in a to-be-made pipeline resource

Utilising a pipeline.tf file like below:

```
resource "buildkite_pipeline" "terraform-bk-example" {
    name = "terraform-bk-example"
    repository = "git@github.com:james2791/terraform-bk-example.git"
    default_branch = "main"
}
```
Pipeline resource creation

![image](https://user-images.githubusercontent.com/70425486/234782673-74333086-b40a-43f7-ad72-7c642e2847d6.png)

Pipeline creation with the default step:

![image](https://user-images.githubusercontent.com/70425486/234783052-40e0c720-6c10-428d-8132-754bc45eaa67.png)

Acceptance tests created (one with no default steps which gets filled, the other with steps defined) - running against my own org/API key

![image](https://user-images.githubusercontent.com/70425486/235041033-4309c142-ce57-434c-aabc-b40fcdcbe03f.png)

