### PR TITLE
SUP-2777 - Allow configurable pipeline slugs

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1019,10 +1019,11 @@ func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
 	model.Tags = tags
 }
 
-// As of May 21, 2021, GraphQL Pipeline is lacking support for the following properties:
+// As of December 23, 2024, `pipelineCreate` and `pipelineUpdate` GraphQL Mutations are lacking support the following properties:
 // - badge_url
 // - provider_settings
-// We fallback to REST API
+// - slug
+// We fallback to REST API for secondary calls to set/update these properties.
 
 // PipelineExtraInfo is used to manage pipeline attributes that are not exposed via GraphQL API.
 type PipelineExtraInfo struct {

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -269,6 +269,7 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 			resp.Diagnostics.AddError("Unable to read pipeline info from REST", err.Error())
 			return
 		}
+		state.Slug = types.StringValue(extraInfo.Slug)
 		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
 		state.ProviderSettings = plan.ProviderSettings
 	}

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 	"unsafe"
 
@@ -236,6 +237,22 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 	setPipelineModel(&state, &response.PipelineCreate.Pipeline)
 	state.WebhookUrl = types.StringValue(response.PipelineCreate.Pipeline.GetWebhookURL())
 	state.DefaultTeamId = plan.DefaultTeamId
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
+
+	var useSlugValue string
+	if len(plan.Slug.ValueString()) > 0 {
+		useSlugValue = plan.Slug.ValueString()
+
+		pipelineExtraInfo, err := updatePipelineSlug(ctx, response.PipelineCreate.Pipeline.Slug, useSlugValue, p.client, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
+			return
+		}
+
+		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+		state.Slug = types.StringValue(useSlugValue)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
+	}
 
 	if plan.ProviderSettings != nil {
 		pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, response.PipelineCreate.Pipeline.Slug, plan.ProviderSettings, p.client, timeouts)
