### PR TITLE
Fix state management on updating the hosted_agents configuration of a cluster queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## Unreleased
 
+- Update golang.org/x/net [[PR #599](https://github.com/buildkite/terraform-provider-buildkite/pull/599)] @yob
+- Fix state management on updating the hosted_agents configuration of a cluster queue [[PR #600](https://github.com/buildkite/terraform-provider-buildkite/pull/600)] @CerealBoy
+- SUP-2591: add PlanModifiers when Hosted Agent attributes [[PR #598](https://github.com/buildkite/terraform-provider-buildkite/pull/598)] @tomowatt
+
+## [v1.15.1]()
+
+- SUP-2591: add PlanModifiers when Hosted Agent attributes [[PR #598](https://github.com/buildkite/terraform-provider-buildkite/pull/598)] @tomowatt
+- Adding more examples for working with cluster queues [[PR #597](https://github.com/buildkite/terraform-provider-buildkite/pull/597)] @CerealBoy
+
+## [v1.15.0]()
+
+- Bump golang.org/x/crypto from 0.25.0 to 0.31.0 [[PR #594](https://github.com/buildkite/terraform-provider-buildkite/pull/594)] @dependabot
 - SUP-2813: correct logic for pausing/resuming Dispatch on Queues and remove error with Default Cluster Queues [[PR #593](https://github.com/buildkite/terraform-provider-buildkite/pull/593)] @tomowatt
 - Adding cluster queue support for hosted agents [[PR #596](https://github.com/buildkite/terraform-provider-buildkite/pull/596)] @CerealBoy
-- Adding more examples for working with cluster queues [[PR #597](https://github.com/buildkite/terraform-provider-buildkite/pull/597)] @CerealBoy
 
 ## [v1.14.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.13.1...v1.14.0)
 

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -472,11 +472,15 @@ func (cq *clusterQueueResource) Update(ctx context.Context, req resource.UpdateR
 	state.DispatchPaused = types.BoolValue(r.ClusterQueueUpdate.ClusterQueue.DispatchPaused)
 	if state.HostedAgents != nil {
 		state.HostedAgents.InstanceShape = types.StringValue(string(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.InstanceShape.Name))
-		if state.HostedAgents.Mac != nil {
-			state.HostedAgents.Mac.XcodeVersion = types.StringValue(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.PlatformSettings.Macos.XcodeVersion)
+		if plan.HostedAgents.Mac != nil {
+			state.HostedAgents.Mac = &macConfigModel{
+				XcodeVersion: types.StringValue(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.PlatformSettings.Macos.XcodeVersion),
+			}
 		}
-		if state.HostedAgents.Linux != nil {
-			state.HostedAgents.Linux.ImageAgentRef = types.StringValue(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.PlatformSettings.Linux.AgentImageRef)
+		if plan.HostedAgents.Linux != nil {
+			state.HostedAgents.Linux = &linuxConfigModel{
+				ImageAgentRef: types.StringValue(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.PlatformSettings.Linux.AgentImageRef),
+			}
 		}
 	}
 


### PR DESCRIPTION
Initially the `Update` would only capture and update the state by checking if state already existed, which meant that if no linux or mac configuration was provided in the create, it would never be stored in an update (an `agent_image_ref` couldn't be added to an existing queue).

This fix is to validate against the plan, setting the state appropriately as the plan generated it.

I also updated the `CHANGELOG.md` to clean up the past few PRs.