### PR TITLE
Refactor to remove hard coded goreleaser architecture

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
           format: junit
 
   - label: build
-    command: "make"
+    command: "make build-snapshot"
     agents:
       queue: "hosted"
     plugins:

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -23,8 +23,8 @@ echo "--- importing GPG Secret Key"
 
 if [ -z "$GPG_SECRET_KEY_BASE64" ]
 then
-      echo "\$GPG_SECRET_KEY_BASE64 env variable must contain a base64 encoded GPG secret key"
-      exit 1
+    echo "\$GPG_SECRET_KEY_BASE64 env variable must contain a base64 encoded GPG secret key"
+    exit 1
 fi
 
 echo "${GPG_SECRET_KEY_BASE64}" |base64 -d | gpg --import --no-tty --batch --yes
@@ -39,22 +39,12 @@ echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}"
 echo "--- Checking GitHub Token"
 if [ -z "$GITHUB_TOKEN" ]
 then
-      echo "\$GITHUB_TOKEN env variable must contain a Github API token with permission to create releases in buildkite/terraform-provider-buildkite"
-      exit 1
+    echo "\$GITHUB_TOKEN env variable must contain a Github API token with permission to create releases in buildkite/terraform-provider-buildkite"
+    exit 1
 fi
-
-echo "--- installing goreleaser"
-
-curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v1.7.0/goreleaser_Linux_x86_64.tar.gz
-
-cd /tmp && echo "e74934e7571991522324642ac7b032310f04baf192ce2a54db1dc323b97bcd7d  goreleaser_Linux_x86_64.tar.gz" | sha256sum -c
-
-tar -zxvf goreleaser_Linux_x86_64.tar.gz
-
-cp goreleaser /work
 
 cd /work
 
 echo "--- running goreleaser"
 
-./goreleaser release --rm-dist
+goreleaser release --rm-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ RUN apt-get update \
     && apt-get install -y unzip
 
 COPY --from=hashicorp/terraform:1.4@sha256:5ca7188b7566703fd96c6f84c27d8e7aa4fe1c690803157264b8569580a99712 /bin/terraform /usr/local/bin/terraform
+COPY --from=goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3 /usr/bin/goreleaser /usr/local/bin/goreleaser

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ default: build
 build:
 	go build -o terraform-provider-buildkite -ldflags="-s -w -X main.version=$(shell git describe --tag)" .
 
+.PHONY: build-snapshot
+build-snapshot:
+	goreleaser build --snapshot --clean
+
 .PHONY: docs
 docs:
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs


### PR DESCRIPTION
This change is primarily focused on the goreleaser configuration, which is updated as follows:

1. Remove the installation process and follow the pattern used to install terraform using docker copy, and a method
   which will automatically cover other architectures such as arm64.
2. Ensure goreleaser configuration is validated during builds to avoid release build only failures.
3. This also leans on the signature of the goreleaser docker container to pin the artifact in a similar way to
   terraform.

Hopefully these refinements can be also be used to improve other projects using goreleaser and buildkite.
