### PR TITLE
Add deprecation warning. Update CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+### Forthcoming Changes
+`deletion_protection` is being deprecated and will be removed in a future release (`v1`). This feature offers similar
+functionality to [lifecycles](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle) which are supported by Terraform.
 
 ## Unreleased
 

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -113,8 +113,10 @@ func resourcePipeline() *schema.Resource {
 				Type:     schema.TypeInt,
 			},
 			"deletion_protection": {
-				Optional:    true,
-				Default:     false,
+				Optional: true,
+				Default:  false,
+				Deprecated: "Deletion protection will be removed in a future release. A similar solution already " +
+					"exists and is supported by Terraform. See https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle.",
 				Type:        schema.TypeBool,
 				Description: "If set to 'true', deletion of a pipeline via `terraform destroy` will fail, until set to 'false'.",
 			},


### PR DESCRIPTION
## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

### Proposed Changes
Mark `deletion_protection` as `Deprecated` in favour of moving towards the use of [lifecycles](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle).

This enables us to continue to support the attribute for now, but gives warning to users that it's been deprecated. The deprecation `message` links to lifecycles.
