### PR TITLE
SUP-2774: Stop panicking on organization rule updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- SUP-2744: Stop panicking on organization rule updates [[PR #584](https://github.com/buildkite/terraform-provider-buildkite/pull/584)] @james2791
+
 ## [v1.13.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.12.0...v1.13.0)
 
 - Support cluster queue dispatch pausing [[PR #573](https://github.com/buildkite/terraform-provider-buildkite/pull/573)] @mcncl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- SUP-2744: Stop panicking on organization rule updates [[PR #584](https://github.com/buildkite/terraform-provider-buildkite/pull/584)] @james2791
+- SUP-2774: Stop panicking on organization rule updates [[PR #584](https://github.com/buildkite/terraform-provider-buildkite/pull/584)] @james2791
 
 ## [v1.13.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.12.0...v1.13.0)
 

--- a/buildkite/resource_organization_rule.go
+++ b/buildkite/resource_organization_rule.go
@@ -312,7 +312,6 @@ func (or *organizationRuleResource) ImportState(ctx context.Context, req resourc
 
 func (or *organizationRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	resp.Diagnostics.AddError("Cannot update an organization rule", "An existing rule must be deleted/re-created")
-	panic("cannot update an organization rule")
 }
 
 func (or *organizationRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Bug/Fix(Organization rules resource/): A quick amendment with an inclusive test case for `buildkite_organization_rule` resources not to `panic` when trying to update a rule in its current form.

The provider will now relay the diagnostic error that was surfaced before panicking, and thus presenting that to applies of such deltas.

## Test Coverage
I've added a test that creates a rule with all attributes (`configAllCustomDescription`), then tries to update the `description` of that created rule, which will be caught by regex and pass accordingly.