### PR TITLE
SUP-1877: Team datasource docs/example tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- SUP-1877: Team datasource docs/example tweaks [[PR #487](https://github.com/buildkite/terraform-provider-buildkite/pull/487)] @james2791
+
 ## [v1.4.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.4.0...v1.4.1)
 
 - Update state upgrade functionality to match v0.27.1 [[PR #483](https://github.com/buildkite/terraform-provider-buildkite/pull/483)] @jradtilbrook

--- a/buildkite/data_source_team.go
+++ b/buildkite/data_source_team.go
@@ -53,7 +53,7 @@ func (t *teamDatasource) Schema(ctx context.Context, req datasource.SchemaReques
 		`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "The ID of the team to find. Use either ID or slug.",
+				MarkdownDescription: "The GraphQL ID of the team to find.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -68,7 +68,7 @@ func (t *teamDatasource) Schema(ctx context.Context, req datasource.SchemaReques
 				Computed:            true,
 			},
 			"slug": schema.StringAttribute{
-				MarkdownDescription: "The slug of the team to find. Use either ID or slug.",
+				MarkdownDescription: "The slug of the team to find.",
 				Computed:            true,
 				Optional:            true,
 			},

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -15,8 +15,12 @@ Use this data source to retrieve a team by slug or id. You can find out more abo
 ## Example Usage
 
 ```terraform
+data "buildkite_team" "team-dev" {
+  id = buildkite_team.team_dev.id
+}
+
 data "buildkite_team" "team" {
-  id = "Everyone"
+  slug = "Everyone"
 }
 ```
 
@@ -25,8 +29,8 @@ data "buildkite_team" "team" {
 
 ### Optional
 
-- `id` (String) The ID of the team to find. Use either ID or slug.
-- `slug` (String) The slug of the team to find. Use either ID or slug.
+- `id` (String) The GraphQL ID of the team to find.
+- `slug` (String) The slug of the team to find.
 
 ### Read-Only
 

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -15,7 +15,7 @@ Use this data source to retrieve a team by slug or id. You can find out more abo
 ## Example Usage
 
 ```terraform
-data "buildkite_team" "team-dev" {
+data "buildkite_team" "team_dev" {
   id = buildkite_team.team_dev.id
 }
 

--- a/examples/data-sources/buildkite_team/data-source.tf
+++ b/examples/data-sources/buildkite_team/data-source.tf
@@ -1,3 +1,7 @@
+data "buildkite_team" "team-dev" {
+  id = buildkite_team.team_dev.id
+}
+
 data "buildkite_team" "team" {
-  id = "Everyone"
+  slug = "Everyone"
 }

--- a/examples/data-sources/buildkite_team/data-source.tf
+++ b/examples/data-sources/buildkite_team/data-source.tf
@@ -1,4 +1,4 @@
-data "buildkite_team" "team-dev" {
+data "buildkite_team" "team_dev" {
   id = buildkite_team.team_dev.id
 }
 


### PR DESCRIPTION
Docs (Team data source) : Team data source example/description tweak

## PR checklist:
- [x] `docs/` updated
- [ ] tests added -> **Functionality remains the same, no tests altered**
- [x] an example added to `examples/` (useful to demo new field/resource)
- [x] `CHANGELOG.md` updated with pending release information

Folks might get confounded on the mention of the team datasource's `id` or `slug` (within each's Markdown description) that they can  "`Use either ID or slug`" - and might use either attribute in stand for one-another, breaking their underlying `node`/`team` queries.

Small tweak to the descriptions/examples to make it more clear that its exclusive between the two attributes.