### PR TITLE
Added `build_pull_request_ready_for_review` to pipeline resource docs/examples/tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased 
 
 - retryContextError util resource switch [[PR #394](https://github.com/buildkite/terraform-provider-buildkite/pull/394)] @james2791
+- Added `build_pull_request_ready_for_review` to pipeline resource docs/examples/tests[[PR #396](https://github.com/buildkite/terraform-provider-buildkite/pull/396)] @james2791
 
 ## [v0.27.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.26.0...v0.27.0)
 

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -181,10 +181,11 @@ func TestAccBuildkitePipeline(t *testing.T) {
 				tags = ["llama"]
 				provider_settings {
 					trigger_mode = "code"
-					build_pull_requests = false
+					build_pull_requests = true
 					skip_builds_for_existing_commits = true
 					build_branches = true
 					build_tags = true
+					build_pull_request_ready_for_review = true
 					cancel_deleted_branch_builds = true
 					filter_enabled = true
 					filter_condition = "true"
@@ -222,10 +223,11 @@ func TestAccBuildkitePipeline(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", "!main"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.trigger_mode", "code"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_builds_for_existing_commits", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_tags", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_ready_for_review", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.cancel_deleted_branch_builds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_enabled", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_condition", "true"),
@@ -292,10 +294,11 @@ func TestAccBuildkitePipeline(t *testing.T) {
 							tags = ["llama"]
 							provider_settings {
 								trigger_mode = "code"
-								build_pull_requests = false
+								build_pull_requests = true
 								skip_builds_for_existing_commits = true
 								build_branches = true
 								build_tags = true
+								build_pull_request_ready_for_review = true
 								cancel_deleted_branch_builds = true
 								filter_enabled = true
 								filter_condition = "true"

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -139,6 +139,7 @@ Additional properties available for GitHub:
 
 -   `build_pull_request_forks` - (Optional) Whether to create builds for pull requests from third-party forks.
 -   `build_pull_request_labels_changed` - (Optional) Whether to create builds for pull requests when labels are added or removed.
+-   `build_pull_request_ready_for_review` - (Optional)  Whether to create builds for pull requests that are ready for review.
 -   `prefix_pull_request_fork_branch_names` - (Optional) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the `master` branch from `some-user` will become `some-user:master`.
 -   `separate_pull_request_statuses` - (Optional) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
 -   `publish_blocked_as_pending` - (Optional) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -139,7 +139,7 @@ Additional properties available for GitHub:
 
 -   `build_pull_request_forks` - (Optional) Whether to create builds for pull requests from third-party forks.
 -   `build_pull_request_labels_changed` - (Optional) Whether to create builds for pull requests when labels are added or removed.
--   `build_pull_request_ready_for_review` - (Optional)  Whether to create builds for pull requests that are ready for review.
+-   `build_pull_request_ready_for_review` - (Optional) Whether to create builds for pull requests that are ready for review.
 -   `prefix_pull_request_fork_branch_names` - (Optional) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the `master` branch from `some-user` will become `some-user:master`.
 -   `separate_pull_request_statuses` - (Optional) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
 -   `publish_blocked_as_pending` - (Optional) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -41,6 +41,12 @@ resource "buildkite_pipeline" "repo2" {
   lifecycle {
     prevent_destroy = true
   }
+
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    build_pull_request_ready_for_review = true
+  }
 }
 
 resource "buildkite_pipeline_schedule" "weekly" {


### PR DESCRIPTION
feat(Pipeline docs): Addition of `build_pull_request_ready_for_review` for a Pipeline's `provider_settings` configuration 

## PR checklist:
- [x] `docs/` updated 
- [x] tests added (Pipeline create/update all attributes amended with attribute/`build_pull_requests` to `true`)
- [x] an example added to `examples/` (useful to demo new field/resource) (nothing changed with resource implementation)
- [x] `CHANGELOG.md` updated with pending release information

Missing attribute of `provider_settings` that the Pipeline's provider settings schema had implemented but was asked about via the forum, wasn't included in docs/tests or examples previously which I've added here!