### PR TITLE
Add archivePipelineOnDelete field to client

### DIFF
--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -18,22 +18,24 @@ import (
 
 // Client can be used to interact with the Buildkite API
 type Client struct {
-	graphql        *graphql.Client
-	genqlient      genqlient.Client
-	http           *http.Client
-	organization   string
-	organizationId string
-	restUrl        string
-	timeouts       timeouts.Value
+	graphql                 *graphql.Client
+	genqlient               genqlient.Client
+	http                    *http.Client
+	organization            string
+	organizationId          string
+	restUrl                 string
+	timeouts                timeouts.Value
+	archivePipelineOnDelete bool
 }
 
 type clientConfig struct {
-	org        string
-	apiToken   string
-	graphqlURL string
-	restURL    string
-	userAgent  string
-	timeouts   timeouts.Value
+	org                     string
+	apiToken                string
+	graphqlURL              string
+	restURL                 string
+	userAgent               string
+	timeouts                timeouts.Value
+	archivePipelineOnDelete bool
 }
 
 type headerRoundTripper struct {
@@ -64,13 +66,14 @@ func NewClient(config *clientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		graphql:        graphqlClient,
-		genqlient:      genqlient.NewClient(config.graphqlURL, httpClient),
-		http:           httpClient,
-		organization:   config.org,
-		organizationId: orgId,
-		restUrl:        config.restURL,
-		timeouts:       config.timeouts,
+		graphql:                 graphqlClient,
+		genqlient:               genqlient.NewClient(config.graphqlURL, httpClient),
+		http:                    httpClient,
+		organization:            config.org,
+		organizationId:          orgId,
+		restUrl:                 config.restURL,
+		timeouts:                config.timeouts,
+		archivePipelineOnDelete: config.archivePipelineOnDelete,
 	}, nil
 }
 

--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -32,8 +32,7 @@ const (
 )
 
 type terraformProvider struct {
-	version                 string
-	archivePipelineOnDelete bool
+	version string
 }
 
 type providerModel struct {
@@ -48,7 +47,6 @@ type providerModel struct {
 func (tf *terraformProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var data providerModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	tf.archivePipelineOnDelete = data.ArchivePipelineOnDelete.ValueBool()
 
 	apiToken := os.Getenv("BUILDKITE_API_TOKEN")
 	graphqlUrl := defaultGraphqlEndpoint
@@ -73,12 +71,13 @@ func (tf *terraformProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	config := clientConfig{
-		apiToken:   apiToken,
-		graphqlURL: graphqlUrl,
-		org:        organization,
-		restURL:    restUrl,
-		timeouts:   data.Timeouts,
-		userAgent:  userAgent("buildkite", tf.version, req.TerraformVersion),
+		apiToken:                apiToken,
+		graphqlURL:              graphqlUrl,
+		org:                     organization,
+		restURL:                 restUrl,
+		timeouts:                data.Timeouts,
+		userAgent:               userAgent("buildkite", tf.version, req.TerraformVersion),
+		archivePipelineOnDelete: data.ArchivePipelineOnDelete.ValueBool(),
 	}
 	client, err := NewClient(&config)
 
@@ -134,7 +133,7 @@ func (tf *terraformProvider) Resources(context.Context) []func() resource.Resour
 		newClusterResource,
 		newDefaultQueueClusterResource,
 		newOrganizationResource,
-		newPipelineResource(tf.archivePipelineOnDelete),
+		newPipelineResource,
 		newTeamMemberResource,
 		newTeamResource,
 		newTestSuiteResource,

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -112,8 +112,7 @@ type providerSettingsModel struct {
 }
 
 type pipelineResource struct {
-	client          *Client
-	archiveOnDelete bool
+	client *Client
 }
 
 type pipelineResponse interface {
@@ -137,12 +136,8 @@ type pipelineResponse interface {
 	GetWebhookURL() string
 }
 
-func newPipelineResource(archiveOnDelete bool) func() resource.Resource {
-	return func() resource.Resource {
-		return &pipelineResource{
-			archiveOnDelete: archiveOnDelete,
-		}
-	}
+func newPipelineResource() resource.Resource {
+	return &pipelineResource{}
 }
 
 func (p *pipelineResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -242,7 +237,7 @@ func (p *pipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	if p.archiveOnDelete {
+	if p.client.archivePipelineOnDelete {
 		log.Printf("Pipeline %s set to archive on delete. Archiving...", state.Name.ValueString())
 
 		err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {


### PR DESCRIPTION
This commit addresses #421 by storing the configuration of whether
the provider archives a pipeline on deletion or not in the `Client` type.
This matches how the other configuration fields on the provider are
saved. I'm not very familiar with the Terraform plugin framework so I'm
not sure this is the best way to address the issue, but since the change
was relatively straightforward I figured I might as well open a PR for it
to make the discussion easier.