### PR TITLE
SUP-1390: Provider Settings conversion to a nested attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added `build_pull_request_ready_for_review` to pipeline resource docs/examples/tests [[PR #396](https://github.com/buildkite/terraform-provider-buildkite/pull/396)] @james2791
 - SUP-1370 Update to protocol v6 [[PR #400](https://github.com/buildkite/terraform-provider-buildkite/pull/400)] @jradtilbrook
 - SUP-1293 Generate docs from code [[PR #397](https://github.com/buildkite/terraform-provider-buildkite/pull/397)] @jradtilbrook
+- SUP-1390: Provider Settings conversion to a nested attribute [[PR #403](https://github.com/buildkite/terraform-provider-buildkite/pull/403)] @james2791
 
 The `team` block from the `buildkite_pipeline` resource has been removed. Please use the resource `buildkite_pipeline_team` to create and manage team configuration in a pipeline.
 

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -470,7 +470,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"provider_settings": schema.SingleNestedAttribute{
-				Optional: true,
+				Optional:            true,
+				MarkdownDescription: "Control settings depending on the VCS provider used in `repository`.",
 				Attributes: map[string]schema.Attribute{
 					"trigger_mode": schema.StringAttribute{
 						Computed: true,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -980,12 +980,12 @@ func upgradePipelineStateV0toV1(ctx context.Context, req resource.UpgradeStateRe
 		WebhookUrl:                           priorPipelineStateData.WebhookUrl,
 	}
 
-	// If the existing pipelines' state had ProviderSettings - set it as part of the V1 pipelineResourceModel 
+	// If the existing pipelines' state had ProviderSettings - set it as part of the V1 pipelineResourceModel
 	if len(priorPipelineStateData.ProviderSettings) == 1 {
 		upgradedPipelineStateData.ProviderSettings = priorPipelineStateData.ProviderSettings[0]
 	}
 
-	// Upgrade pipeline in state 
+	// Upgrade pipeline in state
 	diags := resp.State.Set(ctx, upgradedPipelineStateData)
 	resp.Diagnostics.Append(diags...)
 }

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -470,7 +470,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"provider_settings": schema.SingleNestedAttribute{
-				Required: false,
+				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"trigger_mode": schema.StringAttribute{
 						Computed: true,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1000,133 +1000,77 @@ func pipelineSchemaV0() schema.Schema {
 		`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The GraphQL ID of the pipeline.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
 			},
 			"allow_rebuilds": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(true),
-				MarkdownDescription: "Whether rebuilds are allowed for this pipeline.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
 			},
 			"cancel_intermediate_builds": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Whether to cancel builds when a new commit is pushed to a matching branch.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"cancel_intermediate_builds_branch_filter": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Filter the `cancel_intermediate_builds` setting based on this branch condition.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"branch_configuration": schema.StringAttribute{
-				MarkdownDescription: "Configure the pipeline to only build on this branch conditional.",
-				Optional:            true,
+				Optional: true,
 			},
 			"cluster_id": schema.StringAttribute{
-				MarkdownDescription: "Attach this pipeline to the given cluster GraphQL ID.",
-				Optional:            true,
+				Optional: true,
 			},
 			"default_branch": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Default branch of the pipeline.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"default_timeout_in_minutes": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             nil,
-				MarkdownDescription: "Set pipeline wide timeout for command steps.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
+				Default:  nil,
 			},
 			"maximum_timeout_in_minutes": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             nil,
-				MarkdownDescription: "Set pipeline wide maximum timeout for command steps.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
+				Default:  nil,
 			},
 			"description": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Description for the pipeline. Can include emoji 🙌.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "Name to give the pipeline.",
+				Required: true,
 			},
 			"repository": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "URL to the repository this pipeline is configured for.",
+				Required: true,
 			},
 			"skip_intermediate_builds": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Whether to skip queued builds if a new commit is pushed to a matching branch.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"skip_intermediate_builds_branch_filter": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Filter the `skip_intermediate_builds` setting based on this branch condition.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
+				Optional: true,
 			},
 			"slug": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The slug generated for the pipeline.",
-				PlanModifiers: []planmodifier.String{
-					custom_modifier.UseStateIfUnchanged("name"),
-				},
+				Computed: true,
 			},
 			"steps": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString(defaultSteps),
-				MarkdownDescription: "The YAML steps to configure for the pipeline. Defaults to `buildkite-agent pipeline upload`.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(defaultSteps),
 			},
 			"tags": schema.SetAttribute{
-				Optional:            true,
-				Computed:            true,
-				ElementType:         types.StringType,
-				Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
-				MarkdownDescription: "Tags to attribute to the pipeline. Useful for searching by in the UI.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
 			},
 			"webhook_url": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The webhook URL used to trigger builds from VCS providers.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
 			},
 			"badge_url": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The badge URL showing build state.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed: true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -1140,206 +1084,78 @@ func pipelineSchemaV0() schema.Schema {
 						"trigger_mode": schema.StringAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: heredoc.Docf(`
-								What type of event to trigger builds on. Must be one of:
-									- %s
-									- %s
-									- %s
-									- %s
-
-									-> %s is only valid if the pipeline uses a GitHub repository.
-							`,
-								"`code` will create builds when code is pushed to GitHub.",
-								"`deployment` will create builds when a deployment is created in GitHub.",
-								"`fork` will create builds when the GitHub repository is forked.",
-								"`none` will not create any builds based on GitHub activity.",
-								"`trigger_mode`",
-							),
-							Validators: []validator.String{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								stringvalidator.OneOf("code", "deployment", "fork", "none"),
-							},
 						},
 						"build_pull_requests": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							MarkdownDescription: "Whether to create builds for commits that are part part of a pull request." +
-								"Only valid for Bitbucket or GitHub using a `trigger_mode = \"code\"`",
-							Validators: []validator.Bool{
-								boolvalidator.Any(
-									pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderBitbucket),
-									boolvalidator.All(
-										pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-										boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-									),
-								),
-							},
 						},
 						"pull_request_branch_filter_enabled": schema.BoolAttribute{
-							Computed:            true,
-							Optional:            true,
-							MarkdownDescription: "Filter pull request builds. Only valid if `build_pull_requests = true`.",
-							Validators: []validator.Bool{
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
-							},
+							Computed: true,
+							Optional: true,
 						},
 						"pull_request_branch_filter_configuration": schema.StringAttribute{
-							Computed:            true,
-							Optional:            true,
-							MarkdownDescription: "Filter pull requests builds by the branch filter. Only valid if `pull_request_branch_filter_enabled = true`.",
-							Validators: []validator.String{
-								stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("pull_request_branch_filter_enabled"), true),
-							},
+							Computed: true,
+							Optional: true,
 						},
 						"skip_builds_for_existing_commits": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							MarkdownDescription: "Whether to skip creating a new build if an existing build for the commit and branch already exists." +
-								"Only valid for GitHub repositories.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							},
 						},
 						"skip_pull_request_builds_for_existing_commits": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							MarkdownDescription: "Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists." +
-								"Only valid if `build_pull_requests = true`.",
-							Validators: []validator.Bool{
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
-							},
 						},
 						"build_pull_request_ready_for_review": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Whether to create a build when a pull request changes to \"Ready for review\"." +
-								"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
-							},
 						},
 						"build_pull_request_labels_changed": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Whether to create builds for pull requests when labels are added or removed." +
-								"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
-							},
 						},
 						"build_pull_request_forks": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Whether to create builds for pull requests from third-party forks." +
-								"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
-							},
 						},
 						"prefix_pull_request_fork_branch_names": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions." +
-								"For example, the master branch from some-user will become some-user:master." +
-								"Only valid when `build_pull_request_forks = true`.",
-							Validators: []validator.Bool{
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_request_forks"), true),
-							},
 						},
 						"build_branches": schema.BoolAttribute{
-							Optional:            true,
-							Computed:            true,
-							MarkdownDescription: "Whether to create builds when branches are pushed. Only valid for GitHub and Bitbucket repositories.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub, pipelinevalidation.RepositoryProviderBitbucket),
-							},
+							Optional: true,
+							Computed: true,
 						},
 						"build_tags": schema.BoolAttribute{
-							Computed:            true,
-							Optional:            true,
-							MarkdownDescription: "Whether to create builds when tags are pushed. Only valid for GitHub and Bitbucket repositories.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub, pipelinevalidation.RepositoryProviderBitbucket),
-							},
+							Computed: true,
+							Optional: true,
 						},
 						"cancel_deleted_branch_builds": schema.BoolAttribute{
-							Computed:            true,
-							Optional:            true,
-							MarkdownDescription: "Automatically cancel running builds for a branch if the branch is deleted. Only valid for GitHub repositories when `trigger_mode = \"code\"`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-							},
+							Computed: true,
+							Optional: true,
 						},
 						"filter_enabled": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Whether to filter builds to only run when the condition in `filter_condition` is true." +
