### PR TITLE
Enable concurrent testing runs.

### DIFF
--- a/buildkite/util.go
+++ b/buildkite/util.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/shurcooL/graphql"
 )
@@ -53,4 +55,12 @@ func GetTeamID(slug string, client *Client) (string, error) {
 	id := string(query.Team.ID)
 	log.Printf("Found id '%s' for team '%s'.", id, slug)
 	return id, nil
+}
+
+// a function that returns a random string from an array of lorem ipsum words
+func RandomString() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	words := []string{"lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore", "magna", "aliqua"}
+
+	return words[r.Intn(len(words))]
 }


### PR DESCRIPTION
## PR checklist:
- [ ] `docs/` updated
- [x] tests added
- [ ] an example added to `examples/` (useful to demo new field/resource)
- [ ] `CHANGELOG.md` updated with pending release information

This change introduces a helper function (util) which creates a random word and uses that word in testing. This allows more than 1 person to run test branches at any one time.

Where a change is made, a second random word is used.

The random words are assigned in the `var` declerations to ensure they're set once and aren't recreated on each function call.
