### PR TITLE
SUP-1400: Test suite and test suite team (team suite) resource retries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - SUP-1392: Random test suite names in tests/t.Run() conversion [[PR #376](https://github.com/buildkite/terraform-provider-buildkite/pull/376)] @james2791
 - SUP-1374 Add timeout to provider and cluster datasource [[PR #363](https://github.com/buildkite/terraform-provider-buildkite/pull/363)] @jradtilbrook
-    - SUP-1374 Remove timeout context [[PR #378](https://github.com/buildkite/terraform-provider-buildkite/pull/378)] @jradtilbrook
+- SUP-1374 Remove timeout context [[PR #378](https://github.com/buildkite/terraform-provider-buildkite/pull/378)] @jradtilbrook
+- SUP-1400: Test suite and test suite team (team suite) resource retries [[PR #383](https://github.com/buildkite/terraform-provider-buildkite/pull/383)] @james2791
 
 ### Changes
 

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -143,7 +143,7 @@ func (client *Client) makeRequest(ctx context.Context, method string, path strin
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Buildkite API request failed: %s %s (status: %d)", method, url, resp.StatusCode)
+		return fmt.Errorf("Buildkite API request failed: %s %s (returned error %d)", method, url, resp.StatusCode)
 	} else if resp.StatusCode == 204 {
 		return nil
 	}

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -62,6 +62,7 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Use the Read timeout for obtaining a Test suite's UUID
 	timeout, diags := ts.client.timeouts.Read(ctx, DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
 
@@ -107,6 +108,11 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Construct URL to call to the REST API
 	url := fmt.Sprintf("/v2/analytics/organizations/%s/suites", ts.client.organization)
+
+	// Use the Create timeout for test suite creation
+	timeout, diags = ts.client.timeouts.Create(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
+
 	createErr := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = ts.client.makeRequest(ctx, "POST", url, payload, &response)
 

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -242,6 +242,11 @@ func (ts *testSuiteResource) Read(ctx context.Context, req resource.ReadRequest,
 			// and we didnt find another team with MANAGE_AND_READ
 			state.TeamOwnerId = types.StringUnknown()
 		}
+	} else {
+		// Test suite was removed - remove from state
+		resp.Diagnostics.AddWarning("Test suite not found", "Removing test suite from state")
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	if state.TeamOwnerId.IsUnknown() {

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -111,7 +111,7 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 		err = ts.client.makeRequest(ctx, "POST", url, payload, &response)
 
 		if err != nil {
-			if isRetryableError(err){
+			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -158,7 +158,7 @@ func (ts *testSuiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 		err := ts.client.makeRequest(ctx, "DELETE", url, nil, nil)
 
 		if err != nil {
-			if isRetryableError(err){
+			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -325,7 +325,7 @@ func (ts *testSuiteResource) Update(ctx context.Context, req resource.UpdateRequ
 		err := ts.client.makeRequest(ctx, "PATCH", url, payload, &response)
 
 		if err != nil {
-			if isRetryableError(err){
+			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -62,7 +62,7 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	timeout, diags := ts.client.timeouts.Create(ctx, DefaultTimeout)
+	timeout, diags := ts.client.timeouts.Read(ctx, DefaultTimeout)
 	resp.Diagnostics.Append(diags...)
 
 	// The REST API requires team UUIDs but everything else in the provider uses GraphQL IDs. So we map from UUID to ID

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -70,18 +70,18 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 	var r *getNodeResponse
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
-		r, err = getNode(ctx, 
-			ts.client.genqlient, 
+		r, err = getNode(ctx,
+			ts.client.genqlient,
 			plan.TeamOwnerId.ValueString(),
 		)
-		
+
 		if err != nil {
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			resp.Diagnostics.AddError(
 				"Failed to find team",
-				 err.Error(),
+				err.Error(),
 			)
 			return retry.NonRetryableError(err)
 		}
@@ -105,13 +105,13 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 	url := fmt.Sprintf("/v2/analytics/organizations/%s/suites", ts.client.organization)
 	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = ts.client.makeRequest(ctx, "POST", url, payload, &response)
-		
+
 		if err != nil {
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			resp.Diagnostics.AddError(
-				"Failed to create test suite", 
+				"Failed to create test suite",
 				err.Error())
 			return retry.NonRetryableError(err)
 		}
@@ -147,13 +147,13 @@ func (ts *testSuiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 	url := fmt.Sprintf("/v2/analytics/organizations/%s/suites/%s", ts.client.organization, state.Slug.ValueString())
 	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err := ts.client.makeRequest(ctx, "DELETE", url, nil, nil)
-		
+
 		if err != nil {
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
 			resp.Diagnostics.AddError(
-				"Failed to delete test suite", 
+				"Failed to delete test suite",
 				err.Error(),
 			)
 			return retry.NonRetryableError(err)
@@ -187,8 +187,8 @@ func (ts *testSuiteResource) Read(ctx context.Context, req resource.ReadRequest,
 	var r *getTestSuiteResponse
 	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
-		r, err = getTestSuite(ctx, 
-			ts.client.genqlient, state.ID.ValueString(), 
+		r, err = getTestSuite(ctx,
+			ts.client.genqlient, state.ID.ValueString(),
 			50,
 		)
 		if err != nil {
@@ -197,7 +197,7 @@ func (ts *testSuiteResource) Read(ctx context.Context, req resource.ReadRequest,
 			}
 			resp.Diagnostics.AddError(
 				"Failed to load test suite from GraphQL",
-				 err.Error(),
+				err.Error(),
 			)
 			return retry.NonRetryableError(err)
 		}

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -107,9 +107,6 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 		err = ts.client.makeRequest(ctx, "POST", url, payload, &response)
 
 		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
 			resp.Diagnostics.AddError(
 				"Failed to create test suite",
 				err.Error())
@@ -149,9 +146,6 @@ func (ts *testSuiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 		err := ts.client.makeRequest(ctx, "DELETE", url, nil, nil)
 
 		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
 			resp.Diagnostics.AddError(
 				"Failed to delete test suite",
 				err.Error(),

--- a/buildkite/resource_test_suite_team.go
+++ b/buildkite/resource_test_suite_team.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
 type testSuiteTeamModel struct {
@@ -82,31 +83,48 @@ func (tst *testSuiteTeamResource) Schema(ctx context.Context, req resource.Schem
 func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var state testSuiteTeamModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
+	diags := req.Plan.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeout, diags := tst.client.timeouts.Create(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	log.Printf("Adding team %s to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
-	apiResponse, err := createTestSuiteTeam(ctx,
-		tst.client.genqlient,
-		state.TeamID.ValueString(),
-		state.TestSuiteId.ValueString(),
-		SuiteAccessLevels(state.AccessLevel.ValueString()),
-	)
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create test suite team",
-			fmt.Sprintf("Unable to create test suite team: %s", err.Error()),
+	var r *createTestSuiteTeamResponse
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		var err error
+		r, err = createTestSuiteTeam(ctx,
+			tst.client.genqlient,
+			state.TeamID.ValueString(),
+			state.TestSuiteId.ValueString(),
+			SuiteAccessLevels(state.AccessLevel.ValueString()),
 		)
-		return
-	}
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to create test suite team",
+				fmt.Sprintf("Unable to create test suite team: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
 
 	// Set ID and UUID to state
-	state.ID = types.StringValue(apiResponse.TeamSuiteCreate.TeamSuite.Id)
-	state.UUID = types.StringValue(apiResponse.TeamSuiteCreate.TeamSuite.TeamSuiteUuid)
+	state.ID = types.StringValue(r.TeamSuiteCreate.TeamSuite.Id)
+	state.UUID = types.StringValue(r.TeamSuiteCreate.TeamSuite.TeamSuiteUuid)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -114,25 +132,45 @@ func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.Creat
 func (tst *testSuiteTeamResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state testSuiteTeamModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeout, diags := tst.client.timeouts.Read(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	log.Printf("Reading test suite team with ID %s ...", state.ID.ValueString())
-	apiResponse, err := getNode(ctx, tst.client.genqlient, state.ID.ValueString())
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to read test suite team",
-			fmt.Sprintf("Unable to read test suite team member: %s", err.Error()),
+	var r *getNodeResponse
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		var err error
+		r, err = getNode(ctx,
+			tst.client.genqlient,
+			state.ID.ValueString(),
 		)
-		return
-	}
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to read test suite team",
+				fmt.Sprintf("Unable to read test suite team member: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
 
 	// Convert fron Node to getNodeTeamMember type
-	if teamSuiteNode, ok := apiResponse.GetNode().(*getNodeNodeTeamSuite); ok {
+	if teamSuiteNode, ok := r.GetNode().(*getNodeNodeTeamSuite); ok {
 		if teamSuiteNode == nil {
 			resp.Diagnostics.AddError(
 				"Unable to get test suite team",
@@ -158,26 +196,49 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 	var state testSuiteTeamModel
 	var testSuiteTeamAccessLevel string
 
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("access_level"), &testSuiteTeamAccessLevel)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	diagsState := req.State.Get(ctx, &state)
+	diagsAccessLevel := req.Plan.GetAttribute(ctx, path.Root("access_level"), &testSuiteTeamAccessLevel)
 
-	log.Printf("Updating team %s in test suite %s to %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString(), testSuiteTeamAccessLevel)
-	apiResponse, err := updateTestSuiteTeam(ctx,
-		tst.client.genqlient,
-		state.ID.ValueString(),
-		SuiteAccessLevels(testSuiteTeamAccessLevel),
-	)
+	resp.Diagnostics.Append(diagsState...)
+	resp.Diagnostics.Append(diagsAccessLevel...)
 
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update test suite team",
-			fmt.Sprintf("Unable to update test suite team: %s", err.Error()),
-		)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	timeout, diags := tst.client.timeouts.Update(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	log.Printf("Updating team %s in test suite %s to %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString(), testSuiteTeamAccessLevel)
+	var r *updateTestSuiteTeamResponse
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		var err error
+		r, err = updateTestSuiteTeam(ctx,
+			tst.client.genqlient,
+			state.ID.ValueString(),
+			SuiteAccessLevels(testSuiteTeamAccessLevel),
+		)
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to update test suite team",
+				fmt.Sprintf("Unable to update test suite team: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
 	// Update state access level
-	state.AccessLevel = types.StringValue(string(apiResponse.TeamSuiteUpdate.TeamSuite.AccessLevel))
+	state.AccessLevel = types.StringValue(string(r.TeamSuiteUpdate.TeamSuite.AccessLevel))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -185,22 +246,39 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 func (tst *testSuiteTeamResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state testSuiteTeamModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeout, diags := tst.client.timeouts.Delete(ctx, DefaultTimeout)
+	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	log.Printf("Deleting team %s's access to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
-	_, err := deleteTestSuiteTeam(ctx, tst.client.genqlient, state.ID.ValueString())
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete test suite team",
-			fmt.Sprintf("Unable to delete test suite team: %s", err.Error()),
+	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		_, err := deleteTestSuiteTeam(ctx,
+			tst.client.genqlient,
+			state.ID.ValueString(),
 		)
-		return
-	}
+
+		if err != nil {
+			if isRetryableError(err) {
+				return retry.RetryableError(err)
+			}
+			resp.Diagnostics.AddError(
+				"Unable to delete test suite team",
+				fmt.Sprintf("Unable to delete test suite team: %s", err.Error()),
+			)
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 }
 
 func updateTeamSuiteTeamResource(tstm *testSuiteTeamModel, tsn getNodeNodeTeamSuite) {

--- a/buildkite/resource_test_suite_team.go
+++ b/buildkite/resource_test_suite_team.go
@@ -99,7 +99,7 @@ func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.Creat
 
 	log.Printf("Adding team %s to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
 	var r *createTestSuiteTeamResponse
-	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
 		r, err = createTestSuiteTeam(ctx,
 			tst.client.genqlient,
@@ -112,15 +112,19 @@ func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.Creat
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
-			resp.Diagnostics.AddError(
-				"Unable to create test suite team",
-				fmt.Sprintf("Unable to create test suite team: %s", err.Error()),
-			)
 			return retry.NonRetryableError(err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create test suite team",
+			fmt.Sprintf("Unable to create test suite team: %s", err.Error()),
+		)
+		return
+	}
 
 	// Set ID and UUID to state
 	state.ID = types.StringValue(r.TeamSuiteCreate.TeamSuite.Id)
@@ -148,7 +152,7 @@ func (tst *testSuiteTeamResource) Read(ctx context.Context, req resource.ReadReq
 
 	log.Printf("Reading test suite team with ID %s ...", state.ID.ValueString())
 	var r *getNodeResponse
-	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
 		r, err = getNode(ctx,
 			tst.client.genqlient,
@@ -159,15 +163,19 @@ func (tst *testSuiteTeamResource) Read(ctx context.Context, req resource.ReadReq
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
-			resp.Diagnostics.AddError(
-				"Unable to read test suite team",
-				fmt.Sprintf("Unable to read test suite team member: %s", err.Error()),
-			)
 			return retry.NonRetryableError(err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read test suite team",
+			fmt.Sprintf("Unable to read test suite team member: %s", err.Error()),
+		)
+		return
+	}
 
 	// Convert fron Node to getNodeTeamMember type
 	if teamSuiteNode, ok := r.GetNode().(*getNodeNodeTeamSuite); ok {
@@ -215,7 +223,7 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 
 	log.Printf("Updating team %s in test suite %s to %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString(), testSuiteTeamAccessLevel)
 	var r *updateTestSuiteTeamResponse
-	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		var err error
 		r, err = updateTestSuiteTeam(ctx,
 			tst.client.genqlient,
@@ -227,15 +235,19 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
-			resp.Diagnostics.AddError(
-				"Unable to update test suite team",
-				fmt.Sprintf("Unable to update test suite team: %s", err.Error()),
-			)
 			return retry.NonRetryableError(err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update test suite team",
+			fmt.Sprintf("Unable to update test suite team: %s", err.Error()),
+		)
+		return
+	}
 
 	// Update state access level
 	state.AccessLevel = types.StringValue(string(r.TeamSuiteUpdate.TeamSuite.AccessLevel))
@@ -261,7 +273,7 @@ func (tst *testSuiteTeamResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	log.Printf("Deleting team %s's access to test suite %s ...", state.TeamID.ValueString(), state.TestSuiteId.ValueString())
-	retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := deleteTestSuiteTeam(ctx,
 			tst.client.genqlient,
 			state.ID.ValueString(),
@@ -271,14 +283,18 @@ func (tst *testSuiteTeamResource) Delete(ctx context.Context, req resource.Delet
 			if isRetryableError(err) {
 				return retry.RetryableError(err)
 			}
-			resp.Diagnostics.AddError(
-				"Unable to delete test suite team",
-				fmt.Sprintf("Unable to delete test suite team: %s", err.Error()),
-			)
 			return retry.NonRetryableError(err)
 		}
 		return nil
 	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete test suite team",
+			fmt.Sprintf("Unable to delete test suite team: %s", err.Error()),
+		)
+		return
+	}
 }
 
 func updateTeamSuiteTeamResource(tstm *testSuiteTeamModel, tsn getNodeNodeTeamSuite) {

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -225,10 +225,10 @@ func TestAccBuildkiteTestSuiteTeam(t *testing.T) {
 
 		check := func(s *terraform.State) error {
 			teamSuite := s.RootModule().Resources["buildkite_test_suite_team.teamsuite"]
-			_, err := deleteTestSuiteTeam(context.Background(), genqlientGraphql, teamSuite.Primary.ID,)
+			_, err := deleteTestSuiteTeam(context.Background(), genqlientGraphql, teamSuite.Primary.ID)
 			return err
 		}
-	
+
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -10,198 +10,204 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccTestSuiteTeam_add_remove(t *testing.T) {
-	ownerTeamName := acctest.RandString(12)
-	newTeamName := acctest.RandString(12)
-	var tr teamResourceModel
-	var ts getTestSuiteSuite
-	var tst testSuiteTeamModel
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, "READ_ONLY"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the new team/test suite exists in the Buildkite API
-					testAccCheckTeamExists("buildkite_team.newteam", &tr),
-					checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
-					// Confirm the test suite team exists in the buildkite API
-					testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
-					// Confirm the test suite team has the correct values in Buildkite's system
-					testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
-					// Confirm the test suite team has the correct values in terraform state
-					resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTestSuiteTeam_update(t *testing.T) {
-	ownerTeamName := acctest.RandString(12)
-	newTeamName := acctest.RandString(12)
-	var tr teamResourceModel
-	var ts getTestSuiteSuite
-	var tst testSuiteTeamModel
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, "READ_ONLY"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the new team/test suite exists in the Buildkite API
-					testAccCheckTeamExists("buildkite_team.newteam", &tr),
-					checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
-					// Confirm the test suite team exists in the buildkite API
-					testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
-					// Confirm the test suite team has the correct values in Buildkite's system
-					testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
-					// Confirm the test suite team has the correct values in terraform state
-					resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
-				),
-			},
-			{
-				Config: testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, "MANAGE_AND_READ"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the new team/test suite exists in the Buildkite API
-					testAccCheckTeamExists("buildkite_team.newteam", &tr),
-					checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
-					// Confirm the test suite team exists in the buildkite API
-					testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
-					// Confirm the test suite team has the correct values in Buildkite's system
-					testAccCheckTestSuiteTeamRemoteValues("MANAGE_AND_READ", &tr, &ts, &tst),
-					// Confirm the test suite team has the correct values in terraform state
-					resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "MANAGE_AND_READ"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTestSuiteTeam_import(t *testing.T) {
-	ownerTeamName := acctest.RandString(12)
-	newTeamName := acctest.RandString(12)
-	var tr teamResourceModel
-	var ts getTestSuiteSuite
-	var tst testSuiteTeamModel
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, "READ_ONLY"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the new team/test suite exists in the Buildkite API
-					testAccCheckTeamExists("buildkite_team.newteam", &tr),
-					checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
-					// Confirm the test suite team exists in the buildkite API
-					testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
-					// Confirm the test suite team has the correct values in Buildkite's system
-					testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
-					// Confirm the test suite team has the correct values in terraform state
-					resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
-					resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
-				),
-			},
-			{
-				// re-import the resource (using the graphql token of the existing resource) and confirm they match
-				ResourceName:      "buildkite_test_suite_team.teamsuite",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccTestSuiteTeam_disappears(t *testing.T) {
-	ownerTeamName := acctest.RandString(12)
-	newTeamName := acctest.RandString(12)
-	var tr teamResourceModel
-	var ts getTestSuiteSuite
-	var tst testSuiteTeamModel
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		// CheckDestroy:             testAccCheckPipelineResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, "READ_ONLY"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Confirm the new team/test suite exists in the Buildkite API
-					testAccCheckTeamExists("buildkite_team.newteam", &tr),
-					checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
-					// Confirm the test suite team exists in the buildkite API
-					testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
-					// Ensure the test suite team removal from spec
-					testAccCheckTestSuiteTeamDisappears("buildkite_test_suite_team.teamsuite"),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func testAccCTestSuiteTeamConfigBasic(ownerTeamName, newTeamName, accessLevel string) string {
-	config := `
-
-	resource "buildkite_team" "ownerteam" {
-		name = "Test Suite Team %s"
-		default_team = false
-		privacy = "VISIBLE"
-		default_member_role = "MAINTAINER"
+func TestAccBuildkiteTestSuiteTeam(t *testing.T) {
+	config := func(ownerTeamName, newTeamName, accessLevel string) string {
+		return fmt.Sprintf(`
+		resource "buildkite_team" "ownerteam" {
+			name = "Test Suite Team %s"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+	
+		resource "buildkite_team" "newteam" {
+			name = "Test Suite Team %s"
+			default_team = false
+			privacy = "VISIBLE"
+			default_member_role = "MAINTAINER"
+		}
+	
+		resource "buildkite_test_suite" "testsuite" {
+			name = "Test Suite %s"
+			default_branch = "main"
+			team_owner_id = buildkite_team.ownerteam.id
+		}
+	
+		resource "buildkite_test_suite_team" "teamsuite" {
+			test_suite_id = buildkite_test_suite.testsuite.id
+			team_id = buildkite_team.newteam.id
+			access_level = "%s"
+		}
+		`, ownerTeamName, newTeamName, ownerTeamName, accessLevel)
 	}
 
-	resource "buildkite_team" "newteam" {
-		name = "Test Suite Team %s"
-		default_team = false
-		privacy = "VISIBLE"
-		default_member_role = "MAINTAINER"
-	}
+	t.Run("creates a test suite team", func(t *testing.T) {
+		ownerTeamName := acctest.RandString(12)
+		newTeamName := acctest.RandString(12)
+		var tr teamResourceModel
+		var ts getTestSuiteSuite
+		var tst testSuiteTeamModel
 
-	resource "buildkite_test_suite" "testsuite" {
-		name = "Test Suite %s"
-		default_branch = "main"
-		team_owner_id = buildkite_team.ownerteam.id
-	}
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the new team/test suite exists in the Buildkite API
+			testAccCheckTeamExists("buildkite_team.newteam", &tr),
+			checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
+			// Confirm the test suite team exists in the buildkite API
+			testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
+			// Confirm the test suite team has the correct values in Buildkite's system
+			testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
+			// Confirm the test suite team has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
+		)
 
-	resource "buildkite_test_suite_team" "teamsuite" {
-		test_suite_id = buildkite_test_suite.testsuite.id
-		team_id = buildkite_team.newteam.id
-		access_level = "%s"
-	}
-	`
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(ownerTeamName, newTeamName, "READ_ONLY"),
+					Check:  check,
+				},
+			},
+		})
+	})
 
-	return fmt.Sprintf(config, ownerTeamName, newTeamName, ownerTeamName, accessLevel)
+	t.Run("updates a test suite teams access level", func(t *testing.T) {
+		ownerTeamName := acctest.RandString(12)
+		newTeamName := acctest.RandString(12)
+		var tr teamResourceModel
+		var ts getTestSuiteSuite
+		var tst testSuiteTeamModel
+
+		checkReadOnly := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the new team/test suite exists in the Buildkite API
+			testAccCheckTeamExists("buildkite_team.newteam", &tr),
+			checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
+			// Confirm the test suite team exists in the buildkite API
+			testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
+			// Confirm the test suite team has the correct values in Buildkite's system
+			testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
+			// Confirm the test suite team has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
+		)
+
+		checkManageAndRead := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the new team/test suite exists in the Buildkite API
+			testAccCheckTeamExists("buildkite_team.newteam", &tr),
+			checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
+			// Confirm the test suite team exists in the buildkite API
+			testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
+			// Confirm the test suite team has the correct values in Buildkite's system
+			testAccCheckTestSuiteTeamRemoteValues("MANAGE_AND_READ", &tr, &ts, &tst),
+			// Confirm the test suite team has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "MANAGE_AND_READ"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(ownerTeamName, newTeamName, "READ_ONLY"),
+					Check:  checkReadOnly,
+				},
+				{
+					Config: config(ownerTeamName, newTeamName, "MANAGE_AND_READ"),
+					Check:  checkManageAndRead,
+				},
+			},
+		})
+	})
+
+	t.Run("imports a test suite team", func(t *testing.T) {
+		ownerTeamName := acctest.RandString(12)
+		newTeamName := acctest.RandString(12)
+		var tr teamResourceModel
+		var ts getTestSuiteSuite
+		var tst testSuiteTeamModel
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the new team/test suite exists in the Buildkite API
+			testAccCheckTeamExists("buildkite_team.newteam", &tr),
+			checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
+			// Confirm the test suite team exists in the buildkite API
+			testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
+			// Confirm the test suite team has the correct values in Buildkite's system
+			testAccCheckTestSuiteTeamRemoteValues("READ_ONLY", &tr, &ts, &tst),
+			// Confirm the test suite team has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_test_suite_team.teamsuite", "access_level", "READ_ONLY"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "uuid"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "test_suite_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "team_id"),
+			resource.TestCheckResourceAttrSet("buildkite_test_suite_team.teamsuite", "access_level"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckTestSuiteTeamDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(ownerTeamName, newTeamName, "READ_ONLY"),
+					Check:  check,
+				},
+				{
+					// re-import the resource (using the graphql token of the existing resource) and confirm they match
+					ResourceName:      "buildkite_test_suite_team.teamsuite",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("removes a test suite team", func(t *testing.T) {
+		ownerTeamName := acctest.RandString(12)
+		newTeamName := acctest.RandString(12)
+		var tr teamResourceModel
+		var ts getTestSuiteSuite
+		var tst testSuiteTeamModel
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the new team/test suite exists in the Buildkite API
+			testAccCheckTeamExists("buildkite_team.newteam", &tr),
+			checkTestSuiteExists("buildkite_test_suite.testsuite", &ts),
+			// Confirm the test suite team exists in the buildkite API
+			testAccCheckTestSuiteTeamExists("buildkite_test_suite_team.teamsuite", &tst),
+			// Ensure the test suite team removal from spec
+			testAccCheckTestSuiteTeamDisappears("buildkite_test_suite_team.teamsuite"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config:             config(ownerTeamName, newTeamName, "READ_ONLY"),
+					Check:              check,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
 }
 
 func testAccCheckTestSuiteTeamExists(resourceName string, tst *testSuiteTeamModel) resource.TestCheckFunc {

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -13,6 +13,15 @@ import (
 func TestAccBuildkiteTestSuiteTeam(t *testing.T) {
 	config := func(ownerTeamName, newTeamName, accessLevel string) string {
 		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
+		
 		resource "buildkite_team" "ownerteam" {
 			name = "Test Suite Team %s"
 			default_team = false

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccBuildkiteTestSuiteTeam(t *testing.T) {
+func TestAccBuildkiteTestSuiteTeamResource(t *testing.T) {
 	config := func(ownerTeamName, newTeamName, accessLevel string) string {
 		return fmt.Sprintf(`
 		provider "buildkite" {

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccBuildkiteTestSuite(t *testing.T) {
+func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 	basicTestSuite := func(name string) string {
 		return fmt.Sprintf(`
 		provider "buildkite" {

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -15,6 +15,15 @@ import (
 func TestAccBuildkiteTestSuite(t *testing.T) {
 	basicTestSuite := func(name string) string {
 		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
+
 		resource "buildkite_team" "team" {
 			name = "test suite team"
 			default_team = false
@@ -31,6 +40,15 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 
 	testSuiteWithTwoTeams := func(name string) string {
 		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
+
 		resource "buildkite_team" "ateam" {
 			name = "a team"
 			default_team = false
@@ -53,6 +71,15 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 
 	testSuiteTeamAddition := func(name string) string {
 		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
+
 		resource "buildkite_team" "ateam" {
 			name = "a team"
 			default_team = false

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -78,9 +78,10 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 		`, name)
 	}
 
-	t.Run("Creates a Test Suite", func(t *testing.T) {
+	t.Run("creates a test suite", func(t *testing.T) {
 		var suite getTestSuiteSuite
 		randName := acctest.RandString(10)
+
 		check := resource.ComposeAggregateTestCheckFunc(
 			checkTestSuiteExists("buildkite_test_suite.suite", &suite),
 			checkTestSuiteRemoteValue(&suite, "Name", fmt.Sprintf("test suite %s", randName)),
@@ -105,9 +106,10 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 		})
 	})
 
-	t.Run("Updates a Test Suite", func(t *testing.T) {
+	t.Run("updates a test suite", func(t *testing.T) {
 		var suite getTestSuiteSuite
 		randName := acctest.RandString(10)
+
 		check := resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "id"),
 			resource.TestCheckResourceAttrSet("buildkite_test_suite.suite", "api_token"),
@@ -137,7 +139,7 @@ func TestAccBuildkiteTestSuite(t *testing.T) {
 		})
 	})
 
-	t.Run("Creates and handles Test Suite Team owner resolution", func(t *testing.T) {
+	t.Run("creates and handles test suite team owner resolution", func(t *testing.T) {
 		var suite getTestSuiteSuite
 		randName := acctest.RandString(10)
 


### PR DESCRIPTION
feat (Timeouts/Retries): Add timeouts (provider config set) and CRUD retries to the Test suite and test suite team resources.

## PR checklist:
- [x] `docs/` updated (provider docs updated previously)
- [x] tests added (TST tests migrated to t.Run())
- [x] an example added to `examples/` (provider example updated with `timeouts` block)
- [x] `CHANGELOG.md` updated with pending release information

Also converted the Test suite team tests with `t.Run` to enable parallelism / set timeouts in test configuration. Both TS and TST have randomness enabled previously.

This PR also adjusts the Client's `makeRequest` function to returns errors with a `returned error` format line so that REST API requests can benefit from the rate limit/server error retry methods implemented.