### PR TITLE
SUP-2813: correct logic for pausing/resuming Dispatch on Queues and remove error with Default Cluster Queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- SUP-2813: correct logic for pausing/resuming Dispatch on Queues and remove error with Default Cluster Queues [[PR #593](https://github.com/buildkite/terraform-provider-buildkite/pull/593)] @tomowatt
+
 ## [v1.14.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.13.1...v1.14.0)
 
 - Bump docker/library/golang from 1.23.2 to 1.23.3 [[PR #587](https://github.com/buildkite/terraform-provider-buildkite/pull/587)] @dependabot

--- a/buildkite/resource_cluster_default_queue.go
+++ b/buildkite/resource_cluster_default_queue.go
@@ -161,13 +161,6 @@ func (c *clusterDefaultQueueResource) Read(ctx context.Context, req resource.Rea
 			)
 			return
 		}
-		if clusterNode.DefaultQueue == nil {
-			resp.Diagnostics.AddError(
-				"Cannot find a default queue for this cluster",
-				"No default queue is assigned to the cluster",
-			)
-			return
-		}
 		state.ClusterId = types.StringValue(clusterNode.Id)
 		state.UUID = types.StringValue(clusterNode.Uuid)
 		state.QueueId = types.StringValue(clusterNode.DefaultQueue.Id)

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -226,16 +226,10 @@ func (cq *clusterQueueResource) ImportState(ctx context.Context, req resource.Im
 
 func (cq *clusterQueueResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state clusterQueueResourceModel
-	var description types.String
 	var planDispatchPaused, stateDispatchPaused bool
 
-	diagsState := req.State.Get(ctx, &state)
-	diagsDescription := req.Plan.GetAttribute(ctx, path.Root("description"), &description)
-
-	// Load state and obtain description from plan (singularly)
-	resp.Diagnostics.Append(diagsState...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(diagsDescription...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -310,7 +304,7 @@ func (cq *clusterQueueResource) Update(ctx context.Context, req resource.UpdateR
 				cq.client.genqlient,
 				*org,
 				state.Id.ValueString(),
-				description.ValueStringPointer(),
+				plan.Description.ValueStringPointer(),
 			)
 		}
 

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -146,8 +146,15 @@ func (cq *clusterQueueResource) Create(ctx context.Context, req resource.CreateR
 	state.ClusterUuid = types.StringValue(r.ClusterQueueCreate.ClusterQueue.Cluster.Uuid)
 	state.Key = types.StringValue(r.ClusterQueueCreate.ClusterQueue.Key)
 	state.Description = types.StringPointerValue(r.ClusterQueueCreate.ClusterQueue.Description)
-	state.DispatchPaused = plan.DispatchPaused
 
+	// GraphQL API does not allow Cluster Queue to be created with Dispatch Paused
+	if plan.DispatchPaused.ValueBool() {
+		resp.Diagnostics.AddWarning(
+			"Cluster Queue cannot be created with Dispatch Paused",
+			"Setting dispatch_paused in State to 'true' but requires re-run of Apply",
+		)
+	}
+	state.DispatchPaused = plan.DispatchPaused
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -114,8 +114,6 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 				{
 					Config: configBasic(clusterName, queueKey, updatedQueueDesc),
 					Check:  checkUpdated,
-					// Destroying a queue will pause its dispatch
-					ExpectNonEmptyPlan: true,
 				},
 			},
 		})

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -112,9 +112,8 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 					Check:  check,
 				},
 				{
-					Config:       configBasic(clusterName, queueKey, updatedQueueDesc),
-					Check:        checkUpdated,
-					RefreshState: true,
+					Config: configBasic(clusterName, queueKey, updatedQueueDesc),
+					Check:  checkUpdated,
 					// Destroying a queue will pause its dispatch
 					ExpectNonEmptyPlan: true,
 				},

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -112,8 +112,9 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 					Check:  check,
 				},
 				{
-					Config: configBasic(clusterName, queueKey, updatedQueueDesc),
-					Check:  checkUpdated,
+					Config:       configBasic(clusterName, queueKey, updatedQueueDesc),
+					Check:        checkUpdated,
+					RefreshState: true,
 					// Destroying a queue will pause its dispatch
 					ExpectNonEmptyPlan: true,
 				},

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -36,6 +36,29 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 		`, fields[0], fields[1], fields[2])
 	}
 
+	configBasicDispatch := func(fields ...string) string {
+		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts = {
+				create = "10s"
+				read = "10s"
+				update = "10s"
+				delete = "10s"
+			}
+		}
+		resource "buildkite_cluster" "cluster_test" {
+			name = "Test cluster %s"
+			description = "Acceptance testing cluster"
+		}
+		resource "buildkite_cluster_queue" "foobar" {
+			cluster_id = buildkite_cluster.cluster_test.id
+			key = "queue-%s"
+			description = "Acceptance test %s"
+			dispatch_paused = "%s"
+		}
+		`, fields[0], fields[1], fields[2], fields[3])
+	}
+
 	t.Run("creates a cluster queue", func(t *testing.T) {
 		var cq clusterQueueResourceModel
 		clusterName := acctest.RandString(10)
@@ -113,6 +136,48 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 				},
 				{
 					Config: configBasic(clusterName, queueKey, updatedQueueDesc),
+					Check:  checkUpdated,
+				},
+			},
+		})
+	})
+
+	t.Run("pause dispatch on a cluster queue", func(t *testing.T) {
+		var cq clusterQueueResourceModel
+		clusterName := acctest.RandString(10)
+		queueKey := acctest.RandString(10)
+		queueDesc := acctest.RandString(10)
+		check := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the cluster queue exists in the buildkite API
+			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
+			// Confirm the cluster queue has the correct values in Buildkite's system
+			testAccCheckClusterQueueRemoteValues(&cq, fmt.Sprintf("Acceptance test %s", queueDesc), fmt.Sprintf("queue-%s", queueKey)),
+			// Confirm the cluster queue has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "key", fmt.Sprintf("queue-%s", queueKey)),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "description", fmt.Sprintf("Acceptance test %s", queueDesc)),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "dispatch_paused", "false"),
+		)
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
+			// Confirm the cluster queue exists in the buildkite API
+			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
+			// Confirm the cluster queue has the correct values in Buildkite's system
+			testAccCheckClusterQueueRemoteValues(&cq, fmt.Sprintf("Acceptance test %s", queueDesc), fmt.Sprintf("queue-%s", queueKey)),
+			// Confirm the cluster queue has the correct values in terraform state
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "key", fmt.Sprintf("queue-%s", queueKey)),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "description", fmt.Sprintf("Acceptance test %s", queueDesc)),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "dispatch_paused", "true"),
+		)
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckClusterQueueDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: configBasicDispatch(clusterName, queueKey, queueDesc, "false"),
+					Check:  check,
+				},
+				{
+					Config: configBasicDispatch(clusterName, queueKey, queueDesc, "true"),
 					Check:  checkUpdated,
 				},
 			},


### PR DESCRIPTION
* removed `isPausible` as it would trigger Pausing when the Description was updated and State `DispatchedPaused = false`
* compare Plan and State values to pause/resume dispatch else do nothing, which stops changes to the `Description` causing the Queue to be paused
* `r.ClusterQueueUpdate.ClusterQueue.DispatchPaused` is nil at the time of the original logic resulting in `panic: runtime error: invalid memory address or nil pointer dereference` so changed to the Plan Value to be used for clarity else could be hardcoded as `state.DispatchPaused = types.BoolValue(true)` or `state.DispatchPaused = types.BoolValue(false)` (where appropritate)
* Remove error raised when a Cluster Queue doesn't have a Default Queue defined as there is an error with the API when updating a Queue resulting it in being removed as Default. But Clusters do not require a Default Queue being set so error not required.
* Add Warning as Queues cannot be created with `dispatch_paused = true` due to limitation with API.

Includes fixes for https://github.com/buildkite/terraform-provider-buildkite/issues/591 though there is a API issue resulting in the changes of Default Queues during updates to the Cluster Queue
