### PR TITLE
chore: update CODEOWNERS to GitHub Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mcncl @lizrabuya @PriyaSudip @tomowatt
+* @buildkite/terraform-technical-services


### PR DESCRIPTION
to make it easier to manage the CODEOWNERS externally rather than needing to create PRs to update the file