-								"Only valid for GitHub repositories when `trigger_mode = \"code\"`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-							},
 						},
 						"filter_condition": schema.StringAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "The condition to evaluate when deciding if a build should run." +
-								"More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines)." +
-								"Only valid if `filter_enabled = true`.",
-							Validators: []validator.String{
-								stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("filter_enabled"), true),
-							},
 						},
 						"publish_commit_status": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							MarkdownDescription: "Whether to update the status of commits in Bitbucket or GitHub." +
-								"Only valid for Bitbucket, or GitHub repositories when `trigger_mode = \"code\"`.",
-							Validators: []validator.Bool{
-								boolvalidator.Any(
-									pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderBitbucket),
-									boolvalidator.All(
-										pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-										boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-									),
-								),
-							},
 						},
 						"publish_blocked_as_pending": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks)" +
-								"to prevent merging pull requests with blocked builds. Only valid for GitHub repositories when `publish_commit_statue = true`.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
-							},
 						},
 						"publish_commit_status_per_step": schema.BoolAttribute{
-							Computed:            true,
-							Optional:            true,
-							MarkdownDescription: "Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub, pipelinevalidation.RepositoryProviderBitbucket),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
-							},
+							Computed: true,
+							Optional: true,
 						},
 						"separate_pull_request_statuses": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
