### PR TITLE
SUP-1375 Use context everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- SUP-1375 Use context everywhere [[PR #362](https://github.com/buildkite/terraform-provider-buildkite/pull/362)] @jradtilbrook
+
 ## [v0.25.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.24.0...v0.25.0)
 
 - Move archive pipeline config to provider [[PR #354](https://github.com/buildkite/terraform-provider-buildkite/pull/354)] @jradtilbrook

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -86,7 +87,7 @@ func (rt *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return rt.next.RoundTrip(req)
 }
 
-func (client *Client) makeRequest(method string, path string, postData interface{}, responseObject interface{}) error {
+func (client *Client) makeRequest(ctx context.Context, method string, path string, postData interface{}, responseObject interface{}) error {
 	var bodyBytes io.Reader
 	if postData != nil {
 		jsonPayload, err := json.Marshal(postData)
@@ -98,7 +99,7 @@ func (client *Client) makeRequest(method string, path string, postData interface
 
 	url := fmt.Sprintf("%s%s", client.restUrl, path)
 
-	req, err := http.NewRequest(method, url, bodyBytes)
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/buildkite/data_source_cluster.go
+++ b/buildkite/data_source_cluster.go
@@ -40,7 +40,7 @@ func (c *clusterDatasource) Read(ctx context.Context, req datasource.ReadRequest
 	var matchFound bool
 	var cursor *string
 	for {
-		r, err := getClusterByName(c.client.genqlient, c.client.organization, cursor)
+		r, err := getClusterByName(ctx, c.client.genqlient, c.client.organization, cursor)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to read Cluster",

--- a/buildkite/data_source_meta.go
+++ b/buildkite/data_source_meta.go
@@ -39,7 +39,7 @@ func (*metaDatasource) Metadata(ctx context.Context, req datasource.MetadataRequ
 func (m *metaDatasource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state metaDatasourceModel
 	meta := MetaResponse{}
-	err := m.client.makeRequest("GET", "/v2/meta", nil, &meta)
+	err := m.client.makeRequest(ctx, "GET", "/v2/meta", nil, &meta)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read meta", err.Error())
 		return

--- a/buildkite/data_source_organization.go
+++ b/buildkite/data_source_organization.go
@@ -44,7 +44,7 @@ func (o *organizationDatasource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	response, err := getOrganization(o.client.genqlient, o.client.organization)
+	response, err := getOrganization(ctx, o.client.genqlient, o.client.organization)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read organization settings",

--- a/buildkite/data_source_pipeline.go
+++ b/buildkite/data_source_pipeline.go
@@ -86,7 +86,7 @@ func (c *pipelineDatasource) Read(ctx context.Context, req datasource.ReadReques
 	orgPipelineSlug := fmt.Sprintf("%s/%s", c.client.organization, state.Slug.ValueString())
 
 	log.Printf("Obtaining pipeline with slug %s ...", orgPipelineSlug)
-	pipeline, err := getPipeline(c.client.genqlient, orgPipelineSlug)
+	pipeline, err := getPipeline(ctx, c.client.genqlient, orgPipelineSlug)
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/data_source_pipeline_test.go
+++ b/buildkite/data_source_pipeline_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestAccBuildkitePipelineDataSource(t *testing.T) {
 	loadPipeline := func(pipeline *getPipelinePipeline) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
 			slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-			resp, err := getPipeline(genqlientGraphql, slug)
+			resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 			pipeline = &resp.Pipeline
 			return err
 		}

--- a/buildkite/data_source_team.go
+++ b/buildkite/data_source_team.go
@@ -105,7 +105,7 @@ func (t *teamDatasource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if !state.Slug.IsNull() {
-		res, err := GetTeamFromSlug(t.client.genqlient, fmt.Sprintf("%s/%s", t.client.organization, state.Slug.ValueString()))
+		res, err := GetTeamFromSlug(ctx, t.client.genqlient, fmt.Sprintf("%s/%s", t.client.organization, state.Slug.ValueString()))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to get team",
@@ -115,7 +115,7 @@ func (t *teamDatasource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 		updateTeamDatasourceStateFromSlug(&state, *res)
 	} else if !state.ID.IsNull() {
-		res, err := getNode(t.client.genqlient, state.ID.ValueString())
+		res, err := getNode(ctx, t.client.genqlient, state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to get team",

--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -3,6 +3,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -10381,6 +10382,7 @@ fragment TeamFields on Team {
 `
 
 func GetTeamFromSlug(
+	ctx context.Context,
 	client graphql.Client,
 	slug string,
 ) (*GetTeamFromSlugResponse, error) {
@@ -10397,7 +10399,7 @@ func GetTeamFromSlug(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10415,6 +10417,7 @@ mutation archivePipeline ($id: ID!) {
 `
 
 func archivePipeline(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*archivePipelineResponse, error) {
@@ -10431,7 +10434,7 @@ func archivePipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10456,6 +10459,7 @@ mutation createAgentToken ($organizationId: ID!, $description: String) {
 `
 
 func createAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	description *string,
@@ -10474,7 +10478,7 @@ func createAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10503,6 +10507,7 @@ fragment ClusterFields on Cluster {
 `
 
 func createCluster(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	name string,
@@ -10527,7 +10532,7 @@ func createCluster(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10557,6 +10562,7 @@ fragment ClusterAgentTokenValues on ClusterToken {
 `
 
 func createClusterAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	clusterId string,
@@ -10577,7 +10583,7 @@ func createClusterAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10607,6 +10613,7 @@ fragment ClusterQueueValues on ClusterQueue {
 `
 
 func createClusterQueue(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	clusterId string,
@@ -10629,7 +10636,7 @@ func createClusterQueue(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10696,6 +10703,7 @@ fragment PipelineValues on Pipeline {
 `
 
 func createPipeline(
+	ctx context.Context,
 	client graphql.Client,
 	input PipelineCreateInput,
 ) (*createPipelineResponse, error) {
@@ -10712,7 +10720,7 @@ func createPipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10751,6 +10759,7 @@ fragment PipelineScheduleValues on PipelineSchedule {
 `
 
 func createPipelineSchedule(
+	ctx context.Context,
 	client graphql.Client,
 	pipelineId string,
 	label *string,
@@ -10781,7 +10790,7 @@ func createPipelineSchedule(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10814,6 +10823,7 @@ fragment TeamMemberValues on TeamMember {
 `
 
 func createTeamMember(
+	ctx context.Context,
 	client graphql.Client,
 	teamID string,
 	userID string,
@@ -10834,7 +10844,7 @@ func createTeamMember(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10867,6 +10877,7 @@ fragment TeamPipelineFields on TeamPipeline {
 `
 
 func createTeamPipeline(
+	ctx context.Context,
 	client graphql.Client,
 	teamID string,
 	pipelineID string,
@@ -10887,7 +10898,7 @@ func createTeamPipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10931,6 +10942,7 @@ fragment TeamSuiteFields on TeamSuite {
 `
 
 func createTestSuiteTeam(
+	ctx context.Context,
 	client graphql.Client,
 	teamId string,
 	suiteId string,
@@ -10951,7 +10963,7 @@ func createTestSuiteTeam(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -10969,6 +10981,7 @@ mutation deleteCluster ($organizationId: ID!, $id: ID!) {
 `
 
 func deleteCluster(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -10987,7 +11000,7 @@ func deleteCluster(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11005,6 +11018,7 @@ mutation deleteClusterQueue ($organizationId: ID!, $id: ID!) {
 `
 
 func deleteClusterQueue(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -11023,7 +11037,7 @@ func deleteClusterQueue(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11041,6 +11055,7 @@ mutation deletePipeline ($id: ID!) {
 `
 
 func deletePipeline(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*deletePipelineResponse, error) {
@@ -11057,7 +11072,7 @@ func deletePipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11075,6 +11090,7 @@ mutation deletePipelineSchedule ($id: ID!) {
 `
 
 func deletePipelineSchedule(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*deletePipelineScheduleResponse, error) {
@@ -11091,7 +11107,7 @@ func deletePipelineSchedule(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11109,6 +11125,7 @@ mutation deleteTeamMember ($id: ID!) {
 `
 
 func deleteTeamMember(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*deleteTeamMemberResponse, error) {
@@ -11125,7 +11142,7 @@ func deleteTeamMember(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11144,6 +11161,7 @@ mutation deleteTeamPipeline ($id: ID!) {
 `
 
 func deleteTeamPipeline(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*deleteTeamPipelineResponse, error) {
@@ -11160,7 +11178,7 @@ func deleteTeamPipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11181,6 +11199,7 @@ mutation deleteTestSuiteTeam ($id: ID!) {
 `
 
 func deleteTestSuiteTeam(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*deleteTestSuiteTeamResponse, error) {
@@ -11197,7 +11216,7 @@ func deleteTestSuiteTeam(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11217,6 +11236,7 @@ query getAgentToken ($slug: ID!) {
 `
 
 func getAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	slug string,
 ) (*getAgentTokenResponse, error) {
@@ -11233,7 +11253,7 @@ func getAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11261,6 +11281,7 @@ fragment ClusterFields on Cluster {
 `
 
 func getCluster(
+	ctx context.Context,
 	client graphql.Client,
 	orgSlug string,
 	id string,
@@ -11279,7 +11300,7 @@ func getCluster(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11314,6 +11335,7 @@ fragment ClusterAgentTokenValues on ClusterToken {
 `
 
 func getClusterAgentTokens(
+	ctx context.Context,
 	client graphql.Client,
 	orgSlug string,
 	id string,
@@ -11332,7 +11354,7 @@ func getClusterAgentTokens(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11368,6 +11390,7 @@ fragment ClusterFields on Cluster {
 `
 
 func getClusterByName(
+	ctx context.Context,
 	client graphql.Client,
 	orgSlug string,
 	cursor *string,
@@ -11386,7 +11409,7 @@ func getClusterByName(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11422,6 +11445,7 @@ fragment ClusterQueueValues on ClusterQueue {
 `
 
 func getClusterQueues(
+	ctx context.Context,
 	client graphql.Client,
 	orgSlug string,
 	id string,
@@ -11440,7 +11464,7 @@ func getClusterQueues(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11564,6 +11588,7 @@ fragment TeamPipelineFields on TeamPipeline {
 `
 
 func getNode(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*getNodeResponse, error) {
@@ -11580,7 +11605,7 @@ func getNode(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11600,6 +11625,7 @@ query getOrganization ($slug: ID!) {
 `
 
 func getOrganization(
+	ctx context.Context,
 	client graphql.Client,
 	slug string,
 ) (*getOrganizationResponse, error) {
@@ -11616,7 +11642,7 @@ func getOrganization(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11681,6 +11707,7 @@ fragment PipelineValues on Pipeline {
 `
 
 func getPipeline(
+	ctx context.Context,
 	client graphql.Client,
 	slug string,
 ) (*getPipelineResponse, error) {
@@ -11697,7 +11724,7 @@ func getPipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11732,6 +11759,7 @@ fragment PipelineScheduleValues on PipelineSchedule {
 `
 
 func getPipelineSchedule(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*getPipelineScheduleResponse, error) {
@@ -11748,7 +11776,7 @@ func getPipelineSchedule(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11780,6 +11808,7 @@ fragment PipelineScheduleValues on PipelineSchedule {
 `
 
 func getPipelineScheduleBySlug(
+	ctx context.Context,
 	client graphql.Client,
 	slug string,
 ) (*getPipelineScheduleBySlugResponse, error) {
@@ -11796,7 +11825,7 @@ func getPipelineScheduleBySlug(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11832,6 +11861,7 @@ query getTestSuite ($id: ID!, $teamCount: Int) {
 `
 
 func getTestSuite(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	teamCount int,
@@ -11850,7 +11880,7 @@ func getTestSuite(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11872,6 +11902,7 @@ mutation revokeAgentToken ($id: ID!, $reason: String!) {
 `
 
 func revokeAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	reason string,
@@ -11890,7 +11921,7 @@ func revokeAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11908,6 +11939,7 @@ mutation revokeClusterAgentToken ($organizationId: ID!, $id: ID!) {
 `
 
 func revokeClusterAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -11926,7 +11958,7 @@ func revokeClusterAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11948,6 +11980,7 @@ mutation setApiIpAddresses ($organizationID: ID!, $ipAddresses: String!) {
 `
 
 func setApiIpAddresses(
+	ctx context.Context,
 	client graphql.Client,
 	organizationID string,
 	ipAddresses string,
@@ -11966,7 +11999,7 @@ func setApiIpAddresses(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -11999,6 +12032,7 @@ fragment TeamFields on Team {
 `
 
 func teamCreate(
+	ctx context.Context,
 	client graphql.Client,
 	organizationID string,
 	name string,
@@ -12027,7 +12061,7 @@ func teamCreate(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12045,6 +12079,7 @@ mutation teamDelete ($id: ID!) {
 `
 
 func teamDelete(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*teamDeleteResponse, error) {
@@ -12061,7 +12096,7 @@ func teamDelete(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12081,6 +12116,7 @@ mutation teamPipelineCreate ($teamId: ID!, $pipelineId: ID!, $accessLevel: Pipel
 `
 
 func teamPipelineCreate(
+	ctx context.Context,
 	client graphql.Client,
 	teamId string,
 	pipelineId string,
@@ -12101,7 +12137,7 @@ func teamPipelineCreate(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12119,6 +12155,7 @@ mutation teamPipelineDelete ($id: ID!) {
 `
 
 func teamPipelineDelete(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 ) (*teamPipelineDeleteResponse, error) {
@@ -12135,7 +12172,7 @@ func teamPipelineDelete(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12155,6 +12192,7 @@ mutation teamPipelineUpdate ($id: ID!, $accessLevel: PipelineAccessLevels!) {
 `
 
 func teamPipelineUpdate(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	accessLevel PipelineAccessLevels,
@@ -12173,7 +12211,7 @@ func teamPipelineUpdate(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12204,6 +12242,7 @@ fragment TeamFields on Team {
 `
 
 func teamUpdate(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	name string,
@@ -12232,7 +12271,7 @@ func teamUpdate(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12261,6 +12300,7 @@ fragment ClusterFields on Cluster {
 `
 
 func updateCluster(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -12287,7 +12327,7 @@ func updateCluster(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12316,6 +12356,7 @@ fragment ClusterAgentTokenValues on ClusterToken {
 `
 
 func updateClusterAgentToken(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -12336,7 +12377,7 @@ func updateClusterAgentToken(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12366,6 +12407,7 @@ fragment ClusterQueueValues on ClusterQueue {
 `
 
 func updateClusterQueue(
+	ctx context.Context,
 	client graphql.Client,
 	organizationId string,
 	id string,
@@ -12386,7 +12428,7 @@ func updateClusterQueue(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12453,6 +12495,7 @@ fragment PipelineValues on Pipeline {
 `
 
 func updatePipeline(
+	ctx context.Context,
 	client graphql.Client,
 	input PipelineUpdateInput,
 ) (*updatePipelineResponse, error) {
@@ -12469,7 +12512,7 @@ func updatePipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12503,6 +12546,7 @@ fragment PipelineScheduleValues on PipelineSchedule {
 `
 
 func updatePipelineSchedule(
+	ctx context.Context,
 	client graphql.Client,
 	input PipelineScheduleUpdateInput,
 ) (*updatePipelineScheduleResponse, error) {
@@ -12519,7 +12563,7 @@ func updatePipelineSchedule(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12550,6 +12594,7 @@ fragment TeamMemberValues on TeamMember {
 `
 
 func updateTeamMember(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	role string,
@@ -12568,7 +12613,7 @@ func updateTeamMember(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12599,6 +12644,7 @@ fragment TeamPipelineFields on TeamPipeline {
 `
 
 func updateTeamPipeline(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	accessLevel PipelineAccessLevels,
@@ -12617,7 +12663,7 @@ func updateTeamPipeline(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)
@@ -12639,6 +12685,7 @@ mutation updateTestSuiteTeam ($id: ID!, $accessLevel: SuiteAccessLevels!) {
 `
 
 func updateTestSuiteTeam(
+	ctx context.Context,
 	client graphql.Client,
 	id string,
 	accessLevel SuiteAccessLevels,
@@ -12657,7 +12704,7 @@ func updateTestSuiteTeam(
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
-		nil,
+		ctx,
 		req,
 		resp,
 	)

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -47,7 +47,7 @@ func (at *AgentTokenResource) Create(ctx context.Context, req resource.CreateReq
 	var plan, state AgentTokenStateModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
-	apiResponse, err := createAgentToken(
+	apiResponse, err := createAgentToken(ctx,
 		at.client.genqlient,
 		at.client.organizationId,
 		plan.Description.ValueStringPointer(),
@@ -69,7 +69,7 @@ func (at *AgentTokenResource) Delete(ctx context.Context, req resource.DeleteReq
 	var plan AgentTokenStateModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
 
-	_, err := revokeAgentToken(at.client.genqlient, plan.Id.ValueString(), "Revoked by Terraform")
+	_, err := revokeAgentToken(ctx, at.client.genqlient, plan.Id.ValueString(), "Revoked by Terraform")
 
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), err.Error())
@@ -84,7 +84,7 @@ func (at *AgentTokenResource) Read(ctx context.Context, req resource.ReadRequest
 	var plan, state AgentTokenStateModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
 
-	agentToken, err := getAgentToken(at.client.genqlient, fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString()))
+	agentToken, err := getAgentToken(ctx, at.client.genqlient, fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString()))
 
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), err.Error())

--- a/buildkite/resource_cluster.go
+++ b/buildkite/resource_cluster.go
@@ -86,7 +86,7 @@ func (c *clusterResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	r, err := createCluster(
+	r, err := createCluster(ctx,
 		c.client.genqlient,
 		c.client.organizationId,
 		state.Name.ValueString(),
@@ -118,7 +118,7 @@ func (c *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	r, err := getCluster(c.client.genqlient, c.client.organization, state.UUID.ValueString())
+	r, err := getCluster(ctx, c.client.genqlient, c.client.organization, state.UUID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -144,7 +144,7 @@ func (c *clusterResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	id := state.ID.ValueString()
 
-	_, err := updateCluster(
+	_, err := updateCluster(ctx,
 		c.client.genqlient,
 		c.client.organizationId,
 		id,
@@ -174,7 +174,7 @@ func (c *clusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	_, err := deleteCluster(c.client.genqlient, c.client.organizationId, state.ID.ValueString())
+	_, err := deleteCluster(ctx, c.client.genqlient, c.client.organizationId, state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_cluster_agent_token.go
+++ b/buildkite/resource_cluster_agent_token.go
@@ -86,7 +86,7 @@ func (ct *ClusterAgentToken) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	log.Printf("Creating cluster agent token with description %s into cluster %s ...", plan.Description.ValueString(), plan.ClusterId.ValueString())
-	r, err := createClusterAgentToken(
+	r, err := createClusterAgentToken(ctx,
 		ct.client.genqlient,
 		ct.client.organizationId,
 		plan.ClusterId.ValueString(),
@@ -120,7 +120,7 @@ func (ct *ClusterAgentToken) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	log.Printf("Getting cluster agent tokens for cluster %s ...", state.ClusterUuid.ValueString())
-	tokens, err := getClusterAgentTokens(ct.client.genqlient, ct.client.organization, state.ClusterUuid.ValueString())
+	tokens, err := getClusterAgentTokens(ctx, ct.client.genqlient, ct.client.organization, state.ClusterUuid.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -151,7 +151,7 @@ func (ct *ClusterAgentToken) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	log.Printf("Updating cluster token %s", state.Id.ValueString())
-	response, err := updateClusterAgentToken(
+	response, err := updateClusterAgentToken(ctx,
 		ct.client.genqlient,
 		ct.client.organizationId,
 		state.Id.ValueString(),
@@ -180,7 +180,7 @@ func (ct *ClusterAgentToken) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	log.Printf("Revoking Cluster Agent Token %s ...", plan.Id.ValueString())
-	_, err := revokeClusterAgentToken(ct.client.genqlient, ct.client.organizationId, plan.Id.ValueString())
+	_, err := revokeClusterAgentToken(ctx, ct.client.genqlient, ct.client.organizationId, plan.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_cluster_agent_token_test.go
+++ b/buildkite/resource_cluster_agent_token_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -99,6 +100,7 @@ func testAccCheckClusterAgentTokenExists(resourceName string, ct *ClusterAgentTo
 		}
 
 		clusterTokens, err := getClusterAgentTokens(
+			context.Background(),
 			genqlientGraphql,
 			getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			resourceState.Primary.Attributes["cluster_uuid"],
@@ -145,6 +147,7 @@ func testAccCheckClusterAgentTokenDestroy(s *terraform.State) error {
 		}
 
 		clusterTokens, err := getClusterAgentTokens(
+			context.Background(),
 			genqlientGraphql,
 			getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			rs.Primary.Attributes["cluster_uuid"],

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -91,7 +91,7 @@ func (cq *ClusterQueueResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	log.Printf("Creating cluster queue with key %s into cluster %s ...", plan.Key.ValueString(), plan.ClusterId.ValueString())
-	apiResponse, err := createClusterQueue(
+	apiResponse, err := createClusterQueue(ctx,
 		cq.client.genqlient,
 		cq.client.organizationId,
 		plan.ClusterId.ValueString(),
@@ -127,7 +127,7 @@ func (cq *ClusterQueueResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	log.Printf("Getting cluster queues for cluster %s ...", state.ClusterUuid.ValueString())
-	queues, err := getClusterQueues(cq.client.genqlient, cq.client.organization, state.ClusterUuid.ValueString())
+	queues, err := getClusterQueues(ctx, cq.client.genqlient, cq.client.organization, state.ClusterUuid.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -187,7 +187,7 @@ func (cq *ClusterQueueResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	log.Printf("Updating cluster queue %s ...", state.Id.ValueString())
-	apiResponse, err := updateClusterQueue(
+	apiResponse, err := updateClusterQueue(ctx,
 		cq.client.genqlient,
 		cq.client.organizationId,
 		state.Id.ValueString(),
@@ -217,7 +217,7 @@ func (cq *ClusterQueueResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	log.Printf("Deleting cluster queue %s ...", plan.Id.ValueString())
-	_, err := deleteClusterQueue(
+	_, err := deleteClusterQueue(ctx,
 		cq.client.genqlient,
 		cq.client.organizationId,
 		plan.Id.ValueString(),

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,7 +12,7 @@ import (
 
 func testAccClusterQueueConfigBasic(name string) string {
 	config := `
-	
+
 	resource "buildkite_cluster_queue" "foobar" {
 		cluster_id = "Q2x1c3Rlci0tLTFkNmIxOTg5LTJmYjctNDRlMC04MWYyLTAxYjIxNzQ4MTVkMg=="
 		description = "Acceptance Test %s"
@@ -134,6 +135,7 @@ func testAccCheckClusterQueueExists(resourceName string, clusterQueueResourceMod
 
 		// Obtain queues of the queue's cluster from its cluster UUID
 		queues, err := getClusterQueues(
+			context.Background(),
 			genqlientGraphql,
 			getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			resourceState.Primary.Attributes["cluster_uuid"],
@@ -195,6 +197,7 @@ func testAccCheckClusterQueueDestroy(s *terraform.State) error {
 
 		// Obtain queues of the queue's cluster from its cluster UUID
 		queues, err := getClusterQueues(
+			context.Background(),
 			genqlientGraphql,
 			getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			rs.Primary.Attributes["cluster_uuid"],

--- a/buildkite/resource_cluster_test.go
+++ b/buildkite/resource_cluster_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -122,7 +123,7 @@ func testAccCheckClusterExists(n string, c *clusterResourceModel) resource.TestC
 			return fmt.Errorf("no cluster ID is set")
 		}
 
-		r, err := getCluster(genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"), rs.Primary.Attributes["uuid"])
+		r, err := getCluster(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"), rs.Primary.Attributes["uuid"])
 
 		if err != nil {
 			return err
@@ -149,7 +150,7 @@ func testAccCheckClusterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := getCluster(genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"), rs.Primary.Attributes["uuid"])
+		_, err := getCluster(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"), rs.Primary.Attributes["uuid"])
 
 		if err == nil {
 			return fmt.Errorf("Cluster still exists")

--- a/buildkite/resource_organization.go
+++ b/buildkite/resource_organization.go
@@ -77,6 +77,7 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 
 	log.Printf("Creating settings for organization %s ...", o.client.organizationId)
 	apiResponse, err := setApiIpAddresses(
+		ctx,
 		o.client.genqlient,
 		o.client.organizationId,
 		strings.Join(cidrs, " "),
@@ -113,7 +114,7 @@ func (o *organizationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	log.Printf("Reading settings for organization ...")
-	response, err := getOrganization(o.client.genqlient, o.client.organization)
+	response, err := getOrganization(ctx, o.client.genqlient, o.client.organization)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -154,6 +155,7 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 
 	log.Printf("Updating settings for organization %s ...", o.client.organizationId)
 	apiResponse, err := setApiIpAddresses(
+		ctx,
 		o.client.genqlient,
 		o.client.organizationId,
 		strings.Join(cidrs, " "),
@@ -182,7 +184,7 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	log.Printf("Deleting settings for organization %s ...", o.client.organizationId)
 
-	_, err := setApiIpAddresses(o.client.genqlient, o.client.organizationId, "")
+	_, err := setApiIpAddresses(ctx, o.client.genqlient, o.client.organizationId, "")
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_organization_settings.go
+++ b/buildkite/resource_organization_settings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var deprecationMessage = `This resource has been deprecated in favour of the newer buildkite_organization resource. 
+var deprecationMessage = `This resource has been deprecated in favour of the newer buildkite_organization resource.
 Please visit the provider's documentation at https://registry.terraform.io/providers/buildkite/buildkite/latest/docs for more details.`
 
 func resourceOrganizationSettings() *schema.Resource {
@@ -43,7 +43,7 @@ func CreateUpdateDeleteOrganizationSettings(ctx context.Context, d *schema.Resou
 	var diags diag.Diagnostics
 	client := m.(*Client)
 
-	response, err := getOrganization(client.genqlient, client.organization)
+	response, err := getOrganization(ctx, client.genqlient, client.organization)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -59,7 +59,7 @@ func CreateUpdateDeleteOrganizationSettings(ctx context.Context, d *schema.Resou
 		cidrs[i] = v.(string)
 	}
 
-	apiResponse, err := setApiIpAddresses(client.genqlient, response.Organization.Id, strings.Join(cidrs, " "))
+	apiResponse, err := setApiIpAddresses(ctx, client.genqlient, response.Organization.Id, strings.Join(cidrs, " "))
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -77,7 +77,7 @@ func DeleteOrganizationSettings(ctx context.Context, d *schema.ResourceData, m i
 	var diags diag.Diagnostics
 	client := m.(*Client)
 
-	response, err := getOrganization(client.genqlient, client.organization)
+	response, err := getOrganization(ctx, client.genqlient, client.organization)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -87,7 +87,7 @@ func DeleteOrganizationSettings(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(fmt.Errorf("organization not found: '%s'", client.organization))
 	}
 
-	_, err = setApiIpAddresses(client.genqlient, response.Organization.Id, "")
+	_, err = setApiIpAddresses(ctx, client.genqlient, response.Organization.Id, "")
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -102,7 +102,7 @@ func ReadOrganizationSettings(ctx context.Context, d *schema.ResourceData, m int
 
 	client := m.(*Client)
 
-	response, err := getOrganization(client.genqlient, client.organization)
+	response, err := getOrganization(ctx, client.genqlient, client.organization)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/buildkite/resource_organization_settings_test.go
+++ b/buildkite/resource_organization_settings_test.go
@@ -123,7 +123,7 @@ func testCheckOrganizationSettingsResourceRemoved(s *terraform.State) error {
 
 func testAccCheckOrganizationSettingsRemoteValues(ip_addresses []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resp, err := getOrganization(genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"))
+		resp, err := getOrganization(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"))
 
 		if err != nil {
 			return err

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -88,7 +88,7 @@ func TestAccOrganization_import(t *testing.T) {
 
 func testAccOrganizationConfigBasic(ip_addresses []string) string {
 	config := `
-	
+
 	resource "buildkite_organization" "let_them_in" {
         allowed_api_ip_addresses = %v
 	}
@@ -124,7 +124,7 @@ func testCheckOrganizationResourceRemoved(s *terraform.State) error {
 
 func testAccCheckOrganizationRemoteValues(ip_addresses []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resp, err := getOrganization(genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"))
+		resp, err := getOrganization(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"))
 
 		if err != nil {
 			return err

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -118,7 +118,7 @@ func (ps *pipelineSchedule) Create(ctx context.Context, req resource.CreateReque
 	log.Printf("Creating Pipeline schedule %s ...", plan.Label.ValueString())
 
 	envVars := envVarsMapFromTfToString(ctx, plan.Env)
-	apiResponse, err := createPipelineSchedule(
+	apiResponse, err := createPipelineSchedule(ctx,
 		ps.client.genqlient,
 		plan.PipelineId.ValueString(),
 		plan.Label.ValueStringPointer(),
@@ -162,7 +162,7 @@ func (ps *pipelineSchedule) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	log.Printf("Reading Pipeline schedule %s ...", state.Label.ValueString())
-	apiResponse, err := getPipelineSchedule(
+	apiResponse, err := getPipelineSchedule(ctx,
 		ps.client.genqlient,
 		state.Id.ValueString(),
 	)
@@ -211,7 +211,7 @@ func (ps *pipelineSchedule) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	log.Printf("Updating Pipeline schedule %s ...", plan.Label.ValueString())
-	_, err := updatePipelineSchedule(
+	_, err := updatePipelineSchedule(ctx,
 		ps.client.genqlient,
 		input,
 	)
@@ -237,7 +237,7 @@ func (ps *pipelineSchedule) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	log.Println("Deleting Pipeline schedule ...")
-	_, err := deletePipelineSchedule(ps.client.genqlient, plan.Id.ValueString())
+	_, err := deletePipelineSchedule(ctx, ps.client.genqlient, plan.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Pipeline schedule",

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 	loadPipeline := func(name string, pipeline *getPipelinePipeline) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
 			slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), name)
-			resp, err := getPipeline(genqlientGraphql, slug)
+			resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 			*pipeline = resp.Pipeline
 			return err
 		}
@@ -37,7 +38,7 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 	loadPipelineSchedule := func(schedule *PipelineScheduleValues) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
 			scheduleRes := s.RootModule().Resources["buildkite_pipeline_schedule.pipeline"]
-			resp, err := getPipelineSchedule(genqlientGraphql, scheduleRes.Primary.ID)
+			resp, err := getPipelineSchedule(context.Background(), genqlientGraphql, scheduleRes.Primary.ID)
 			if err != nil {
 				return err
 			}
@@ -60,7 +61,7 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),
 			CheckDestroy: func(s *terraform.State) error {
-				resp, err := getPipeline(genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
+				resp, err := getPipeline(context.Background(), genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
 				if resp.Pipeline.Name == pipelineName {
 					return fmt.Errorf("Pipeline still exists: %s", pipelineName)
 				}

--- a/buildkite/resource_pipeline_team.go
+++ b/buildkite/resource_pipeline_team.go
@@ -88,7 +88,7 @@ func (tp *pipelineTeamResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	apiResponse, err := createTeamPipeline(
+	apiResponse, err := createTeamPipeline(ctx,
 		tp.client.genqlient,
 		state.TeamId.ValueString(),
 		state.PipelineId.ValueString(),
@@ -120,7 +120,7 @@ func (tp *pipelineTeamResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	apiResponse, err := getNode(
+	apiResponse, err := getNode(ctx,
 		tp.client.genqlient,
 		state.Id.ValueString(),
 	)
@@ -166,7 +166,7 @@ func (tp *pipelineTeamResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	_, err := updateTeamPipeline(tp.client.genqlient,
+	_, err := updateTeamPipeline(ctx, tp.client.genqlient,
 		state.Id.ValueString(),
 		PipelineAccessLevels(accessLevel),
 	)
@@ -193,7 +193,7 @@ func (tp *pipelineTeamResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	_, err := deleteTeamPipeline(tp.client.genqlient, state.Id.ValueString())
+	_, err := deleteTeamPipeline(ctx, tp.client.genqlient, state.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_pipeline_team_test.go
+++ b/buildkite/resource_pipeline_team_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -139,7 +140,7 @@ func testAccCheckPipelineTeamExists(resourceName string, tp *pipelineTeamResourc
 			return fmt.Errorf("No ID is set in state")
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, resourceState.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, resourceState.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching team pipeline from graphql API: %v", err)
@@ -164,7 +165,7 @@ func testCheckPipelineTeamResourceRemoved(s *terraform.State) error {
 			continue
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, rs.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching team pipeline from graphql API: %v", err)

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -63,7 +64,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 						// check api values are expected
 						func(s *terraform.State) error {
 							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-							resp, err := getPipeline(genqlientGraphql, slug)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = resp.Pipeline
 							return err
 						},
@@ -125,7 +126,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 						// check api values are expected
 						func(s *terraform.State) error {
 							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-							resp, err := getPipeline(genqlientGraphql, slug)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = &resp.Pipeline
 							return err
 						},
@@ -273,7 +274,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 					// check api values are expected
 					Check: func(s *terraform.State) error {
 						slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-						resp, err := getPipeline(genqlientGraphql, slug)
+						resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 						pipeline = resp.Pipeline
 						return err
 					},
@@ -367,7 +368,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 					Check: func(s *terraform.State) error {
 						// remove the pipeline
 						pipeline := s.RootModule().Resources["buildkite_pipeline.pipeline"]
-						_, err := deletePipeline(genqlientGraphql, pipeline.Primary.ID)
+						_, err := deletePipeline(context.Background(), genqlientGraphql, pipeline.Primary.ID)
 						return err
 					},
 					ExpectNonEmptyPlan: true,
@@ -389,7 +390,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),
 			CheckDestroy: func(s *terraform.State) error {
-				resp, err := getPipeline(genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
+				resp, err := getPipeline(context.Background(), genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
 				if resp.Pipeline.Name == pipelineName {
 					return fmt.Errorf("Pipeline still exists: %s", pipelineName)
 				}
@@ -416,7 +417,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),
 			CheckDestroy: func(s *terraform.State) error {
-				resp, err := getPipeline(genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
+				resp, err := getPipeline(context.Background(), genqlientGraphql, fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName))
 				if err != nil {
 					return err
 				}
@@ -462,18 +463,18 @@ func TestAccBuildkitePipeline(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						func(s *terraform.State) error {
 							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-							resp, err := getPipeline(genqlientGraphql, slug)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = resp.Pipeline
 							return err
 						},
 						func(s *terraform.State) error {
 							// add new team to pipeline
-							team, err := teamCreate(genqlientGraphql, organizationID, acctest.RandString(6), nil, "VISIBLE", false, "MEMBER", false)
+							team, err := teamCreate(context.Background(), genqlientGraphql, organizationID, acctest.RandString(6), nil, "VISIBLE", false, "MEMBER", false)
 							teamID = team.TeamCreate.TeamEdge.Node.Id
 							if err != nil {
 								return err
 							}
-							_, err = teamPipelineCreate(genqlientGraphql, teamID, string(pipeline.Id), PipelineAccessLevelsBuildAndRead)
+							_, err = teamPipelineCreate(context.Background(), genqlientGraphql, teamID, string(pipeline.Id), PipelineAccessLevelsBuildAndRead)
 							if err != nil {
 								return err
 							}
@@ -519,13 +520,13 @@ func TestAccBuildkitePipeline(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						func(s *terraform.State) error {
 							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-							resp, err := getPipeline(genqlientGraphql, slug)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = resp.Pipeline
 							return err
 						},
 						func(s *terraform.State) error {
 							// change team access level
-							_, err := teamPipelineUpdate(genqlientGraphql, pipeline.Teams.Edges[0].Node.Id, PipelineAccessLevelsBuildAndRead)
+							_, err := teamPipelineUpdate(context.Background(), genqlientGraphql, pipeline.Teams.Edges[0].Node.Id, PipelineAccessLevelsBuildAndRead)
 							if err != nil {
 								return err
 							}
@@ -572,13 +573,13 @@ func TestAccBuildkitePipeline(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						func(s *terraform.State) error {
 							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
-							resp, err := getPipeline(genqlientGraphql, slug)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = resp.Pipeline
 							return err
 						},
 						func(s *terraform.State) error {
 							// change team access level
-							_, err := teamPipelineDelete(genqlientGraphql, pipeline.Teams.Edges[0].Node.Id)
+							_, err := teamPipelineDelete(context.Background(), genqlientGraphql, pipeline.Teams.Edges[0].Node.Id)
 							if err != nil {
 								return err
 							}

--- a/buildkite/resource_team.go
+++ b/buildkite/resource_team.go
@@ -134,7 +134,7 @@ func (t *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	r, err := teamCreate(
+	r, err := teamCreate(ctx,
 		t.client.genqlient,
 		t.client.organizationId,
 		state.Name.ValueString(),
@@ -163,7 +163,7 @@ func (t *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	var state teamResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	res, err := getNode(t.client.genqlient, state.ID.ValueString())
+	res, err := getNode(ctx, t.client.genqlient, state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -195,7 +195,7 @@ func (t *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	_, err := teamUpdate(
+	_, err := teamUpdate(ctx,
 		t.client.genqlient,
 		state.ID.ValueString(),
 		plan.Name.ValueString(),
@@ -226,7 +226,7 @@ func (t *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	_, err := teamDelete(t.client.genqlient, state.ID.ValueString())
+	_, err := teamDelete(ctx, t.client.genqlient, state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -88,7 +88,7 @@ func (tm *teamMemberResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	log.Printf("Creating team member into team %s ...", state.TeamId.ValueString())
-	apiResponse, err := createTeamMember(
+	apiResponse, err := createTeamMember(ctx,
 		tm.client.genqlient,
 		state.TeamId.ValueString(),
 		state.UserId.ValueString(),
@@ -122,7 +122,7 @@ func (tm *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	log.Printf("Reading team member %s ...", state.Id.ValueString())
-	apiResponse, err := getNode(tm.client.genqlient, state.Id.ValueString())
+	apiResponse, err := getNode(ctx, tm.client.genqlient, state.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -162,7 +162,7 @@ func (tm *teamMemberResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	log.Printf("Updating team member %s with role %s ...", id, role)
-	apiResponse, err := updateTeamMember(tm.client.genqlient, id, role)
+	apiResponse, err := updateTeamMember(ctx, tm.client.genqlient, id, role)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -187,7 +187,7 @@ func (tm *teamMemberResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	log.Printf("Deleting team member with ID %s ...", state.Id.ValueString())
-	_, err := deleteTeamMember(tm.client.genqlient, state.Id.ValueString())
+	_, err := deleteTeamMember(ctx, tm.client.genqlient, state.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -144,7 +145,7 @@ func testAccCheckTeamMemberExists(resourceName string, tm *teamMemberResourceMod
 			return fmt.Errorf("No ID is set in state")
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, resourceState.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, resourceState.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching team member from graphql API: %v", err)
@@ -168,7 +169,7 @@ func testCheckTeamMemberResourceRemoved(s *terraform.State) error {
 			continue
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, rs.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching team member from graphql API: %v", err)

--- a/buildkite/resource_team_test.go
+++ b/buildkite/resource_team_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -145,7 +146,7 @@ func testAccCheckTeamExists(name string, tr *teamResourceModel) resource.TestChe
 			return fmt.Errorf("No ID is set in state")
 		}
 
-		r, err := getNode(genqlientGraphql, rs.Primary.ID)
+		r, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -177,7 +178,7 @@ func testAccCheckTeamResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		r, err := getNode(genqlientGraphql, rs.Primary.ID)
+		r, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/buildkite/resource_test_suite_team.go
+++ b/buildkite/resource_test_suite_team.go
@@ -89,7 +89,7 @@ func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	log.Printf("Adding team %s to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
-	apiResponse, err := createTestSuiteTeam(
+	apiResponse, err := createTestSuiteTeam(ctx,
 		tst.client.genqlient,
 		state.TeamID.ValueString(),
 		state.TestSuiteId.ValueString(),
@@ -121,7 +121,7 @@ func (tst *testSuiteTeamResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	log.Printf("Reading test suite team with ID %s ...", state.ID.ValueString())
-	apiResponse, err := getNode(tst.client.genqlient, state.ID.ValueString())
+	apiResponse, err := getNode(ctx, tst.client.genqlient, state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -162,7 +162,7 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	log.Printf("Updating team %s in test suite %s to %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString(), testSuiteTeamAccessLevel)
-	apiResponse, err := updateTestSuiteTeam(
+	apiResponse, err := updateTestSuiteTeam(ctx,
 		tst.client.genqlient,
 		state.ID.ValueString(),
 		SuiteAccessLevels(testSuiteTeamAccessLevel),
@@ -192,7 +192,7 @@ func (tst *testSuiteTeamResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	log.Printf("Deleting team %s's access to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
-	_, err := deleteTestSuiteTeam(tst.client.genqlient, state.ID.ValueString())
+	_, err := deleteTestSuiteTeam(ctx, tst.client.genqlient, state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -172,7 +173,7 @@ func TestAccTestSuiteTeam_disappears(t *testing.T) {
 
 func testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, accessLevel string) string {
 	config := `
-	
+
 	resource "buildkite_team" "ownerteam" {
 		name = "Test Suite Team %s"
 		default_team = false
@@ -215,7 +216,7 @@ func testAccCheckTestSuiteTeamExists(resourceName string, tst *testSuiteTeamMode
 			return fmt.Errorf("No ID is set in state")
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, resourceState.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, resourceState.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching test suite team from graphql API: %v", err)
@@ -238,7 +239,7 @@ func testAccCheckTestSuiteTeamDestroy(s *terraform.State) error {
 			continue
 		}
 
-		apiResponse, err := getNode(genqlientGraphql, rs.Primary.ID)
+		apiResponse, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching test suite team from graphql API: %v", err)
@@ -283,7 +284,7 @@ func testAccCheckTestSuiteTeamDisappears(resourceName string) resource.TestCheck
 			return fmt.Errorf("Resource ID missing: %s", resourceName)
 		}
 
-		_, err := deleteTestSuiteTeam(genqlientGraphql, resourceState.Primary.ID)
+		_, err := deleteTestSuiteTeam(context.Background(), genqlientGraphql, resourceState.Primary.ID)
 
 		return err
 	}

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -205,7 +206,7 @@ func checkTestSuiteRemoteValue(suite *getTestSuiteSuite, property, value string)
 }
 
 func loadRemoteTestSuite(id string) *getTestSuiteSuite {
-	_suite, err := getTestSuite(genqlientGraphql, id, 1)
+	_suite, err := getTestSuite(context.Background(), genqlientGraphql, id, 1)
 	if err != nil {
 		return nil
 	}
@@ -246,7 +247,7 @@ func testTestSuiteDestroy(s *terraform.State) error {
 			continue
 		}
 
-		suite, err := getTestSuite(genqlientGraphql, rs.Primary.Attributes["id"], 1)
+		suite, err := getTestSuite(context.Background(), genqlientGraphql, rs.Primary.Attributes["id"], 1)
 
 		if err != nil {
 			return fmt.Errorf("Error fetching test suite from graphql API: %v", err)

--- a/genqlient.yaml
+++ b/genqlient.yaml
@@ -5,9 +5,6 @@ operations:
 
 generated: buildkite/generated.go
 
-# We pass context.Background() everywhere so just leave it off
-context_type: "-"
-
 bindings:
   YAML:
     type: string


### PR DESCRIPTION
## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

This is a precursor to adding timeouts everywhere so we can configure a context with a timeout as well
