### PR TITLE
SUP-1392: Random test suite names in tests/t.Run() conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- SUP-1392: Random test suite names in tests/t.Run() conversion [[PR #376](https://github.com/buildkite/terraform-provider-buildkite/pull/376)] @james2791
+
 ## [v0.26.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.25.0...v0.26.0)
 
 - SUP-1375 Use context everywhere [[PR #362](https://github.com/buildkite/terraform-provider-buildkite/pull/362)] @jradtilbrook

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -7,191 +7,167 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAcc_testSuiteAddRemove(t *testing.T) {
-	t.Parallel()
-	var suite getTestSuiteSuite
+func TestAccBuildkiteTestSuite(t *testing.T) {
+	basicTestSuite := func(name string) string {
+		return fmt.Sprintf(`
+		resource "buildkite_team" "team" {
+			name = "test suite team"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+		resource "buildkite_test_suite" "suite" {
+			name = "test suite %s"
+			default_branch = "main"
+			team_owner_id = resource.buildkite_team.team.id
+		}
+		`, name)
+	}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testTestSuiteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: `
-				resource "buildkite_team" "team" {
-					name = "test suite team"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_test_suite" "suite" {
-					name = "test suite"
-					default_branch = "main"
-					team_owner_id = resource.buildkite_team.team.id
-				}
-				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-					checkTestSuiteRemoteValue(&suite, "Name", "test suite"),
-					checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
-				),
+	testSuiteWithTwoTeams := func(name string) string {
+		return fmt.Sprintf(`
+		resource "buildkite_team" "ateam" {
+			name = "a team"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+		resource "buildkite_team" "bteam" {
+			name = "b team"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+		resource "buildkite_test_suite" "suite" {
+			name = "test suite update %s"
+			default_branch = "main"
+			team_owner_id = resource.buildkite_team.bteam.id
+		}
+		`, name)
+	}
+
+	testSuiteTeamAddition := func(name string) string {
+		return fmt.Sprintf(`
+		resource "buildkite_team" "ateam" {
+			name = "a team"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+		resource "buildkite_team" "bteam" {
+			name = "b team"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+		resource "buildkite_test_suite" "suite" {
+			name = "test suite update %s"
+			default_branch = "main"
+			team_owner_id = resource.buildkite_team.bteam.id
+		}
+		resource "buildkite_test_suite_team" "team-a" {
+			test_suite_id = buildkite_test_suite.suite.id
+			team_id = buildkite_team.ateam.id
+			access_level = "MANAGE_AND_READ"
+		}
+		`, name)
+	}
+
+	t.Run("Creates a Test Suite", func(t *testing.T) {
+		var suite getTestSuiteSuite
+		randName := acctest.RandString(10)
+		check := resource.ComposeAggregateTestCheckFunc(
+			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
+			checkTestSuiteRemoteValue(&suite, "Name", "test suite"),
+			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testTestSuiteDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: basicTestSuite(randName),
+					Check:  check,
+				},
 			},
-		},
+		})
 	})
-}
 
-func TestAcc_testSuiteUpdate(t *testing.T) {
-	t.Parallel()
-	var suite getTestSuiteSuite
+	t.Run("Updates a Test Suite", func(t *testing.T) {
+		var suite getTestSuiteSuite
+		randName := acctest.RandString(10)
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
+			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
+			checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
+			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
+		)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testTestSuiteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: `
-				resource "buildkite_team" "team" {
-					name = "test suite team update"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_test_suite" "suite" {
-					name = "test suite update"
-					default_branch = "main"
-					team_owner_id = resource.buildkite_team.team.id
-				}
-				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
-					checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-					checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
-					checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
-				),
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testTestSuiteDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: basicTestSuite(randName),
+					Check:  check,
+				},
+				{
+					Config: basicTestSuite(randName),
+					Taint:  []string{"buildkite_team.team"},
+					Check:  check,
+				},
 			},
-			{
-				Config: `
-				resource "buildkite_team" "team" {
-					name = "test suite team update"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_test_suite" "suite" {
-					name = "test suite update"
-					default_branch = "main"
-					team_owner_id = resource.buildkite_team.team.id
-				}
-				`,
-				Taint: []string{"buildkite_team.team"},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
-					checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-					checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
-					checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
-				),
-			},
-		},
+		})
 	})
-}
 