-							MarkdownDescription: "Whether to create a separate status for pull request builds, allowing you to require a passing pull request" +
-								"build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.",
-							Validators: []validator.Bool{
-								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-								boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
-							},
 						},
 					},
 				},

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -505,7 +505,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderBitbucket),
 								boolvalidator.All(
 									pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-									boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
+									boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
 								),
 							),
 						},
@@ -515,7 +515,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						MarkdownDescription: "Filter pull request builds. Only valid if `build_pull_requests = true`.",
 						Validators: []validator.Bool{
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_requests"), true),
 						},
 					},
 					"pull_request_branch_filter_configuration": schema.StringAttribute{
@@ -523,7 +523,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						MarkdownDescription: "Filter pull requests builds by the branch filter. Only valid if `pull_request_branch_filter_enabled = true`.",
 						Validators: []validator.String{
-							stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("pull_request_branch_filter_enabled"), true),
+							stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("pull_request_branch_filter_enabled"), true),
 						},
 					},
 					"skip_builds_for_existing_commits": schema.BoolAttribute{
@@ -541,7 +541,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						MarkdownDescription: "Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists." +
 							"Only valid if `build_pull_requests = true`.",
 						Validators: []validator.Bool{
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_requests"), true),
 						},
 					},
 					"build_pull_request_ready_for_review": schema.BoolAttribute{
@@ -551,8 +551,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
+							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_requests"), true),
 						},
 					},
 					"build_pull_request_labels_changed": schema.BoolAttribute{
@@ -562,8 +562,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
+							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_requests"), true),
 						},
 					},
 					"build_pull_request_forks": schema.BoolAttribute{
@@ -573,8 +573,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"Only valid for GitHub repositories that have `trigger_mode = \"code\"` and `build_pull_requests = true`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_requests"), true),
+							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_requests"), true),
 						},
 					},
 					"prefix_pull_request_fork_branch_names": schema.BoolAttribute{
@@ -584,7 +584,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"For example, the master branch from some-user will become some-user:master." +
 							"Only valid when `build_pull_request_forks = true`.",
 						Validators: []validator.Bool{
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("build_pull_request_forks"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("build_pull_request_forks"), true),
 						},
 					},
 					"build_branches": schema.BoolAttribute{
@@ -609,7 +609,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						MarkdownDescription: "Automatically cancel running builds for a branch if the branch is deleted. Only valid for GitHub repositories when `trigger_mode = \"code\"`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
+							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
 						},
 					},
 					"filter_enabled": schema.BoolAttribute{
@@ -619,7 +619,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"Only valid for GitHub repositories when `trigger_mode = \"code\"`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
+							boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
 						},
 					},
 					"filter_condition": schema.StringAttribute{
@@ -629,7 +629,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines)." +
 							"Only valid if `filter_enabled = true`.",
 						Validators: []validator.String{
-							stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("filter_enabled"), true),
+							stringvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("filter_enabled"), true),
 						},
 					},
 					"publish_commit_status": schema.BoolAttribute{
@@ -642,7 +642,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 								pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderBitbucket),
 								boolvalidator.All(
 									pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-									boolvalidation.WhenString(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("trigger_mode"), "code"),
+									boolvalidation.WhenString(path.MatchRoot("provider_settings").AtName("trigger_mode"), "code"),
 								),
 							),
 						},
