### PR TITLE
SUP-1711: Pipeline template data source docs format

### DIFF
--- a/docs/data-sources/pipeline_template.md
+++ b/docs/data-sources/pipeline_template.md
@@ -21,11 +21,11 @@ locals {
 }
 
 data "buildkite_pipeline_template" "dev_template" {
-	  id = buildkite_pipeline_template.template_dev.id
+  id = buildkite_pipeline_template.template_dev.id
 }
 
 data "buildkite_pipeline_template" "frontend_template" {
-	  name = "Frontend app template"
+	name = "Frontend app template"
 }
 
 

--- a/docs/data-sources/pipeline_template.md
+++ b/docs/data-sources/pipeline_template.md
@@ -25,7 +25,7 @@ data "buildkite_pipeline_template" "dev_template" {
 }
 
 data "buildkite_pipeline_template" "frontend_template" {
-	name = "Frontend app template"
+  name = "Frontend app template"
 }
 
 

--- a/examples/data-sources/buildkite_pipeline_template/data-source.tf
+++ b/examples/data-sources/buildkite_pipeline_template/data-source.tf
@@ -3,11 +3,11 @@ locals {
 }
 
 data "buildkite_pipeline_template" "dev_template" {
-	  id = buildkite_pipeline_template.template_dev.id
+  id = buildkite_pipeline_template.template_dev.id
 }
 
 data "buildkite_pipeline_template" "frontend_template" {
-	  name = "Frontend app template"
+	name = "Frontend app template"
 }
 
 

--- a/examples/data-sources/buildkite_pipeline_template/data-source.tf
+++ b/examples/data-sources/buildkite_pipeline_template/data-source.tf
@@ -7,7 +7,7 @@ data "buildkite_pipeline_template" "dev_template" {
 }
 
 data "buildkite_pipeline_template" "frontend_template" {
-	name = "Frontend app template"
+  name = "Frontend app template"
 }
 
 


### PR DESCRIPTION
Docs (Pipeline data source: Pipeline template data source docs format

## PR checklist:
- [x] `docs/` updated
- [ ] tests added -> **Both pipeline resource and pipeline template datasource tests**
- [ ] an example added to `examples/` (useful to demo new field/resource)
- [ ] `CHANGELOG.md` updated with pending release information

Spacing on the pipeline template data source examples was indented a bit too much; reverted to 2 space indentation for consistency