### PR TITLE
SUP-2536: Asserting pipeline template datasource attributes on its tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix: Pipeliine template datasource tests asserting datasource attributes
+- SUP-2536: Asserting pipeline template datasource attributes on tests [[PR #559](https://github.com/buildkite/terraform-provider-buildkite/pull/559)] @james2791
 
 ## [v1.10.2](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.10.1...v1.10.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: Pipeliine template datasource tests asserting datasource attributes
+
 ## [v1.10.2](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.10.1...v1.10.2)
 
 - Adding a feature request template for better issue management/submission [[PR #549](https://github.com/buildkite/terraform-provider-buildkite/pull/549)] @mcncl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- SUP-2536: Asserting pipeline template datasource attributes on tests [[PR #559](https://github.com/buildkite/terraform-provider-buildkite/pull/559)] @james2791
+- SUP-2536: Asserting pipeline template datasource attributes on its tests [[PR #559](https://github.com/buildkite/terraform-provider-buildkite/pull/559)] @james2791
 
 ## [v1.10.2](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.10.1...v1.10.2)
 

--- a/buildkite/data_source_pipeline_template_test.go
+++ b/buildkite/data_source_pipeline_template_test.go
@@ -27,7 +27,7 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			configuration = "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\""
 		}
 
-		data "buildkite_pipeline_template" "data_template_foo" {
+		data "buildkite_pipeline_template" "template_foo" {
 			depends_on = [buildkite_pipeline_template.template_foo]
 			id = buildkite_pipeline_template.template_foo.id
 		}
@@ -50,7 +50,7 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			configuration = "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\""
 		}
 
-		data "buildkite_pipeline_template" "data_template_bar" {
+		data "buildkite_pipeline_template" "template_bar" {
 			depends_on = [buildkite_pipeline_template.template_bar]
 			name = "Template %s"
 		}
@@ -73,7 +73,7 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			configuration = "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\""
 		}
 
-		data "buildkite_pipeline_template" "data_template_bar" {
+		data "buildkite_pipeline_template" "template_bar" {
 			depends_on = [buildkite_pipeline_template.template_bar]
 			name = "Template %s"
 		}
@@ -96,7 +96,7 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			configuration = "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\""
 		}
 
-		data "buildkite_pipeline_template" "data_template_bar" {
+		data "buildkite_pipeline_template" "template_bar" {
 			depends_on = [buildkite_pipeline_template.template_bar]
 			id = buildkite_pipeline_template.template_bar.id
 			name = "Template %s"
@@ -114,10 +114,10 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			// Confirm the pipeline template has the correct values in Buildkite's system
 			testAccCheckPipelineTemplateRemoteValues(&ptr, fmt.Sprintf("Template %s", randName), false),
 			// Check all pipeline template resource attributes are set in state (required attributes)
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_foo", "id"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_foo", "uuid"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_foo", "name"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_foo", "configuration"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_foo", "id"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_foo", "uuid"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_foo", "name"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_foo", "configuration"),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{
@@ -143,10 +143,10 @@ func TestAccBuildkitePipelineTemplateDatasource(t *testing.T) {
 			// Confirm the pipeline template has the correct values in Buildkite's system
 			testAccCheckPipelineTemplateRemoteValues(&ptr, fmt.Sprintf("Template %s", randName), false),
 			// Check all pipeline template resource attributes are set in state (required attributes)
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_bar", "id"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_bar", "uuid"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_bar", "name"),
-			resource.TestCheckResourceAttrSet("buildkite_pipeline_template.template_bar", "configuration"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_bar", "id"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_bar", "uuid"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_bar", "name"),
+			resource.TestCheckResourceAttrSet("data.buildkite_pipeline_template.template_bar", "configuration"),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Fix(Pipeline Template datasource): Corrected attribute checks against created pipeline template datasources within its tests. The tests were previously checking the resource attributes for both of the `id` and `name` variants, which have been corrected. 

## PR checklist:
- [ ] `docs/` updated **N/A: Fixes up pipeline template datasource tests - not consumable**
- [x] tests added
- [ ] an example added to `examples/` (useful to demo new field/resource) - **N/A No examples changed**
- [x] `CHANGELOG.md` updated with pending release information