-func TestAcc_testSuiteTeamOwnerResolution(t *testing.T) {
-	t.Parallel()
-	var suite getTestSuiteSuite
+	t.Run("Creates and handles Test Suite Team owner resolution", func(t *testing.T) {
+		var suite getTestSuiteSuite
+		randName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testTestSuiteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: `
-				resource "buildkite_team" "ateam" {
-					name = "a team"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_team" "bteam" {
-					name = "b team"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_test_suite" "suite" {
-					name = "test suite update"
-					default_branch = "main"
-					team_owner_id = resource.buildkite_team.bteam.id
-				}
-				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
-					resource.TestCheckResourceAttrPair("buildkite_test_suite.suite", "team_owner_id", "buildkite_team.bteam", "id"),
-					checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-					checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
-					checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
-				),
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
+			resource.TestCheckResourceAttrPair("buildkite_test_suite.suite", "team_owner_id", "buildkite_team.bteam", "id"),
+			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
+			checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
+			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testTestSuiteDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testSuiteWithTwoTeams(randName),
+					Check:  check,
+				},
+				{
+					Config: testSuiteTeamAddition(randName),
+					Check:  check,
+				},
 			},
-			{
-				Config: `
-				resource "buildkite_team" "ateam" {
-					name = "a team"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_team" "bteam" {
-					name = "b team"
-					default_team = false
-					privacy = "VISIBLE"
-					default_member_role = "MAINTAINER"
-				}
-				resource "buildkite_test_suite" "suite" {
-					name = "test suite update"
-					default_branch = "main"
-					team_owner_id = resource.buildkite_team.bteam.id
-				}
-				resource "buildkite_test_suite_team" "team-a" {
-					test_suite_id = buildkite_test_suite.suite.id
-					team_id = buildkite_team.ateam.id
-					access_level = "MANAGE_AND_READ"
-				}
-				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-					resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
-					resource.TestCheckResourceAttrPair("buildkite_test_suite.suite", "team_owner_id", "buildkite_team.bteam", "id"),
-					checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-					checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
-					checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
-				),
-			},
-		},
+		})
 	})
 }
 

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -112,10 +112,10 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
 			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite update %s", randName)),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite %s", randName)),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite update %s", randName)),
+			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite %s", randName)),
 			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
 		)
 

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -83,7 +83,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 		randName := acctest.RandString(10)
 		check := resource.ComposeAggregateTestCheckFunc(
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-			checkTestSuiteRemoteValue(&suite, "Name", "test suite"),
+			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite %s", randName)),
 			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
@@ -115,7 +115,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite update %s", randName)),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-			checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
+			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite update %s", randName)),
 			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
 		)
 
@@ -149,7 +149,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 			resource.TestCheckResourceAttrPair("buildkite_test_suite.suite", "team_owner_id", "buildkite_team.bteam", "id"),
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
-			checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
+			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite update %s", randName)),
 			checkTestSuiteRemoteValue(&suite, "DefaultBranch", "main"),
 		)
 

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -88,7 +88,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
 			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite %s", randName)),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 		)
 
@@ -112,7 +112,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
 			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite update %s", randName)),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
 			checkTestSuiteRemoteValue(&suite, "Name", "test suite update"),
@@ -145,7 +145,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
 			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "default_branch", "main"),
-			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", "test suite update"),
+			resource.TestCheckResourceAttr("buildkite_test_suite.suite", "name", fmt.Sprintf("test suite update %s", randName)),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "team_owner_id"),
 			resource.TestCheckResourceAttrPair("buildkite_test_suite.suite", "team_owner_id", "buildkite_team.bteam", "id"),
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),


### PR DESCRIPTION
fix (Test suite tests): [Randomising test suite names]

## PR checklist:
- [x] `docs/` updated -> provider tests, not needed as functionality is unchanged
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource) -> provider tests, not needed as functionality is unchanged
- [x] `CHANGELOG.md` updated with pending release information
