### PR TITLE
Ensure global `env` are signed with steps

### DIFF
--- a/buildkite/data_source_signed_pipeline_steps.go
+++ b/buildkite/data_source_signed_pipeline_steps.go
@@ -221,7 +221,7 @@ func (s *signedPipelineStepsDataSource) Read(
 		}
 	}
 
-	if err := signature.SignSteps(ctx, p.Steps, key, data.Repository.ValueString()); err != nil {
+	if err := signature.SignSteps(ctx, p.Steps, key, data.Repository.ValueString(), signature.WithEnv(p.Env.ToMap())); err != nil {
 		resp.Diagnostics.AddError("Failed to sign pipeline", err.Error())
 		return
 	}

--- a/buildkite/data_source_signed_pipeline_steps_test.go
+++ b/buildkite/data_source_signed_pipeline_steps_test.go
@@ -27,6 +27,10 @@ func TestAccBuildkiteSignedPipelineStepsDataSource(t *testing.T) {
 		steps:
 		- label: ":pipeline:"
 		  command: buildkite-agent pipeline upload
+		  env:
+		    LOCAL_ENV: "bar"
+		env:
+		  GLOBAL_ENV: "foo"
 	`)
 
 	privateJWKS, _, err := jwkutil.NewKeyPair(jwksKeyID, jwa.EdDSA)
@@ -49,7 +53,7 @@ func TestAccBuildkiteSignedPipelineStepsDataSource(t *testing.T) {
 		t.Fatalf("Failed to parse pipeline: %v", err)
 	}
 
-	if err := signature.SignSteps(context.Background(), p.Steps, privateKey, repository); err != nil {
+	if err := signature.SignSteps(context.Background(), p.Steps, privateKey, repository, signature.WithEnv(p.Env.ToMap())); err != nil {
 		t.Fatalf("Failed to sign pipeline: %v", err)
 	}
 


### PR DESCRIPTION
We changed from using `SignPipeline()` to using `SignSteps()` with `go-pipeline` for signed pipeline steps. Need to also pass `env` as `Options` when calling `SignSteps()` to ensure they are included with `signed_fields`.