### PR TITLE
Windows ARM64 is deprecated in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
## Changes
- In our release we attempt to build Windows ARM64, but that's deprecated as of Go 1.17

Ref: https://goreleaser.com/deprecations/#builds-for-windowsarm64
