### PR TITLE
SUP-906/Fix: Adjustment of README version, Pipeline Argument Reference amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     buildkite = {
       source = "buildkite/buildkite"
-      version = "0.12.0"
+      version = "0.17.1"
     }
   }
 }

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -102,7 +102,7 @@ resource "buildkite_pipeline" "repo2-release" {
 -   `allow_rebuilds` - (Optional, Default: `true` ) A boolean on whether or not to allow rebuilds for the pipeline.
 -   `cluster_id` - (Optional) The GraphQL ID of the cluster you want to use for the pipeline.
 -   `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. See [Teams Configuration](#team) below for details.
--   `tags` - (Optional) A set of tags to be set to the pipeline. For example `["terraform", "provider"]`
+-   `tags` - (Optional) A set of tags to be set to the pipeline. For example `["terraform", "provider"]`.
 -   `provider_settings` - (Optional) Source control provider settings for the pipeline. See [Provider Settings Configuration](#provider-settings-configuration) below for details.
 -   `deletion_protection` - (Optional) Set to either `true` or `false`. When set to `true`, `destroy` actions on a pipeline will be blocked and fail with a message "Deletion protection is enabled for pipeline: <pipeline name>"
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -89,7 +89,7 @@ resource "buildkite_pipeline" "repo2-release" {
 
 -   `name` - (Required) The name of the pipeline.
 -   `repository` - (Required) The git URL of the repository.
--   `steps` - (Required) The string YAML steps to run the pipeline.
+-   `steps` - (Optional) The string YAML steps to run the pipeline. Defaults to `buildkite-agent pipeline upload` if not specified.
 -   `description` - (Optional) A description of the pipeline.
 -   `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered, usually main or master but can be anything.
 -   `default_timeout_in_minutes` - (Optional) The default timeout for commands in this pipeline, in minutes.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -102,6 +102,7 @@ resource "buildkite_pipeline" "repo2-release" {
 -   `allow_rebuilds` - (Optional, Default: `true` ) A boolean on whether or not to allow rebuilds for the pipeline.
 -   `cluster_id` - (Optional) The GraphQL ID of the cluster you want to use for the pipeline.
 -   `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. See [Teams Configuration](#team) below for details.
+-   `tags` - (Optional) A set of tags to be set to the pipeline. For example `["terraform", "provider"]`
 -   `provider_settings` - (Optional) Source control provider settings for the pipeline. See [Provider Settings Configuration](#provider-settings-configuration) below for details.
 -   `deletion_protection` - (Optional) Set to either `true` or `false`. When set to `true`, `destroy` actions on a pipeline will be blocked and fail with a message "Deletion protection is enabled for pipeline: <pipeline name>"
 


### PR DESCRIPTION
Added the latest (to be) provider version as the README's version pointer

Revised in the Argument Reference:
- `steps` to be Optional, and defaulting to `buildkite-agent pipeline upload` if not set in the TF schema
- `tags` added (SUP-906)

Branch build [passing](https://buildkite.com/buildkite/terraform-provider-buildkite-main/builds/361)