### PR TITLE
SUP-2591: add PlanModifiers when Hosted Agent attributes changed

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -137,6 +138,9 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 				Validators: []validator.Object{
 					&hostedAgentValidator{},
 				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]resource_schema.Attribute{
 					"mac": resource_schema.SingleNestedAttribute{
 						Optional: true,
@@ -175,6 +179,9 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 								LinuxARM64InstanceLarge,
 								LinuxARM64InstanceXLarge,
 							),
+						},
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 				},

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -159,8 +159,6 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 						}
 
 						rrifr.RequiresReplace = false
-						return
-
 					}, "Recreates the resource if the hosted_agents attribute is added or removed.", "Recreates the resource if the hosted_agents attribute is added or removed."),
 				},
 				Attributes: map[string]resource_schema.Attribute{


### PR DESCRIPTION
* Queues cannot change from Self-Hosted to Hosted (and vice-versa) so Resource should be recreated
* instance_shape cannot be updated in-place so Resource should be recreated to change it