### PR TITLE
Dont set provider_settings if not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
  
+## [v1.0.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.0.0...v1.0.1)
+
+- Dont set provider_settings if not defined [[PR #411](https://github.com/buildkite/terraform-provider-buildkite/pull/411)] @jradtilbrook
+
 ## [v1.0.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.27.0...v1.0.0) 🎉
 
 We are thrilled to release v1.0 of the Buildkite Terraform provider. This is the culmination of years of development and

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -764,7 +764,6 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
-		state.ProviderSettings = new(providerSettingsModel)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)


### PR DESCRIPTION

## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information
