### PR TITLE
SUP-2495: Update Resources to be replaced if Cluster ID changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Adding a feature request template for better issue management/submission [[PR #549](https://github.com/buildkite/terraform-provider-buildkite/pull/549)] @mcncl
+- SUP-2495: Update Resources to be replaced if Cluster ID changes [[PR #554](https://github.com/buildkite/terraform-provider-buildkite/pull/554)] @tomowatt
+
 ## [v1.10.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.10.0...v1.10.1)
 
 - Fix nil reference error when err may be nil [[PR #546](https://github.com/buildkite/terraform-provider-buildkite/pull/546)] @mcncl

--- a/buildkite/resource_cluster_agent_token.go
+++ b/buildkite/resource_cluster_agent_token.go
@@ -80,6 +80,9 @@ func (ct *clusterAgentToken) Schema(_ context.Context, _ resource.SchemaRequest,
 			"cluster_id": resource_schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The GraphQL ID of the Cluster that this Cluster Agent Token belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"cluster_uuid": resource_schema.StringAttribute{
 				Computed:            true,

--- a/buildkite/resource_cluster_default_queue.go
+++ b/buildkite/resource_cluster_default_queue.go
@@ -211,6 +211,9 @@ func (c *clusterDefaultQueueResource) Schema(ctx context.Context, req resource.S
 			"cluster_id": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The GraphQL ID of the cluster to which to add a default queue.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"queue_id": schema.StringAttribute{
 				Required:            true,

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -72,6 +72,9 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 			"cluster_id": resource_schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The ID of the cluster that this cluster queue belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"key": resource_schema.StringAttribute{
 				Required:            true,


### PR DESCRIPTION
Agent Tokens and (Default) Queues cannot be moved between Clusters so any attempt via Terraform should force the Resources to be replaced if the Cluster ID changes.