### PR TITLE
Migrate to Protocol v6 - ONLY MERGE WHEN v1 READY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Move archive pipeline config to provider [[PR #354](https://github.com/buildkite/terraform-provider-buildkite/pull/354)] @jradtilbrook
+- Migrate provider to Protocol v6 [[PR #358](https://github.com/buildkite/terraform-provider-buildkite/pull/358) @mcncl
 
 ## [v0.24.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.23.0...v0.24.0)
 

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -142,9 +142,11 @@ func (*terraformProvider) Schema(ctx context.Context, req provider.SchemaRequest
 	}
 }
 
-func New(version string) provider.Provider {
-	return &terraformProvider{
-		version: version,
+func New(version string) func() provider.Provider {
+	return func() provider.Provider {
+		return &terraformProvider{
+			version: version,
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -7,10 +7,6 @@ import (
 
 	"github.com/buildkite/terraform-provider-buildkite/buildkite"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
 // Set at compile time from ldflags
@@ -20,44 +16,20 @@ var (
 
 func main() {
 	ctx := context.Background()
-
 	var debug bool
 
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	upgradedSdkServer, err := tf5to6server.UpgradeServer(
+	opts := providerserver.ServeOpts{
+		Address: "registry.terraform.io/buildkite/buildkite",
+		Debug:   debug,
+	}
+
+	err := providerserver.Serve(
 		ctx,
-		buildkite.Provider(version).GRPCProvider,
-	)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	providers := []func() tfprotov6.ProviderServer{
-		providerserver.NewProtocol6(buildkite.New(version)),
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkServer
-		},
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var serveOpts []tf6server.ServeOpt
-
-	if debug {
-		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
-	}
-
-	err = tf6server.Serve(
-		"registry.terraform.io/buildkite/buildkite",
-		muxServer.ProviderServer,
-		serveOpts...,
+		buildkite.New(version),
+		opts,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## PR checklist:
- [ ] `docs/` updated
- [ ] tests added
- [ ] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

feat: Migrate to protocol v6
BREAKING CHANGE: This will mean that versions of Terraform < 0.15.4 are no longer supported