@@ -654,7 +654,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"to prevent merging pull requests with blocked builds. Only valid for GitHub repositories when `publish_commit_statue = true`.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("publish_commit_status"), true),
 						},
 					},
 					"publish_commit_status_per_step": schema.BoolAttribute{
@@ -663,7 +663,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						MarkdownDescription: "Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub, pipelinevalidation.RepositoryProviderBitbucket),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("publish_commit_status"), true),
 						},
 					},
 					"separate_pull_request_statuses": schema.BoolAttribute{
@@ -673,7 +673,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.",
 						Validators: []validator.Bool{
 							pipelinevalidation.WhenRepositoryProviderIs(pipelinevalidation.RepositoryProviderGitHub),
-							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtAnyListIndex().AtName("publish_commit_status"), true),
+							boolvalidation.WhenBool(path.MatchRoot("provider_settings").AtName("publish_commit_status"), true),
 						},
 					},
 				},

--- a/buildkite/resource_pipeline_team_test.go
+++ b/buildkite/resource_pipeline_team_test.go
@@ -137,6 +137,7 @@ func testAccPipelineTeamConfigBasic(teamName string, accessLevel string) string 
 	    name = "acctest pipeline %s"
 	    repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 	    steps = "steps:\n- label: ':pipeline: Pipeline Upload'\n  command: buildkite-agent pipeline upload"
