### PR TITLE
Fix Teams resource documentation

### DIFF
--- a/buildkite/resource_team.go
+++ b/buildkite/resource_team.go
@@ -65,8 +65,8 @@ func (t *teamResource) Configure(ctx context.Context, req resource.ConfigureRequ
 
 func (t *teamResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = resource_schema.Schema{
-		MarkdownDescription: "A Cluster is a group of Agents that can be used to run your builds. " +
-			"Clusters are useful for grouping Agents by their capabilities, such as operating system, hardware, or location. ",
+		MarkdownDescription: "A Team is a group of users that can be given permissions for using Pipelines." +
+			"This feature is only available to Business and Enterprise customers.  You can find out more about Teams in the Buildkite [documentation](https://buildkite.com/docs/team-management/permissions).",
 		Attributes: map[string]resource_schema.Attribute{
 			"id": resource_schema.StringAttribute{
 				Computed:            true,

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -3,12 +3,12 @@
 page_title: "buildkite_team Resource - terraform-provider-buildkite"
 subcategory: ""
 description: |-
-  A Cluster is a group of Agents that can be used to run your builds. Clusters are useful for grouping Agents by their capabilities, such as operating system, hardware, or location.
+  A Team is a group of users that can be given permissions for using Pipelines.This feature is only available to Business and Enterprise customers.  You can find out more about Teams in the Buildkite documentation https://buildkite.com/docs/team-management/permissions.
 ---
 
 # buildkite_team (Resource)
 
-A Cluster is a group of Agents that can be used to run your builds. Clusters are useful for grouping Agents by their capabilities, such as operating system, hardware, or location.
+A Team is a group of users that can be given permissions for using Pipelines.This feature is only available to Business and Enterprise customers.  You can find out more about Teams in the Buildkite [documentation](https://buildkite.com/docs/team-management/permissions).
 
 ## Example Usage
 


### PR DESCRIPTION
The current MarkdownDescription for the Teams resource references the Cluster documentation.  This PR fixes the description of the resource and links to the appropriate part of the Buildkite docs.