### PR TITLE
Ignore default team in teams block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.27.2](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.27.1...v0.27.2)
+
+- Ignore default team in teams block [[PR #484](https://github.com/buildkite/terraform-provider-buildkite/pull/484)] @jradtilbrook
+
 ## [v0.27.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v0.27.0...v0.27.1)
 
 - SUP-1853 backport default_team_id to 0.27 [[PR #481](https://github.com/buildkite/terraform-provider-buildkite/pull/481)] @jradtilbrook


### PR DESCRIPTION
## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

The release for 0.27.1 has an issue where the default team ends up being included in the teams block in state and then failing verification from terraform. This adds checks for the default team so that it is not included in state