### PR TITLE
SUP-1405: Fix dangling team resources created in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - SUP-1402: Agent token resource retries [[PR #382](https://github.com/buildkite/terraform-provider-buildkite/pull/382)] @james2791
 - SUP-1399: Add retry to pipeline team resource [[PR #384](https://github.com/buildkite/terraform-provider-buildkite/pull/384)] @lizrabuya
 - SUP-1361: Add timeouts to pipeline resource api[[PR #385](https://github.com/buildkite/terraform-provider-buildkite/pull/385)] @lizrabuya
+- SUP-1405: Fix dangling team resources created in tests [[PR #389](https://github.com/buildkite/terraform-provider-buildkite/pull/389)] @lizrabuya
 
 ### Changes
 

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -156,7 +156,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 		clusterName := acctest.RandString(12)
 		config := fmt.Sprintf(`
 			resource "buildkite_team" "team" {
-				name = "%s"
+				name = "pipeline test %s"
 				default_team = false
 				default_member_role = "MEMBER"
 				privacy = "VISIBLE"
@@ -280,7 +280,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 				{
 					Config: fmt.Sprintf(`
 						resource "buildkite_team" "team" {
-							name = "%s"
+							name = "pipeline test %s"
 							default_team = false
 							default_member_role = "MEMBER"
 							privacy = "VISIBLE"
@@ -449,6 +449,15 @@ func TestAccBuildkitePipeline(t *testing.T) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy: func(s *terraform.State) error {
+				// if team created in the tests still exists,it must be deleted
+				_, err := getNode(context.Background(), genqlientGraphql, teamID)
+				if err != nil {
+					return err
+				}
+				_, err = teamDelete(context.Background(), genqlientGraphql, teamID)
+				return err
+			},
 			Steps: []resource.TestStep{
 				{
 					Config: fmt.Sprintf(`
@@ -467,7 +476,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 						},
 						func(s *terraform.State) error {
 							// add new team to pipeline
-							team, err := teamCreate(context.Background(), genqlientGraphql, organizationID, acctest.RandString(6), nil, "VISIBLE", false, "MEMBER", false)
+							team, err := teamCreate(context.Background(), genqlientGraphql, organizationID, fmt.Sprintf("pipeline adhoc team %s", acctest.RandString(6)), nil, "VISIBLE", false, "MEMBER", false)
 							teamID = team.TeamCreate.TeamEdge.Node.Id
 							if err != nil {
 								return err
@@ -501,7 +510,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 				{
 					Config: fmt.Sprintf(`
 						resource "buildkite_team" "team" {
-							name = "%s"
+							name = "pipeline team test %s"
 							default_team = false
 							default_member_role = "MEMBER"
 							privacy = "VISIBLE"
@@ -554,7 +563,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 				{
 					Config: fmt.Sprintf(`
 						resource "buildkite_team" "team" {
-							name = "%s"
+							name = "pipeline team test %s"
 							default_team = false
 							default_member_role = "MEMBER"
 							privacy = "VISIBLE"
@@ -600,7 +609,7 @@ func TestAccBuildkitePipeline(t *testing.T) {
 		teamName := acctest.RandString(12)
 		config := fmt.Sprintf(`
 			resource "buildkite_team" "team" {
-				name = "%s"
+				name = "pipeline team test %s"
 				default_team = false
 				default_member_role = "MEMBER"
 				privacy = "VISIBLE"


### PR DESCRIPTION
## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information
