### PR TITLE
SUP-1906 Error on apply when provider_settings is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Unreleased changes
+- Update tests resolving an error when `provider_settings` attribute is omitted or set to null [[PR #510](https://github.com/buildkite/terraform-provider-buildkite/pull/510)] @lizrabuya
+
 ## [v1.5.2](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.5.1...v1.5.2)
 
 - Update docs with default values for `provider_settings` attributes [[PR #494](https://github.com/buildkite/terraform-provider-buildkite/pull/494)] @lizrabuya

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -658,4 +658,54 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("provider_settings attributes can be removed without state change", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		clusterName := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_cluster" "cluster" {
+							name = "%s"
+						}					
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+							provider_settings = {
+								trigger_mode = "none" 
+							}
+						}
+					`, clusterName, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_cluster" "cluster" {
+							name = "%s"
+						}
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+							cluster_id = buildkite_cluster.cluster.id   
+						}
+					`, clusterName, pipelineName),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionNoop),
+						},
+					},
+				},
+			},
+		})
+	})
+
 }

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -695,6 +695,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							name = "%s"
 							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 							cluster_id = buildkite_cluster.cluster.id   
+							provider_settings = {}							
 						}
 					`, clusterName, pipelineName),
 					ConfigPlanChecks: resource.ConfigPlanChecks{


### PR DESCRIPTION
The error raised here happens  when setting  the `provider_settings` to null or omitting it from the configuration file and these changes to the terraform state file is applied.  Terraform is expecting `provider_settings` as null, but the provider applies values to the `provider_settings` by retrieving them from the actual infrastructure through api. Since the `provider_settings` default values are set at the infrastructure level, these values will always be reflected into the state file.

This is an expected behaviour. The `provider_settings` cannot be set to null when it already exists on the terraform state file as it is not a computed attribute. Our schema only defines it as `Optional` and not `Computed`.  However, we cannot set it to `Computed:true` since this will also mean that `provider_settings` will not be configurable, and changes can only be applied directly from the actual infrastructure and not from configuration. This becomes a change in behaviour of the provider. 

There are two workarounds:
1. run terraform plan -refresh-only so terraform will only compare what is in the current state file with the actual infrastructure state and ignore that `provider_settings` is set to null from the file - means that if it is omitted, just keep what is in the state
2. set provider_settings to {} in the terraform configuration, the result is similar as 1. Since provider_settings is not null, the provider will fetch throuh api the infrastructure's provider_settings and compare it with what is in the state. 

I have added a test scenario to reflect this using the second workaround. 

- First test shows that the process actually fails as reflected in this commit - [6483ecf](https://github.com/buildkite/terraform-provider-buildkite/pull/510/commits/6483ecf36dc21826a85aad5ad835dc111e1cfdd1)
- Second test shows the workaround implemented at the configuration level to avoid the error and still have the state file updated with what is in the infrastructure - [b52b184](https://github.com/buildkite/terraform-provider-buildkite/pull/510/commits/b52b184460cec8f4ed7a0e963c5204bb96eed586) 

## PR checklist: 
- [x] tests added 
- [x] `CHANGELOG.md` updated with pending release information