+		provider_settings = {}
 	}
 
 	resource "buildkite_team" "acc_test_team" {
@@ -178,7 +179,6 @@ func testAccCheckPipelineTeamExists(resourceName string, tp *pipelineTeamResourc
 			if pipelineTeamNode == nil {
 				return fmt.Errorf("Error getting team pipeline: nil response")
 			}
-			fmt.Printf("pipeline access level in BK: %s", pipelineTeamNode.PipelineAccessLevel)
 			updateTeamPipelineResourceState(tp, *pipelineTeamNode)
 		}
 

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -438,7 +438,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					),
 				},
 				{
-					Config: configNested,
+					Config:                   configNested,
 					ProtoV6ProviderFactories: protoV6ProviderFactories(),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -396,7 +396,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
-	t.Run("pipeline provider_settings updated from v0 to v1", func(t *testing.T) {
+	t.Run("empty provider_settings updated from v0 to v1", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 
 		config := fmt.Sprintf(`
@@ -434,6 +434,123 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
+		)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck: func() { testAccPreCheck(t) },
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"buildkite": {
+							Source:            "registry.terraform.io/buildkite/buildkite",
+							VersionConstraint: "0.27.0",
+						},
+					},
+					Check: check,
+				},
+				{
+					Config:                   configNested,
+					ProtoV6ProviderFactories: protoV6ProviderFactories(),
+					Check:                    checkNested,
+					// We expect an empty plan and no action on the pipeline resource before applying nested provider_settings config
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionNoop),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("filled provider_settings updated from v0 to v1", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+
+		config := fmt.Sprintf(`
+			resource "buildkite_pipeline" "pipeline" {
+				name = "%s"
+				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+				provider_settings {
+					trigger_mode = "code"
+					build_pull_requests = true
+					skip_builds_for_existing_commits = true
+					build_branches = true
+					build_tags = true
+					build_pull_request_ready_for_review = true
+					cancel_deleted_branch_builds = true
+					filter_enabled = true
+					filter_condition = "true"
+					publish_commit_status = true
+					publish_blocked_as_pending = true
+					publish_commit_status_per_step = true
+					separate_pull_request_statuses = true
+				}
+			}
+		`, pipelineName)
+
+		configNested := fmt.Sprintf(`
+			resource "buildkite_pipeline" "pipeline" {
+				name = "%s"
+				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+				provider_settings = {
+					trigger_mode = "code"
+					build_pull_requests = true
+					skip_builds_for_existing_commits = true
+					build_branches = true
+					build_tags = true
+					build_pull_request_ready_for_review = true
+					cancel_deleted_branch_builds = true
+					filter_enabled = true
+					filter_condition = "true"
+					publish_commit_status = true
+					publish_blocked_as_pending = true
+					publish_commit_status_per_step = true
+					separate_pull_request_statuses = true
+				}
+			}
+		`, pipelineName)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+			// Ensure that v0 pipeline's provider_settings is a list of length 1 in state, attributes set and are at index 0
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_ready_for_review", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_tags", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.cancel_deleted_branch_builds", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_condition", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_enabled", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_blocked_as_pending", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status_per_step", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.separate_pull_request_statuses", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_builds_for_existing_commits", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.trigger_mode", "code"),
+		)
+
+		checkNested := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+			// Ensure that v1 pipeline's provider_settings set attributes are nested in state when upgraded from v0
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "code"),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -395,4 +395,62 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("pipeline provider_settings updated from v0 to v1", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+
+		config := fmt.Sprintf(`
+			resource "buildkite_pipeline" "pipeline" {
+				name = "%s"
+				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+				provider_settings {}
+			}
+		`, pipelineName)
+
+		configNested := fmt.Sprintf(`
+			resource "buildkite_pipeline" "pipeline" {
+				name = "%s"
+				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+				provider_settings = {}
+			}
+		`, pipelineName)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck: func() { testAccPreCheck(t) },
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"buildkite": {
+							Source:            "registry.terraform.io/buildkite/buildkite",
+							VersionConstraint: "0.27.0",
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+						// Ensure that v0 pipeline's provider_settings is a list of length 1 in state & defaulted attributes are at index 0
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "true"),
+					),
+				},
+				{
+					Config: configNested,
+					ProtoV6ProviderFactories: protoV6ProviderFactories(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+						// Ensure that v1 pipeline's provider_settings defaulted attributes are nested in state when upgraded from v0
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
+					),
+				},
+			},
+		})
+	})
 }

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -108,7 +108,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 				name = "%s"
 				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 				tags = []
-				provider_settings {}
+				provider_settings = {}
 			}
 		`, pipelineName)
 
@@ -136,12 +136,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.trigger_mode", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", ""),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
 					),
 				},
 			},
@@ -170,7 +169,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 				skip_intermediate_builds = true
 				skip_intermediate_builds_branch_filter = "!main"
 				tags = ["llama"]
-				provider_settings {
+				provider_settings = {
 					trigger_mode = "code"
 					build_pull_requests = true
 					skip_builds_for_existing_commits = true
@@ -207,19 +206,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "description", "terraform test"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", "!main"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.trigger_mode", "code"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_builds_for_existing_commits", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_tags", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_ready_for_review", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.cancel_deleted_branch_builds", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_enabled", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_condition", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_blocked_as_pending", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status_per_step", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.separate_pull_request_statuses", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "code"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "true"),
 					),
 				},
 			},
@@ -270,7 +269,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							skip_intermediate_builds = true
 							skip_intermediate_builds_branch_filter = "!main"
 							tags = ["llama"]
