### PR TITLE
SUP-2356: update interpolate version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- SUP-2356: update interpolate version [[PR 547#](https://github.com/buildkite/terraform-provider-buildkite/pull/547)] @tomowatt
+
 ## [v1.10.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.9.0...v1.10.0)
 
 - Improve handling of steps and changing outside TF [[PR #539](https://github.com/buildkite/terraform-provider-buildkite/pull/539)] @jradtilbrook

--- a/buildkite/data_source_signed_pipeline_steps_test.go
+++ b/buildkite/data_source_signed_pipeline_steps_test.go
@@ -125,9 +125,9 @@ func TestAccBuildkiteSignedPipelineStepsDataSource(t *testing.T) {
 	t.Run("signed pipeline steps with escaped interpolations regex", func(t *testing.T) {
 		pipelineWithEscapedInterpolations := heredoc.Doc(`
 			steps:
-			- label: ":pipeline:"	
-				command: buildkite-agent pipeline upload
-				if: 'pipeline.slug !~ /^.+-main\$/'
+			- label: ":pipeline:"
+			  command: buildkite-agent pipeline upload
+			  if: 'pipeline.slug !~ /^.+-main\$/'
 		`)
 
 		resource.ParallelTest(t, resource.TestCase{

--- a/buildkite/data_source_signed_pipeline_steps_test.go
+++ b/buildkite/data_source_signed_pipeline_steps_test.go
@@ -126,8 +126,8 @@ func TestAccBuildkiteSignedPipelineStepsDataSource(t *testing.T) {
 		pipelineWithEscapedInterpolations := heredoc.Doc(`
 			steps:
 			- label: ":pipeline:"	
-  			  command: buildkite-agent pipeline upload
-			  if: pipeline.slug !~ /^.+-main\$/
+				command: buildkite-agent pipeline upload
+				if: 'pipeline.slug !~ /^.+-main\$/'
 		`)
 
 		resource.ParallelTest(t, resource.TestCase{

--- a/buildkite/data_source_signed_pipeline_steps_test.go
+++ b/buildkite/data_source_signed_pipeline_steps_test.go
@@ -150,10 +150,9 @@ func TestAccBuildkiteSignedPipelineStepsDataSource(t *testing.T) {
 						pipelineWithEscapedInterpolations,
 					),
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(
+						resource.TestCheckResourceAttrSet(
 							"data.buildkite_signed_pipeline_steps.my_signed_steps",
 							"steps",
-							string(pipelineWithEscapedInterpolations),
 						),
 					),
 				},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 require (
 	github.com/Khan/genqlient v0.6.0
 	github.com/buildkite/go-pipeline v0.4.1
-	github.com/buildkite/interpolate v0.1.2
+	github.com/buildkite/interpolate v0.1.3
 	github.com/hashicorp/terraform-plugin-framework v1.3.5
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/buildkite/go-pipeline v0.4.1 h1:RZ1afSHOt5mUcTzhFab0WxKm90vvJsOUAPpfQBETgkE=
 github.com/buildkite/go-pipeline v0.4.1/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
-github.com/buildkite/interpolate v0.1.2 h1:mVbMCphpu2MHUr1qLdjq9xc3NjNWYg/w/CbrGS5ckzg=
-github.com/buildkite/interpolate v0.1.2/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
+github.com/buildkite/interpolate v0.1.3 h1:OFEhqji1rNTRg0u9DsSodg63sjJQEb1uWbENq9fUOBM=
+github.com/buildkite/interpolate v0.1.3/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=


### PR DESCRIPTION
for fix with escaped interpolations affecting signed pipelines data sources that have escaped interpolations that should be text e.g., regex

Related library update:
https://github.com/buildkite/interpolate/releases/tag/v0.1.3