@@ -253,6 +270,7 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
+		state.ProviderSettings = plan.ProviderSettings
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -536,9 +554,17 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"slug": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The slug generated for the pipeline.",
+				Optional:            true,
+				MarkdownDescription: "A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If not provided, the slug will be [derived](https://buildkite.com/docs/apis/graphql/cookbooks/pipelines#create-a-pipeline-deriving-a-pipeline-slug-from-the-pipelines-name) from the pipeline `name`.",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 100),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z0-9\-]+$`),
+						"can only contain lowercase characters, numbers and hyphens",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
-					custom_modifier.UseStateIfUnchanged("name"),
+					custom_modifier.UseDerivedPipelineSlug(),
 				},
 			},
 			"steps": schema.StringAttribute{
@@ -828,7 +854,29 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	var useSlugValue string
+	if len(plan.Slug.ValueString()) > 0 {
+		useSlugValue = plan.Slug.ValueString()
+	} else {
+		useSlugValue = response.PipelineUpdate.Pipeline.Slug
+	}
+
+	pipelineExtraInfo, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
+		return
+	}
+
+	updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
 	setPipelineModel(&state, &response.PipelineUpdate.Pipeline)
+
+	state.Slug = types.StringValue(useSlugValue)
+	if len(plan.Slug.ValueString()) > 0 {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
+	}
 
 	if plan.DefaultTeamId.IsNull() && !state.DefaultTeamId.IsNull() {
 		// if the plan is empty but was previously set, just remove the team
@@ -881,12 +929,14 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		}
 	} else {
 		// no provider_settings provided, but we still need to read in the badge url
+
 		extraInfo, err := getPipelineExtraInfo(ctx, p.client, response.PipelineUpdate.Pipeline.Slug, timeouts)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to read pipeline info from REST", err.Error())
 			return
 		}
 		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
+		state.ProviderSettings = plan.ProviderSettings
 		// set the webhook url if its not empty
 		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
 		// state value alone assuming it was previously set correctly
@@ -949,7 +999,6 @@ func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
 	model.Repository = types.StringValue(data.GetRepository().Url)
 	model.SkipIntermediateBuilds = types.BoolValue(data.GetSkipIntermediateBuilds())
 	model.SkipIntermediateBuildsBranchFilter = types.StringValue(data.GetSkipIntermediateBuildsBranchFilter())
-	model.Slug = types.StringValue(data.GetSlug())
 	model.UUID = types.StringValue(data.GetPipelineUuid())
 
 	// only set template or steps. steps is always updated even if using a template, but its redundant and creates
@@ -981,7 +1030,13 @@ type PipelineExtraInfo struct {
 		WebhookUrl string                `json:"webhook_url"`
 		Settings   PipelineExtraSettings `json:"settings"`
 	} `json:"provider"`
+	Slug string `json:"slug"`
 }
+
+type PipelineSlug struct {
+	Slug string `json:"slug"`
+}
+
 type PipelineExtraSettings struct {
 	TriggerMode                             *string `json:"trigger_mode,omitempty"`
 	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
@@ -1018,6 +1073,27 @@ func getPipelineExtraInfo(ctx context.Context, client *Client, slug string, time
 
 	return &pipelineExtraInfo, nil
 }
+
+func updatePipelineSlug(ctx context.Context, slug string, updatedSlug string, client *Client, timeouts time.Duration) (PipelineExtraInfo, error) {
+	payload := PipelineSlug{
+		Slug: updatedSlug,
+	}
+
+	pipelineExtraInfo := PipelineExtraInfo{}
+
+	if len(updatedSlug) > 0 {
+		err := retry.RetryContext(ctx, timeouts, func() *retry.RetryError {
+			err := client.makeRequest(ctx, "PATCH", fmt.Sprintf("/v2/organizations/%s/pipelines/%s", client.organization, slug), payload, &pipelineExtraInfo)
+			return retryContextError(err)
+		})
+
+		if err != nil {
+			return pipelineExtraInfo, err
+		}
+	}
+	return pipelineExtraInfo, nil
+}
+
 func updatePipelineExtraInfo(ctx context.Context, slug string, settings *providerSettingsModel, client *Client, timeouts time.Duration) (PipelineExtraInfo, error) {
 	payload := map[string]any{
 		"provider_settings": PipelineExtraSettings{

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -77,7 +77,6 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check computed values get set
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "badge_url"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "id"),
-						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "slug"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "uuid"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "webhook_url"),
 						// check api values are expected
@@ -102,6 +101,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", ""),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprint(strings.ToLower(pipelineName))),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
 						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
@@ -168,7 +168,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
-	t.Run("create pipeline with user-defined slug", func(t *testing.T) {
+	t.Run("create pipeline with user defined slug", func(t *testing.T) {
 		var pipeline getPipelinePipeline
 		pipelineName := acctest.RandString(12)
 		slugName := strings.ToLower(acctest.RandString(12))
@@ -224,16 +224,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#"),
 					),
 				},
-				{
-					ResourceName:  "buildkite_pipeline.pipeline",
-					ImportState:   true,
-					ImportStateId: pipeline.Id,
-				},
 			},
 		})
 	})
 
-	t.Run("update pipeline with user-defined slug", func(t *testing.T) {
+	t.Run("update pipeline with user defined slug", func(t *testing.T) {
 		var pipeline getPipelinePipeline
 		pipelineName := acctest.RandString(12)
 		slugName := strings.ToLower(acctest.RandString(12))
@@ -288,7 +283,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
-	t.Run("set user-defined slug for existing pipeline", func(t *testing.T) {
+	t.Run("set user defined slug for existing pipeline", func(t *testing.T) {
 		var pipeline getPipelinePipeline
 		pipelineName := acctest.RandString(12)
 		slugName := strings.ToLower(acctest.RandString(12))
@@ -340,9 +335,10 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
-	t.Run("remove user-defined slug from existing pipeline", func(t *testing.T) {
+	t.Run("remove user defined slug from existing pipeline", func(t *testing.T) {
 		var pipeline getPipelinePipeline
-		pipelineName := fmt.Sprintf("TesT --- PipeLine - %s", acctest.RandString(12))
+		pipelineId := acctest.RandString(12)
+		pipelineName := fmt.Sprintf("TesT --- PipeLine - %s", pipelineId)
 		slugName := strings.ToLower(acctest.RandString(12))
 
 		resource.ParallelTest(t, resource.TestCase{
@@ -387,7 +383,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							return nil
 						},
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprintf("test-pipeline-%s", strings.ToLower(slugName))),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprintf("test-pipeline-%s", strings.ToLower(pipelineId))),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
 					),
 				},
@@ -425,7 +421,6 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "badge_url"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "id"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "steps"),
-						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "slug"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "uuid"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "webhook_url"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "pipeline_template_id"),
@@ -452,6 +447,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", ""),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprint(strings.ToLower(pipelineName))),
 
 						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -190,7 +190,6 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check computed values get set
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "badge_url"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "id"),
-						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "slug"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "uuid"),
 						resource.TestCheckResourceAttrSet("buildkite_pipeline.pipeline", "webhook_url"),
 						// check api values are expected

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -356,7 +356,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						// check api values are expected
 						func(s *terraform.State) error {
-							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
+							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), slugName)
 							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
 							pipeline = resp.Pipeline
 							return err

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -87,6 +87,7 @@ resource "buildkite_pipeline" "signed-pipeline" {
 - `provider_settings` (Attributes) Control settings depending on the VCS provider used in `repository`. (see [below for nested schema](#nestedatt--provider_settings))
 - `skip_intermediate_builds` (Boolean) Whether to skip queued builds if a new commit is pushed to a matching branch.
 - `skip_intermediate_builds_branch_filter` (String) Filter the `skip_intermediate_builds` setting based on this branch condition.
+- `slug` (String) A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If not provided, the slug will be [derived](https://buildkite.com/docs/apis/graphql/cookbooks/pipelines#create-a-pipeline-deriving-a-pipeline-slug-from-the-pipelines-name) from the pipeline `name`.
 - `steps` (String) The YAML steps to configure for the pipeline. Can also accept the `steps` attribute from the [`buildkite_signed_pipeline_steps`](/docs/data-sources/signed_pipeline_steps) data source to enable a signed pipeline. Defaults to `buildkite-agent pipeline upload`.
 - `tags` (Set of String) Tags to attribute to the pipeline. Useful for searching by in the UI.
 
@@ -94,7 +95,6 @@ resource "buildkite_pipeline" "signed-pipeline" {
 
 - `badge_url` (String) The badge URL showing build state.
 - `id` (String) The GraphQL ID of the pipeline.
-- `slug` (String) The slug generated for the pipeline.
 - `uuid` (String) The UUID of the pipeline.
 - `webhook_url` (String) The webhook URL used to trigger builds from VCS providers.
 

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -1,0 +1,64 @@
+package planmodifier
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type useDerivedPipelineSlugModifier struct{}
+
+// Description implements planmodifier.String.
+func (useDerivedPipelineSlugModifier) Description(context.Context) string {
+	return "Once set, the value of this attribute in state will only change if the dependent attribute changes."
+}
+
+// MarkdownDescription implements planmodifier.String.
+func (useDerivedPipelineSlugModifier) MarkdownDescription(context.Context) string {
+	return "Once set, the value of this attribute in state will only change if the dependent attribute changes."
+}
+
+// PlanModifyString implements planmodifier.String.
+func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do nothing if there is no state value (new resource creation)
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	privateSlugSource, _ := req.Private.GetKey(ctx, "slugSource")
+
+	var slugSource map[string]interface{}
+	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
+		return
+	}
+	slugSourceVal := slugSource["source"].(string)
+
+	// Retrieve name from state, plan
+	var planValueName, stateValueName string
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &stateValueName)...)
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("name"), &planValueName)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Check if slug is user-provided attribute
+	if req.ConfigValue.IsNull() {
+		// Return unknown if name is changing (re-generate slug from API)
+		if planValueName != stateValueName {
+			resp.PlanValue = types.StringUnknown()
+		}
+		// Return unknown if slug not defined and previous slug source not API (re-generate slug from API)
+		if slugSourceVal != "api" {
+			resp.PlanValue = types.StringUnknown()
+		}
+		return
+	}
+}
+
+func UseDerivedPipelineSlug() planmodifier.String {
+	return useDerivedPipelineSlugModifier{}
+}


### PR DESCRIPTION
Changes `slug` from a read-only attribute to an optional configurable attribute. If not set, `slug` is derived from the pipeline name and returned from the API. The `slug` will be updated when the `name` of the pipeline changes. If the `slug` is defined, a second REST API call is made to update the `slug` for the pipeline. The `slug` can be set or excluded at any time in the pipeline's lifecycle and the value will be set based on the user-defined input or via the API's response.

Utilizes Terraform [private state](https://developer.hashicorp.com/terraform/plugin/framework/resources/private-state) to track whether `slug` value in State was set via `api` or `user`. This extra value is required to correctly evaluate the transition of removing user-defined `slug` from an existing resource and re-trigger storing an updated `slug` from the API.

Addresses: https://github.com/buildkite/terraform-provider-buildkite/issues/586