### PR TITLE
SUP-1402: Agent token resource retries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - SUP-1392: Random test suite names in tests/t.Run() conversion [[PR #376](https://github.com/buildkite/terraform-provider-buildkite/pull/376)] @james2791
 - SUP-1374 Add timeout to provider and cluster datasource [[PR #363](https://github.com/buildkite/terraform-provider-buildkite/pull/363)] @jradtilbrook
-    - SUP-1374 Remove timeout context [[PR #378](https://github.com/buildkite/terraform-provider-buildkite/pull/378)] @jradtilbrook
+- SUP-1374 Remove timeout context [[PR #378](https://github.com/buildkite/terraform-provider-buildkite/pull/378)] @jradtilbrook
+- SUP-1402: Agent token resource retries [[PR #382](https://github.com/buildkite/terraform-provider-buildkite/pull/382)] @james2791
 
 ### Changes
 

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -110,9 +110,9 @@ func (at *AgentTokenResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
-		_, err := revokeAgentToken(ctx, 
-			at.client.genqlient, 
-			state.Id.ValueString(), 
+		_, err := revokeAgentToken(ctx,
+			at.client.genqlient,
+			state.Id.ValueString(),
 			"Revoked by Terraform",
 		)
 
@@ -154,9 +154,9 @@ func (at *AgentTokenResource) Read(ctx context.Context, req resource.ReadRequest
 	var r *getAgentTokenResponse
 	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
-		r, err = getAgentToken(ctx, 
-			at.client.genqlient, 
-			fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString())
+		r, err = getAgentToken(ctx,
+			at.client.genqlient,
+			fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString()),
 		)
 
 		if err != nil {

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -47,7 +47,7 @@ func (at *AgentTokenResource) Configure(ctx context.Context, req resource.Config
 func (at *AgentTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan, state AgentTokenStateModel
 
-	diags := req.Plan.Get(ctx, &state)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/shurcooL/graphql"
 )
 
@@ -45,35 +46,88 @@ func (at *AgentTokenResource) Configure(ctx context.Context, req resource.Config
 
 func (at *AgentTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan, state AgentTokenStateModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
-	apiResponse, err := createAgentToken(ctx,
-		at.client.genqlient,
-		at.client.organizationId,
-		plan.Description.ValueStringPointer(),
-	)
+	diags := req.Plan.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 
-	if err != nil {
-		resp.Diagnostics.AddError(err.Error(), err.Error())
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	state.Description = types.StringPointerValue(apiResponse.AgentTokenCreate.AgentTokenEdge.Node.Description)
-	state.Id = types.StringValue(apiResponse.AgentTokenCreate.AgentTokenEdge.Node.Id)
-	state.Token = types.StringValue(apiResponse.AgentTokenCreate.TokenValue)
-	state.Uuid = types.StringValue(apiResponse.AgentTokenCreate.AgentTokenEdge.Node.Uuid)
+	timeout, diags := at.client.timeouts.Create(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var r *createAgentTokenResponse
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		var err error
+		r, err = createAgentToken(ctx,
+			at.client.genqlient,
+			at.client.organizationId,
+			plan.Description.ValueStringPointer(),
+		)
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to create agent token",
+				fmt.Sprintf("Unable to create agent token: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	state.Description = types.StringPointerValue(r.AgentTokenCreate.AgentTokenEdge.Node.Description)
+	state.Id = types.StringValue(r.AgentTokenCreate.AgentTokenEdge.Node.Id)
+	state.Token = types.StringValue(r.AgentTokenCreate.TokenValue)
+	state.Uuid = types.StringValue(r.AgentTokenCreate.AgentTokenEdge.Node.Uuid)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (at *AgentTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var plan AgentTokenStateModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
+	var state AgentTokenStateModel
 
-	_, err := revokeAgentToken(ctx, at.client.genqlient, plan.Id.ValueString(), "Revoked by Terraform")
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 
-	if err != nil {
-		resp.Diagnostics.AddError(err.Error(), err.Error())
+	if resp.Diagnostics.HasError() {
+		return
 	}
+
+	timeout, diags := at.client.timeouts.Delete(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		_, err := revokeAgentToken(ctx, 
+			at.client.genqlient, 
+			state.Id.ValueString(), 
+			"Revoked by Terraform",
+		)
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to revoke agent token",
+				fmt.Sprintf("Unable to revoke agent token: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 }
 
 func (AgentTokenResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -82,23 +136,53 @@ func (AgentTokenResource) Metadata(ctx context.Context, req resource.MetadataReq
 
 func (at *AgentTokenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var plan, state AgentTokenStateModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
 
-	agentToken, err := getAgentToken(ctx, at.client.genqlient, fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString()))
+	diags := req.State.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
 
-	if err != nil {
-		resp.Diagnostics.AddError(err.Error(), err.Error())
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	if agentToken == nil {
+
+	timeout, diags := at.client.timeouts.Read(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var r *getAgentTokenResponse
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		var err error
+		r, err = getAgentToken(ctx, 
+			at.client.genqlient, 
+			fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString())
+		)
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to read agent token",
+				fmt.Sprintf("Unable to read agent token: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if r == nil {
 		resp.Diagnostics.AddError("Agent token not found", "Removing from state")
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	state.Description = types.StringPointerValue(agentToken.AgentToken.Description)
-	state.Id = types.StringValue(agentToken.AgentToken.Id)
+	state.Description = types.StringPointerValue(r.AgentToken.Description)
+	state.Id = types.StringValue(r.AgentToken.Id)
 	state.Token = plan.Token // token is never returned after creation so use the existing value in state
-	state.Uuid = types.StringValue(agentToken.AgentToken.Uuid)
+	state.Uuid = types.StringValue(r.AgentToken.Uuid)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/buildkite/resource_agent_token_test.go
+++ b/buildkite/resource_agent_token_test.go
@@ -6,80 +6,109 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// Confirm that we can create a new agent token, and then delete it without error
-func TestAccAgentToken_add_remove(t *testing.T) {
-	t.Parallel()
-	var resourceToken AgentTokenNode
+func TestAccBuildkiteAgentToken(t *testing.T) {
+	basic := func(name string) string {
+		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testAccCheckAgentTokenResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAgentTokenConfigBasic("foo"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the token exists in the buildkite API
-					testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
-					// Confirm the token has the correct values in Buildkite's system
-					testAccCheckAgentTokenRemoteValues(&resourceToken, "Acceptance Test foo"),
-					// Confirm the token has the correct values in terraform state
-					resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", "Acceptance Test foo"),
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "token"),
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "uuid"),
-				),
+		resource "buildkite_agent_token" "foobar" {
+			description = "Acceptance Test %s"
+		}
+		`, name)
+	}
+
+	// Confirm that we can create a new agent token, and then delete it without error
+	t.Run("adds an agent token", func(t *testing.T) {
+		var resourceToken AgentTokenNode
+		randName := acctest.RandString(10)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the token exists in the buildkite API
+			testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
+			// Confirm the token has the correct values in Buildkite's system
+			testAccCheckAgentTokenRemoteValues(&resourceToken, fmt.Sprintf("Acceptance Test %s", randName)),
+			// Confirm the token has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", fmt.Sprintf("Acceptance Test %s", randName)),
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "token"),
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "uuid"),
+		)
+	
+		checkRefresh := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the token has the correct values in terraform state
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "token"),
+			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "uuid"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckAgentTokenResourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: basic(randName),
+					Check:  check,
+				},
+				{
+					RefreshState: true,
+					PlanOnly:     true,
+					Check: checkRefresh,
+				},
 			},
-			{
-				RefreshState: true,
-				PlanOnly:     true,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the token has the correct values in terraform state
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "token"),
-					resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "uuid"),
-				),
-			},
-		},
+		})
 	})
-}
 
-// Confirm that we can create a new agent token, and then update the description
-// Technically tokens can't be updated, so this will actuall do a delete+create
-func TestAccAgentToken_update(t *testing.T) {
-	t.Parallel()
-	var resourceToken AgentTokenNode
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testAccCheckAgentTokenResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAgentTokenConfigBasic("foo"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the token exists in the buildkite API
-					testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
-					// Quick check to confirm the local state is correct before we update it
-					resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", "Acceptance Test foo"),
-				),
+	// Confirm that we can create a new agent token, and then update the description
+	// Technically tokens can't be updated, so this will actuall do a delete+create
+	t.Run("updates an agent token", func(t *testing.T) {
+		var resourceToken AgentTokenNode
+		randName := acctest.RandString(10)
+		randNameUpdated := acctest.RandString(10)
+	
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the token exists in the buildkite API
+			testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
+			// Quick check to confirm the local state is correct before we update it
+			resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", fmt.Sprintf("Acceptance Test %s", randName)),
+		)
+	
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the token exists in the buildkite API
+			testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
+			// Confirm the token has the updated values in Buildkite's system
+			testAccCheckAgentTokenRemoteValues(&resourceToken, fmt.Sprintf("Acceptance Test %s", randNameUpdated)),
+			// Confirm the token has the updated values in terraform state
+			resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", fmt.Sprintf("Acceptance Test %s", randNameUpdated)),
+		)
+	
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckAgentTokenResourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: basic(randName),
+					Check:  check,
+				},
+				{
+					Config: basic(randNameUpdated),
+					Check:  checkUpdated,
+				},
 			},
-			{
-				Config: testAccAgentTokenConfigBasic("bar"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the token exists in the buildkite API
-					testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
-					// Confirm the token has the updated values in Buildkite's system
-					testAccCheckAgentTokenRemoteValues(&resourceToken, "Acceptance Test bar"),
-					// Confirm the token has the updated values in terraform state
-					resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", "Acceptance Test bar"),
-				),
-			},
-		},
+		})
 	})
 }
 
@@ -134,15 +163,6 @@ func testAccCheckAgentTokenRemoteValues(resourceToken *AgentTokenNode, descripti
 		}
 		return nil
 	}
-}
-
-func testAccAgentTokenConfigBasic(description string) string {
-	config := `
-		resource "buildkite_agent_token" "foobar" {
-			description = "Acceptance Test %s"
-		}
-	`
-	return fmt.Sprintf(config, description)
 }
 
 // verifies the agent token has been destroyed

--- a/buildkite/resource_agent_token_test.go
+++ b/buildkite/resource_agent_token_test.go
@@ -45,7 +45,7 @@ func TestAccBuildkiteAgentToken(t *testing.T) {
 			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "token"),
 			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "uuid"),
 		)
-	
+
 		checkRefresh := resource.ComposeAggregateTestCheckFunc(
 			// Confirm the token has the correct values in terraform state
 			resource.TestCheckResourceAttrSet("buildkite_agent_token.foobar", "id"),
@@ -65,7 +65,7 @@ func TestAccBuildkiteAgentToken(t *testing.T) {
 				{
 					RefreshState: true,
 					PlanOnly:     true,
-					Check: checkRefresh,
+					Check:        checkRefresh,
 				},
 			},
 		})
@@ -77,14 +77,14 @@ func TestAccBuildkiteAgentToken(t *testing.T) {
 		var resourceToken AgentTokenNode
 		randName := acctest.RandString(10)
 		randNameUpdated := acctest.RandString(10)
-	
+
 		check := resource.ComposeAggregateTestCheckFunc(
 			// Confirm the token exists in the buildkite API
 			testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
 			// Quick check to confirm the local state is correct before we update it
 			resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", fmt.Sprintf("Acceptance Test %s", randName)),
 		)
-	
+
 		checkUpdated := resource.ComposeAggregateTestCheckFunc(
 			// Confirm the token exists in the buildkite API
 			testAccCheckAgentTokenExists("buildkite_agent_token.foobar", &resourceToken),
@@ -93,7 +93,7 @@ func TestAccBuildkiteAgentToken(t *testing.T) {
 			// Confirm the token has the updated values in terraform state
 			resource.TestCheckResourceAttr("buildkite_agent_token.foobar", "description", fmt.Sprintf("Acceptance Test %s", randNameUpdated)),
 		)
-	
+
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),


### PR DESCRIPTION
feat (Timeouts/Retries): Add timeouts (provider config set) and CRUD retries to the Agent token resource.

## PR checklist:
- [x] `docs/` updated (provider docs updated previously)
- [x] tests added (tests migrated to t.Run())
- [x] an example added to `examples/` (provider example updated with `timeouts` block)
- [x] `CHANGELOG.md` updated with pending release information

Also converted the tests with a `t.Run` to enable parallelism / set timeouts in test configuration (random agent token names with `accTest`)