### PR TITLE
Fixed default for allow_rebuilds on provider to match docs

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -79,8 +79,8 @@ func resourcePipeline() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"allow_rebuilds": {
-				Computed: true,
 				Optional: true,
+				Default: true,
 				Type:     schema.TypeBool,
 			},
 			"archive_on_delete": {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -80,7 +80,7 @@ func resourcePipeline() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allow_rebuilds": {
 				Optional: true,
-				Default: true,
+				Default:  true,
 				Type:     schema.TypeBool,
 			},
 			"archive_on_delete": {


### PR DESCRIPTION
Removed computed since this value should be known on creation.

Added default value to true since this is described in the docs to be true by default.

Fixes: https://github.com/buildkite/terraform-provider-buildkite/issues/307