### PR TITLE
SUP-1851 Get pipeline webhook from REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- SUP-1851 Get pipeline webhook from REST API [[PR #485](https://github.com/buildkite/terraform-provider-buildkite/pull/485)] @jradtilbrook
+
 ## [v1.4.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.4.0...v1.4.1)
 
 - Update state upgrade functionality to match v0.27.1 [[PR #483](https://github.com/buildkite/terraform-provider-buildkite/pull/483)] @jradtilbrook

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -350,6 +350,13 @@ func (p *pipelineResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 		setPipelineModel(&state, pipelineNode)
 
+		// set the webhook url if its not empty
+		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
+		// state value alone assuming it was previously set correctly
+		if extraInfo.Provider.WebhookUrl != "" {
+			state.WebhookUrl = types.StringValue(extraInfo.Provider.WebhookUrl)
+		}
+
 		if state.ProviderSettings != nil {
 			updatePipelineResourceExtraInfo(&state, extraInfo)
 		}
@@ -829,6 +836,12 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		}
 
 		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+		// set the webhook url if its not empty
+		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
+		// state value alone assuming it was previously set correctly
+		if pipelineExtraInfo.Provider.WebhookUrl != "" {
+			state.WebhookUrl = types.StringValue(pipelineExtraInfo.Provider.WebhookUrl)
+		}
 	} else {
 		// no provider_settings provided, but we still need to read in the badge url
 		extraInfo, err := getPipelineExtraInfo(ctx, p.client, response.PipelineUpdate.Pipeline.Slug, timeouts)
@@ -837,6 +850,12 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
+		// set the webhook url if its not empty
+		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
+		// state value alone assuming it was previously set correctly
+		if extraInfo.Provider.WebhookUrl != "" {
+			state.WebhookUrl = types.StringValue(extraInfo.Provider.WebhookUrl)
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -914,7 +933,8 @@ func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
 type PipelineExtraInfo struct {
 	BadgeUrl string `json:"badge_url"`
 	Provider struct {
-		Settings PipelineExtraSettings `json:"settings"`
+		WebhookUrl string                `json:"webhook_url"`
+		Settings   PipelineExtraSettings `json:"settings"`
 	} `json:"provider"`
 }
 type PipelineExtraSettings struct {


### PR DESCRIPTION
## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

The graphql API returns an error when trying to query webhook URL after creation for security, however, the REST API will return an empty string if the token is not allowed. So it still returns a successful response.  
We can use this to resolve the webhook URL of a pipeline optimistially when reading the pipeline

Resolves #480.
