### PR TITLE
Fix importing of gpg key used for release signing

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -27,7 +27,7 @@ then
       exit 1
 fi
 
-echo "${GPG_SECRET_KEY_ASCII}" | gpg --import --no-tty --batch --yes
+echo -e "${GPG_SECRET_KEY_ASCII}" | gpg --import --no-tty --batch --yes
 
 gpg --list-secret-keys
 


### PR DESCRIPTION
The gpg key is stored in as ASCII armord format with new lines escaped, like:

    MjAxMjMxMmFkZWZnMjIK\nOTMwNDA0MDRlZWVmYQo=

We need echo to process the escaped newlines before piping it to gpg, so gpg sees:

    MjAxMjMxMmFkZWZnMjIK
    OTMwNDA0MDRlZWVmYQo=