-							provider_settings {
+							provider_settings = {
 								trigger_mode = "code"
 								build_pull_requests = true
 								skip_builds_for_existing_commits = true

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -415,6 +415,27 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			}
 		`, pipelineName)
 
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+			// Ensure that v0 pipeline's provider_settings is a list of length 1 in state & defaulted attributes are at index 0
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "true"),
+		)
+
+		checkNested := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+			// Ensure that v1 pipeline's provider_settings defaulted attributes are nested in state when upgraded from v0
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
+		)
+
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck: func() { testAccPreCheck(t) },
 			Steps: []resource.TestStep{
@@ -426,29 +447,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							VersionConstraint: "0.27.0",
 						},
 					},
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
-						// Ensure that v0 pipeline's provider_settings is a list of length 1 in state & defaulted attributes are at index 0
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "true"),
-					),
+					Check: check,
 				},
 				{
 					Config:                   configNested,
 					ProtoV6ProviderFactories: protoV6ProviderFactories(),
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
-						// Ensure that v1 pipeline's provider_settings defaulted attributes are nested in state when upgraded from v0
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
-					),
+					Check:                    checkNested,
+					// We expect an empty plan and no action on the pipeline resource before applying nested provider_settings config
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionNoop),
+						},
+					},
 				},
 			},
 		})

--- a/docs/guides/upgrade-v1.md
+++ b/docs/guides/upgrade-v1.md
@@ -76,6 +76,8 @@ resource "buildkite_pipeline" "pipeline" {
 }
 ```
 
+~> The upgrade for a pipeline's `provider_settings` as part of 1.0 from a block to nested attribute is designed to be a forward moving event. However, if you require moving back to using a Buildkite Terraform provider version earlier than 1.0 after upgrading your pipeline resources with nested attributed `provider_settings`, various options exist. If you have access to state files, you can roll back to a backup managing pipelines using the older block `provider_settings` (with `"schema_version": 0`), converting each pipeline resource's `provider_settings` configuration back to a block and planning against the older provider version. Alternatively, you can remove the pipeline from state and re-import it once the provider downgrade has occurred.
+
 ### Consistent IDs across resources
 All resources now use their GraphQL IDs as the primary ID in the schema.
 

--- a/docs/guides/upgrade-v1.md
+++ b/docs/guides/upgrade-v1.md
@@ -50,7 +50,7 @@ provider "buildkite" {
 
 ### Pipeline resource `provider_settings` type change
 The `provider_settings` attribute on the pipeline resource has been completely overhauled. It is now a nested attribute
-(thanks to protocol v6) and has validation on inner attributes.
+(thanks to protocol v6) and has validation on its inner attributes.
 
 Previously:
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -55,7 +55,7 @@ resource "buildkite_pipeline" "pipeline" {
 - `default_timeout_in_minutes` (Number) Set pipeline wide timeout for command steps.
 - `description` (String) Description for the pipeline. Can include emoji 🙌.
 - `maximum_timeout_in_minutes` (Number) Set pipeline wide maximum timeout for command steps.
-- `provider_settings` (Attributes) Control settings depending on the VCS provider used in `repository`. (see [below for nested schema](#nestedblock--provider_settings))
+- `provider_settings` (Attributes) Control settings depending on the VCS provider used in `repository`. (see [below for nested schema](#nestedatt--provider_settings))
 - `skip_intermediate_builds` (Boolean) Whether to skip queued builds if a new commit is pushed to a matching branch.
 - `skip_intermediate_builds_branch_filter` (String) Filter the `skip_intermediate_builds` setting based on this branch condition.
 - `steps` (String) The YAML steps to configure for the pipeline. Defaults to `buildkite-agent pipeline upload`.
@@ -68,7 +68,7 @@ resource "buildkite_pipeline" "pipeline" {
 - `slug` (String) The slug generated for the pipeline.
 - `webhook_url` (String) The webhook URL used to trigger builds from VCS providers.
 
-<a id="nestedblock--provider_settings"></a>
+<a id="nestedatt--provider_settings"></a>
 ### Nested Schema for `provider_settings`
 
 Optional:

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -27,7 +27,7 @@ resource "buildkite_pipeline" "pipeline" {
   name       = "repo"
   repository = "git@github.com:org/repo"
 
-  provider_settings {
+  provider_settings = {
     build_branches      = false
     build_tags          = true
     build_pull_requests = false
@@ -55,7 +55,7 @@ resource "buildkite_pipeline" "pipeline" {
 - `default_timeout_in_minutes` (Number) Set pipeline wide timeout for command steps.
 - `description` (String) Description for the pipeline. Can include emoji 🙌.
 - `maximum_timeout_in_minutes` (Number) Set pipeline wide maximum timeout for command steps.
-- `provider_settings` (Block List) Control settings depending on the VCS provider used in `repository`. (see [below for nested schema](#nestedblock--provider_settings))
+- `provider_settings` (Attributes) Control settings depending on the VCS provider used in `repository`. (see [below for nested schema](#nestedblock--provider_settings))
 - `skip_intermediate_builds` (Boolean) Whether to skip queued builds if a new commit is pushed to a matching branch.
 - `skip_intermediate_builds_branch_filter` (String) Filter the `skip_intermediate_builds` setting based on this branch condition.
 - `steps` (String) The YAML steps to configure for the pipeline. Defaults to `buildkite-agent pipeline upload`.

--- a/examples/resources/buildkite_pipeline/resource.tf
+++ b/examples/resources/buildkite_pipeline/resource.tf
@@ -9,7 +9,7 @@ resource "buildkite_pipeline" "pipeline" {
   name       = "repo"
   repository = "git@github.com:org/repo"
 
-  provider_settings {
+  provider_settings = {
     build_branches      = false
     build_tags          = true
     build_pull_requests = false

--- a/templates/guides/upgrade-v1.md
+++ b/templates/guides/upgrade-v1.md
@@ -76,6 +76,8 @@ resource "buildkite_pipeline" "pipeline" {
 }
 ```
 
+~> The upgrade for a pipeline's `provider_settings` as part of 1.0 from a block to nested attribute is designed to be a forward moving event. However, if you require moving back to using a Buildkite Terraform provider version earlier than 1.0 after upgrading your pipeline resources with nested attributed `provider_settings`, various options exist. If you have access to state files, you can roll back to a backup managing pipelines using the older block `provider_settings` (with `"schema_version": 0`), converting each pipeline resource's `provider_settings` configuration back to a block and planning against the older provider version. Alternatively, you can remove the pipeline from state and re-import it once the provider downgrade has occurred. 
+
 ### Consistent IDs across resources
 All resources now use their GraphQL IDs as the primary ID in the schema.
 

--- a/templates/guides/upgrade-v1.md
+++ b/templates/guides/upgrade-v1.md
@@ -50,7 +50,7 @@ provider "buildkite" {
 
 ### Pipeline resource `provider_settings` type change
 The `provider_settings` attribute on the pipeline resource has been completely overhauled. It is now a nested attribute
-(thanks to protocol v6) and has validation on inner attributes.
+(thanks to protocol v6) and has validation on its inner attributes.
 
 Previously:
 


### PR DESCRIPTION
refactor(pipeline resource): Migration of `provider_settings` from a block to a nested attribute

## PR checklist:
- [x] `docs/` updated -> V1 guides from previous, updated pipeline resource docs and V1 upgrade guide with a note on forward moving migration from block->nested attributes 
- [x] tests added -> with `ExternalProviders` - creating pipeline empty and filled `provider_settings` and migrating their state from schema version `0` to `1`)
- [x] an example added to `examples/` (useful to demo new field/resource) -> Adjusted examples with the nested attribute (`provider_settings = {}` implementation)
- [x] `CHANGELOG.md` updated with pending release information

This change converts the `provider_settings` block (pipeline schema version `0`) to a nested attribute (schema version `1` with Terraform Plugin Framework's `UpgradeState` functionality. With this change, there is only the schema version `0`->`1` upgrade, but can be added to the [StateUpgrader](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.4.0/resource#StateUpgrader) map specifying newer schema updates (with a corresponding prior versioned schema and state upgrade function)

Both tests written are using the `ExternalProviders` capability to create a pipeline with block `provider_settings` (one with default attributes, the other with set) - which both are upgraded to the new schema version (`1`) and which the test confirms the migration to a nested attribute (and all existing configuration is kept).