### PR TITLE
Update the paths where we load environment variables from

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,9 +30,9 @@ steps:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-terraform-provider-buildkite-main
       - aws-ssm#v1.0.0:
           parameters:
-            BUILDKITE_ORGANIZATION: /pipelines/terraform-provider-buildkite-main/buildkite_organization
-            BUILDKITE_API_TOKEN: /pipelines/terraform-provider-buildkite-main/buildkite_api_token
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/terraform-provider-buildkite-main/buildkite_analytics_token
+            BUILDKITE_ORGANIZATION: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_organization
+            BUILDKITE_API_TOKEN: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_api_token
+            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_analytics_token
       - docker-compose#v3.9.0:
           run: go
           mount-buildkite-agent: 'true'
@@ -47,8 +47,8 @@ steps:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-terraform-provider-buildkite-main
       - aws-ssm#v1.0.0:
           parameters:
-            BUILDKITE_ORGANIZATION: /pipelines/terraform-provider-buildkite-main/buildkite_organization
-            BUILDKITE_API_TOKEN: /pipelines/terraform-provider-buildkite-main/buildkite_api_token_nonadmin
+            BUILDKITE_ORGANIZATION: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_organization
+            BUILDKITE_API_TOKEN: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_api_token_nonadmin
       - docker-compose#v3.9.0:
           run: go
 


### PR DESCRIPTION
For consistency with other pipelines, we're prefixing all ENV var paths with the org slug in addition to the pipeline slug - note the `/buildkite` inserted into each path here.