### PR TITLE
retryContextError util resource switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased 
+
+- retryContextError util resource switch [[PR #394](https://github.com/buildkite/terraform-provider-buildkite/pull/394)] @james2791
+
 ## [v0.27.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.26.0...v0.27.0)
 
 - SUP-805: SUP-805: Team resource retries [[PR #360](https://github.com/buildkite/terraform-provider-buildkite/pull/360)] @james2791

--- a/buildkite/resource_agent_token.go
+++ b/buildkite/resource_agent_token.go
@@ -70,14 +70,7 @@ func (at *AgentTokenResource) Create(ctx context.Context, req resource.CreateReq
 			plan.Description.ValueStringPointer(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -120,13 +113,7 @@ func (at *AgentTokenResource) Delete(ctx context.Context, req resource.DeleteReq
 			"Revoked by Terraform",
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -167,14 +154,7 @@ func (at *AgentTokenResource) Read(ctx context.Context, req resource.ReadRequest
 			fmt.Sprintf("%s/%s", at.client.organization, plan.Uuid.ValueString()),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_cluster.go
+++ b/buildkite/resource_cluster.go
@@ -110,14 +110,8 @@ func (c *clusterResource) Create(ctx context.Context, req resource.CreateRequest
 			state.Emoji.ValueStringPointer(),
 			state.Color.ValueStringPointer(),
 		)
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
 
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -158,14 +152,7 @@ func (c *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		var err error
 		r, err = getNode(ctx, c.client.genqlient, state.ID.ValueString())
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -225,14 +212,7 @@ func (c *clusterResource) Update(ctx context.Context, req resource.UpdateRequest
 			plan.Color.ValueStringPointer(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -269,14 +249,7 @@ func (c *clusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 		var err error
 		_, err = deleteCluster(ctx, c.client.genqlient, c.client.organizationId, state.ID.ValueString())
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -139,13 +139,7 @@ func (ps *pipelineSchedule) Create(ctx context.Context, req resource.CreateReque
 			&envVars,
 			plan.Enabled.ValueBool())
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -196,13 +190,7 @@ func (ps *pipelineSchedule) Read(ctx context.Context, req resource.ReadRequest, 
 			state.Id.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -271,14 +259,7 @@ func (ps *pipelineSchedule) Update(ctx context.Context, req resource.UpdateReque
 			input,
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -312,13 +293,7 @@ func (ps *pipelineSchedule) Delete(ctx context.Context, req resource.DeleteReque
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := deletePipelineSchedule(ctx, ps.client.genqlient, plan.Id.ValueString())
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_pipeline_team.go
+++ b/buildkite/resource_pipeline_team.go
@@ -106,13 +106,7 @@ func (tp *pipelineTeamResource) Create(ctx context.Context, req resource.CreateR
 			PipelineAccessLevels(state.AccessLevel.ValueString()),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -155,13 +149,7 @@ func (tp *pipelineTeamResource) Read(ctx context.Context, req resource.ReadReque
 			state.Id.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -217,13 +205,8 @@ func (tp *pipelineTeamResource) Update(ctx context.Context, req resource.UpdateR
 			state.Id.ValueString(),
 			PipelineAccessLevels(accessLevel),
 		)
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -257,13 +240,8 @@ func (tp *pipelineTeamResource) Delete(ctx context.Context, req resource.DeleteR
 
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := deleteTeamPipeline(ctx, tp.client.genqlient, state.Id.ValueString())
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_pipeline_team.go
+++ b/buildkite/resource_pipeline_team.go
@@ -240,7 +240,7 @@ func (tp *pipelineTeamResource) Delete(ctx context.Context, req resource.DeleteR
 
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := deleteTeamPipeline(ctx, tp.client.genqlient, state.Id.ValueString())
-		
+
 		return retryContextError(err)
 	})
 

--- a/buildkite/resource_team.go
+++ b/buildkite/resource_team.go
@@ -158,7 +158,7 @@ func (t *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 			state.DefaultMemberRole.ValueString(),
 			state.MembersCanCreatePipelines.ValueBool(),
 		)
-		
+
 		return retryContextError(err)
 	})
 

--- a/buildkite/resource_team.go
+++ b/buildkite/resource_team.go
@@ -158,15 +158,8 @@ func (t *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 			state.DefaultMemberRole.ValueString(),
 			state.MembersCanCreatePipelines.ValueBool(),
 		)
-
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -209,14 +202,7 @@ func (t *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			state.ID.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -277,14 +263,7 @@ func (t *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			plan.MembersCanCreatePipelines.ValueBool(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -322,13 +301,7 @@ func (t *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 			state.ID.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_team_member.go
+++ b/buildkite/resource_team_member.go
@@ -107,14 +107,7 @@ func (tm *teamMemberResource) Create(ctx context.Context, req resource.CreateReq
 			*state.Role.ValueStringPointer(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -160,14 +153,7 @@ func (tm *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest
 			state.Id.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -231,14 +217,7 @@ func (tm *teamMemberResource) Update(ctx context.Context, req resource.UpdateReq
 			*plan.Role.ValueStringPointer(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -278,13 +257,7 @@ func (tm *teamMemberResource) Delete(ctx context.Context, req resource.DeleteReq
 			state.Id.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {

--- a/buildkite/resource_test_suite.go
+++ b/buildkite/resource_test_suite.go
@@ -76,14 +76,7 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 			plan.TeamOwnerId.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -116,14 +109,7 @@ func (ts *testSuiteResource) Create(ctx context.Context, req resource.CreateRequ
 	createErr := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err = ts.client.makeRequest(ctx, "POST", url, payload, &response)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if createErr != nil {
@@ -163,14 +149,7 @@ func (ts *testSuiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err := ts.client.makeRequest(ctx, "DELETE", url, nil, nil)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -210,14 +189,8 @@ func (ts *testSuiteResource) Read(ctx context.Context, req resource.ReadRequest,
 			ts.client.genqlient, state.ID.ValueString(),
 			50,
 		)
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
 
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -335,14 +308,7 @@ func (ts *testSuiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	updateErr := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		err := ts.client.makeRequest(ctx, "PATCH", url, payload, &response)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if updateErr != nil {
@@ -369,14 +335,7 @@ func (ts *testSuiteResource) Update(ctx context.Context, req resource.UpdateRequ
 				SuiteAccessLevelsManageAndRead,
 			)
 
-			if err != nil {
-				if isRetryableError(err) {
-					return retry.RetryableError(err)
-				}
-				return retry.NonRetryableError(err)
-			}
-
-			return nil
+			return retryContextError(err)
 		})
 
 		if err != nil {
@@ -396,13 +355,7 @@ func (ts *testSuiteResource) Update(ctx context.Context, req resource.UpdateRequ
 						team.Node.Id,
 					)
 
-					if err != nil {
-						if isRetryableError(err) {
-							return retry.RetryableError(err)
-						}
-						return retry.NonRetryableError(err)
-					}
-					return nil
+					return retryContextError(err)
 				})
 
 				if err != nil {

--- a/buildkite/resource_test_suite_team.go
+++ b/buildkite/resource_test_suite_team.go
@@ -108,14 +108,7 @@ func (tst *testSuiteTeamResource) Create(ctx context.Context, req resource.Creat
 			SuiteAccessLevels(state.AccessLevel.ValueString()),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -159,14 +152,7 @@ func (tst *testSuiteTeamResource) Read(ctx context.Context, req resource.ReadReq
 			state.ID.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -231,14 +217,7 @@ func (tst *testSuiteTeamResource) Update(ctx context.Context, req resource.Updat
 			SuiteAccessLevels(testSuiteTeamAccessLevel),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {
@@ -279,13 +258,7 @@ func (tst *testSuiteTeamResource) Delete(ctx context.Context, req resource.Delet
 			state.ID.ValueString(),
 		)
 
-		if err != nil {
-			if isRetryableError(err) {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return retryContextError(err)
 	})
 
 	if err != nil {


### PR DESCRIPTION
refactor(Resource timeouts): Move to shared `util.go` retryContextError function

## PR checklist:
- [ ] `docs/` updated (internal move - not needed)
- [ ] tests added (resource logic stays the same)
- [ ] an example added to `examples/` (useful to demo new field/resource) (nothing changed with resource implementation)
- [x] `CHANGELOG.md` updated with pending release information

Implemented by [this](https://github.com/buildkite/terraform-provider-buildkite/pull/385) PR and moved to `util.go` in this [PR](https://github.com/buildkite/terraform-provider-buildkite/pull/388) - this change replaces the retry logic of all other resource retry logic (determining if the GraphQL/REST query is retryable or not based on the status code returned) using the common shared `retryContextError` function
