### PR TITLE
SUP-1043 Change default provider settings to match new pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-* Change default provider settings to match new pipeline[[PR #282](https://github.com/buildkite/terraform-provider-buildkite/pull/282)] 
+* Change default provider settings to match new pipeline [[PR #282](https://github.com/buildkite/terraform-provider-buildkite/pull/282)] 
 
 ## [v0.18.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.18.0...v0.18.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Change default provider settings to match new pipeline[[PR #282](https://github.com/buildkite/terraform-provider-buildkite/pull/282)] 
+
 ## [v0.18.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.18.0...v0.18.1)
 
 ### Fixes
-* Pipelines resource Computed/Default nil values reversion[[PR #277](https://github.com/buildkite/terraform-provider-buildkite/pull/277)] @james2791
+* Pipelines resource Computed/Default nil values reversion [[PR #277](https://github.com/buildkite/terraform-provider-buildkite/pull/277)] @james2791
 
 ## [v0.18.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.17.1...v0.18.0)
 

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -224,6 +224,7 @@ func resourcePipeline() *schema.Resource {
 							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
+							Default:  true,
 						},
 						"pull_request_branch_filter_enabled": {
 							Computed: true,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -221,7 +221,6 @@ func resourcePipeline() *schema.Resource {
 							},
 						},
 						"build_pull_requests": {
-							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
 							Default:  true,
@@ -237,7 +236,6 @@ func resourcePipeline() *schema.Resource {
 							Type:     schema.TypeString,
 						},
 						"skip_pull_request_builds_for_existing_commits": {
-							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
 							Default:  true,
@@ -263,7 +261,6 @@ func resourcePipeline() *schema.Resource {
 							Type:     schema.TypeBool,
 						},
 						"build_branches": {
-							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
 							Default:  true,
@@ -289,7 +286,6 @@ func resourcePipeline() *schema.Resource {
 							Type:     schema.TypeString,
 						},
 						"publish_commit_status": {
-							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
 							Default:  true,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -239,6 +239,7 @@ func resourcePipeline() *schema.Resource {
 							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
+							Default:  true,
 						},
 						"build_pull_request_ready_for_review": {
 							Computed: true,
@@ -264,6 +265,7 @@ func resourcePipeline() *schema.Resource {
 							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
+							Default:  true,
 						},
 						"build_tags": {
 							Computed: true,
@@ -289,6 +291,7 @@ func resourcePipeline() *schema.Resource {
 							Computed: true,
 							Optional: true,
 							Type:     schema.TypeBool,
+							Default:  true,
 						},
 						"publish_blocked_as_pending": {
 							Computed: true,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -235,6 +235,10 @@ func resourcePipeline() *schema.Resource {
 							Optional: true,
 							Type:     schema.TypeString,
 						},
+						"skip_builds_for_existing_commits": {
+							Optional: true,
+							Type:     schema.TypeBool,
+						},
 						"skip_pull_request_builds_for_existing_commits": {
 							Optional: true,
 							Type:     schema.TypeBool,
@@ -539,6 +543,7 @@ type PipelineExtraInfo struct {
 			BuildPullRequests                       bool   `json:"build_pull_requests"`
 			PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled"`
 			PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration"`
+			SkipBuildsForExistingCommits            bool   `json:"skip_builds_for_existing_commits"`
 			SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits"`
 			BuildPullRequestReadyForReview          bool   `json:"build_pull_request_ready_for_review"`
 			BuildPullRequestLabelsChanged           bool   `json:"build_pull_request_labels_changed"`
@@ -802,6 +807,7 @@ func updatePipelineResourceExtraInfo(d *schema.ResourceData, pipeline *PipelineE
 		"build_pull_requests":                           s.BuildPullRequests,
 		"pull_request_branch_filter_enabled":            s.PullRequestBranchFilterEnabled,
 		"pull_request_branch_filter_configuration":      s.PullRequestBranchFilterConfiguration,
+		"skip_builds_for_existing_commits":              s.SkipBuildsForExistingCommits,
 		"skip_pull_request_builds_for_existing_commits": s.SkipPullRequestBuildsForExistingCommits,
 		"build_pull_request_ready_for_review":           s.BuildPullRequestReadyForReview,
 		"build_pull_request_labels_changed":             s.BuildPullRequestLabelsChanged,

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -131,6 +131,7 @@ Properties available for Bitbucket Cloud, GitHub, and GitHub Enterprise:
 - `filter_condition` - (Optional) The condition to evaluate when deciding if a build should run. More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines)
 - `pull_request_branch_filter_enabled` - (Optional) Whether to limit the creation of builds to specific branches or patterns.
 - `pull_request_branch_filter_configuration` - (Optional) The branch filtering pattern. Only pull requests on branches matching this pattern will cause builds to be created.
+- `skip_builds_for_existing_commits` - (Optional) Whether to skip creating a new build if an existing build for the commit and branch already exists.
 - `skip_pull_request_builds_for_existing_commits` - (Optional) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.
 - `publish_commit_status` - (Optional) Whether to update the status of commits in Bitbucket or GitHub.
 - `publish_commit_status_per_step` - (Optional) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.


### PR DESCRIPTION
When creating a new pipeline in the UI, these settings default to on. We should have the terraform provider do the same thing.

The specific settings are:
![Screenshot 2023-06-09 at 15 04 25](https://github.com/buildkite/terraform-provider-buildkite/assets/6128798/201b2afd-c1dd-425a-b7e1-4942860efc91)

And that maps to the `build_pull_requests`, `skip_pull_request_builds_for_existing_commits`, `build_branches`, `publish_commit_status`.

## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
