### PR TITLE
Added note on write_suites API access token scope to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The provider allows you to manage resources in your Buildkite organization.
 Two configuration values are required:
 
 -   An API token, generated at https://buildkite.com/user/api-access-tokens. The
-    token must have the `write_pipelines, read_pipelines` REST API scopes and be enabled for GraphQL
+    token must have the `write_pipelines`, `read_pipelines` and `write_suites` REST API scopes and be enabled for GraphQL API access.
 -   A Buildkite organization slug, available by signing into buildkite.com and
-    examining the URL: https://buildkite.com/<org-slug>
+    examining the URL: https://buildkite.com/<org-slug>.
 
 ## Documentation
 

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -118,7 +118,7 @@ func (*terraformProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			},
 			SchemaKeyAPIToken: framework_schema.StringAttribute{
 				Optional:    true,
-				Description: "API token with GraphQL access and `write_pipelines, read_pipelines` scopes",
+				Description: "API token with GraphQL access and `write_pipelines, read_pipelines` and `write_suites` REST API scopes",
 				Sensitive:   true,
 			},
 			SchemaKeyGraphqlURL: framework_schema.StringAttribute{
@@ -153,7 +153,7 @@ func Provider(version string) *schema.Provider {
 				Type:        schema.TypeString,
 			},
 			SchemaKeyAPIToken: {
-				Description: "API token with GraphQL access and `write_pipelines, read_pipelines` scopes",
+				Description: "API token with GraphQL access and `write_pipelines, read_pipelines` and `write_suites` REST API scopes",
 				Optional:    true,
 				Type:        schema.TypeString,
 				Sensitive:   true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ This provider can be used to manage resources on [buildkite.com](https://buildki
 Two configuration values are required:
 
 -   An API token, generated at https://buildkite.com/user/api-access-tokens. The
-    token must have the `write_pipelines, read_pipelines` REST API scopes and be enabled for GraphQL
+    token must have the `write_pipelines`, `read_pipelines` and `write_suites` REST API scopes and also be enabled for GraphQL
 -   A Buildkite organization slug, available by signing into buildkite.com and
     examining the URL: https://buildkite.com/<org-slug>
 
@@ -30,6 +30,6 @@ provider "buildkite" {
 ## Argument Reference
 
 -   `api_token` - (Required) This is the Buildkite API Access Token. It must be provided but can also be sourced from the `BUILDKITE_API_TOKEN` environment variable.
--   `organization` - (Required) This is the Buildkite organization slug. It must be provided, but can also be sourced from the `BUILDKITE_ORGANIZATION_SLUG` environment variable. The token requires GraphQL access and the `write_pipelines, read_pipelines` scopes.
+-   `organization` - (Required) This is the Buildkite organization slug. It must be provided, but can also be sourced from the `BUILDKITE_ORGANIZATION_SLUG` environment variable. The token requires GraphQL access and the `write_pipelines`, `read_pipelines` and `write_suites` REST API scopes.
 -   `graphql_url` - (Optional) This is the base URL to use for GraphQL requests. It defaults to "https://graphql.buildkite.com/v1", but can also be sourced from the `BUILDKITE_GRAPHQL_URL` environment variable.
 -   `rest_url` - (Optional) This is the the base URL to use for REST requests. It defaults to "https://api.buildkite.com", but can also be sourced from the `BUILDKITE_REST_URL` environment variable.


### PR DESCRIPTION
With the addition of the Test Suite resource in [v0.22.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.21.2...v0.22.0), one's API access token that is used to interact with the provider needs to additionally have the `write_suites` scope for said API token to create/update and delete suites (interaction with the REST API)