### PR TITLE
Support TF version < 0.15.4

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/buildkite/terraform-provider-buildkite/buildkite"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 )
 
 // Set at compile time from ldflags
@@ -26,35 +25,24 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	upgradedSdkServer, err := tf5to6server.UpgradeServer(
-		ctx,
+	providers := []func() tfprotov5.ProviderServer{
+		providerserver.NewProtocol5(buildkite.New(version)),
 		buildkite.Provider(version).GRPCProvider,
-	)
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	providers := []func() tfprotov6.ProviderServer{
-		providerserver.NewProtocol6(buildkite.New(version)),
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkServer
-		},
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var serveOpts []tf6server.ServeOpt
+	var serveOpts []tf5server.ServeOpt
 
 	if debug {
-		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
 	}
 
-	err = tf6server.Serve(
+	err = tf5server.Serve(
 		"registry.terraform.io/buildkite/buildkite",
 		muxServer.ProviderServer,
 		serveOpts...,


### PR DESCRIPTION
## What?
Changed the provider servers to be `v5` rather than `v6`. The former supports older versions of Terraform and doesn't break on `v1.x.x` anyway, so no reason to not use it. Especially if we aren't bumping to a major release.

## Why?
[Issue](https://github.com/buildkite/terraform-provider-buildkite/issues/293) was raised where folks using `v0.14.1` couldn't use the Terraform provider due to a breaking change in updating the provider version; `v6` requires Terraform version `0.15.4` or higher.

If we are't willing to release a major version bump, we need to consider backwards compatibility as a **requirement**.

## How?
Changed the provider versions used to be of `v5` rather than `v6`. According to https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux#mux-server-examples, we need to consider `v5` if we wish to support Terraform versions as old as `0.12.0`.

I downgraded my local TF version to `0.14.11` using `asdf` and then ran the `plan` command, I got the error in the linked Issue. After changing the provider to `v5` I was able to  run both a `plan` and an `apply` without issue, I then upgraded to Terraform version `v1.5.1` locally and was able to re-`init` and run a `plan` and `apply` successfully.