### PR TITLE
Fix pipeline steps default on update

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -593,7 +593,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 								- %s
 								- %s
 
-								-> %s is only valid if the pipeline uses a GitHub repository. 
+								-> %s is only valid if the pipeline uses a GitHub repository.
 								-> If not set, the default value is %s and other provider settings defaults are applied.
 						`,
 							"`code` will create builds when code is pushed to GitHub.",
@@ -717,22 +717,18 @@ func (p *pipelineResource) UpgradeState(ctx context.Context) map[int64]resource.
 }
 
 func (p *pipelineResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Only modify plan on pipeline creation
-	if req.State.Raw.IsNull() {
+	// Don't modify on destroy, but otherwise make sure the steps default is preserved
+	if !req.Plan.Raw.IsNull() {
 		var template, steps types.String
 
 		// Load pipeline_template_id and steps (if defined)
 		req.Plan.GetAttribute(ctx, path.Root("pipeline_template_id"), &template)
 		req.Plan.GetAttribute(ctx, path.Root("steps"), &steps)
 
-		// Set default steps only if there is no template oe defined steps
+		// Set default steps only if there is no template or defined steps
 		if template.IsNull() && (steps.IsUnknown() || steps.IsNull()) {
 			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("steps"), defaultSteps)...)
-			return
 		}
-	} else {
-		// Do nothing on other plan operations (update, delete)
-		return
 	}
 }
 

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -119,6 +119,55 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
+	t.Run("update pipeline with only required attributes", func(t *testing.T) {
+		var pipeline getPipelinePipeline
+		pipelineName := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+						}
+					`, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						// check api values are expected
+						func(s *terraform.State) error {
+							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
+							pipeline = resp.Pipeline
+							return err
+						},
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
+					),
+				},
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider.git"
+						}
+					`, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						// check the pipeline IDs are the same (so it wasn't recreated)
+						func(s *terraform.State) error {
+							p := s.RootModule().Resources["buildkite_pipeline.pipeline"]
+							if p.Primary.ID != pipeline.Id {
+								return fmt.Errorf("Pipelines do not match: %s %s", pipeline.Id, p.Primary.ID)
+							}
+							return nil
+						},
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("create pipeline with a pipeline template", func(t *testing.T) {
 		var pipeline getPipelinePipeline
 		pipelineName := acctest.RandString(12)
@@ -671,12 +720,12 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					Config: fmt.Sprintf(`
 						resource "buildkite_cluster" "cluster" {
 							name = "%s"
-						}					
+						}
 						resource "buildkite_pipeline" "pipeline" {
 							name = "%s"
 							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 							provider_settings = {
-								trigger_mode = "none" 
+								trigger_mode = "none"
 							}
 						}
 					`, clusterName, pipelineName),
@@ -694,8 +743,8 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource "buildkite_pipeline" "pipeline" {
 							name = "%s"
 							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
-							cluster_id = buildkite_cluster.cluster.id   
-							provider_settings = {}							
+							cluster_id = buildkite_cluster.cluster.id
+							provider_settings = {}
 						}
 					`, clusterName, pipelineName),
 					ConfigPlanChecks: resource.ConfigPlanChecks{


### PR DESCRIPTION
The refactor in #474 didn't account for updates on pipelines that previously relied on the default setting of `steps` - this ensures it's always set if not otherwise provided.