### PR TITLE
SUP-3241 - Revert explicit default `provider_settings`, keep fixes to `slug` logic

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -858,9 +858,7 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
 	if len(plan.Slug.ValueString()) > 0 {
 		useSlugValue = plan.Slug.ValueString()
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
 		if plan.Slug != state.Slug {
-
 			_, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -234,34 +233,47 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 	log.Printf("Successfully created pipeline with id '%s'.", response.PipelineCreate.Pipeline.Id)
+
 	setPipelineModel(&state, &response.PipelineCreate.Pipeline)
-
+	state.WebhookUrl = types.StringValue(response.PipelineCreate.Pipeline.GetWebhookURL())
+	state.DefaultTeamId = plan.DefaultTeamId
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
-	if len(plan.Slug.ValueString()) > 0 {
-		useSlugValue := plan.Slug.ValueString()
 
-		_, err := updatePipelineSlug(ctx, response.PipelineCreate.Pipeline.Slug, useSlugValue, p.client, timeouts)
+	var useSlugValue string
+	if len(plan.Slug.ValueString()) > 0 {
+		useSlugValue = plan.Slug.ValueString()
+
+		pipelineExtraInfo, err := updatePipelineSlug(ctx, response.PipelineCreate.Pipeline.Slug, useSlugValue, p.client, timeouts)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
 			return
 		}
 
+		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
 		state.Slug = types.StringValue(useSlugValue)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
 	}
 
-	pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, response.PipelineCreate.Pipeline.Slug, plan.ProviderSettings, p.client, timeouts)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
-		return
+	if plan.ProviderSettings != nil {
+		pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, response.PipelineCreate.Pipeline.Slug, plan.ProviderSettings, p.client, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
+			return
+		}
+
+		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+	} else {
+		// no provider_settings provided, but we still need to read in the badge url
+		extraInfo, err := getPipelineExtraInfo(ctx, p.client, response.PipelineCreate.Pipeline.Slug, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to read pipeline info from REST", err.Error())
+			return
+		}
+		state.Slug = types.StringValue(extraInfo.Slug)
+		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
+		state.ProviderSettings = plan.ProviderSettings
 	}
 
-	state.DefaultTeamId = plan.DefaultTeamId
-	state.BadgeUrl = types.StringValue(pipelineExtraInfo.BadgeUrl)
-	state.WebhookUrl = types.StringValue(pipelineExtraInfo.Provider.WebhookUrl)
-	state.Slug = types.StringValue(pipelineExtraInfo.Slug)
-
-	updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -595,56 +607,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"provider_settings": schema.SingleNestedAttribute{
-				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Control settings depending on the VCS provider used in `repository`.",
-
-				Default: objectdefault.StaticValue(
-					types.ObjectValueMust(
-						map[string]attr.Type{
-							"build_pull_request_forks":                      types.BoolType,
-							"build_pull_request_labels_changed":             types.BoolType,
-							"build_pull_request_ready_for_review":           types.BoolType,
-							"build_pull_requests":                           types.BoolType,
-							"build_branches":                                types.BoolType,
-							"build_tags":                                    types.BoolType,
-							"cancel_deleted_branch_builds":                  types.BoolType,
-							"filter_condition":                              types.StringType,
-							"filter_enabled":                                types.BoolType,
-							"prefix_pull_request_fork_branch_names":         types.BoolType,
-							"publish_blocked_as_pending":                    types.BoolType,
-							"publish_commit_status":                         types.BoolType,
-							"publish_commit_status_per_step":                types.BoolType,
-							"pull_request_branch_filter_configuration":      types.StringType,
-							"pull_request_branch_filter_enabled":            types.BoolType,
-							"separate_pull_request_statuses":                types.BoolType,
-							"skip_builds_for_existing_commits":              types.BoolType,
-							"skip_pull_request_builds_for_existing_commits": types.BoolType,
-							"trigger_mode":                                  types.StringType,
-						},
-						map[string]attr.Value{
-							"build_pull_request_forks":                      types.BoolValue(false),
-							"build_pull_request_labels_changed":             types.BoolValue(false),
-							"build_pull_request_ready_for_review":           types.BoolValue(false),
-							"build_pull_requests":                           types.BoolValue(false),
-							"build_branches":                                types.BoolValue(false),
-							"build_tags":                                    types.BoolValue(false),
-							"cancel_deleted_branch_builds":                  types.BoolValue(false),
-							"filter_condition":                              types.StringValue(""),
-							"filter_enabled":                                types.BoolValue(false),
-							"prefix_pull_request_fork_branch_names":         types.BoolValue(false),
-							"publish_blocked_as_pending":                    types.BoolValue(false),
-							"publish_commit_status":                         types.BoolValue(false),
-							"publish_commit_status_per_step":                types.BoolValue(false),
-							"pull_request_branch_filter_configuration":      types.StringValue(""),
-							"pull_request_branch_filter_enabled":            types.BoolValue(false),
-							"separate_pull_request_statuses":                types.BoolValue(false),
-							"skip_builds_for_existing_commits":              types.BoolValue(false),
-							"skip_pull_request_builds_for_existing_commits": types.BoolValue(false),
-							"trigger_mode":                                  types.StringValue("none"),
-						},
-					),
-				),
 				Attributes: map[string]schema.Attribute{
 					"trigger_mode": schema.StringAttribute{
 						Computed: true,
@@ -664,121 +628,102 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"`fork` will create builds when the GitHub repository is forked.",
 							"`none` will not create any builds based on GitHub activity.",
 							"`trigger_mode`",
-							"`none`",
+							"`code`",
 						),
-						Default: stringdefault.StaticString("none"),
 					},
 					"build_pull_requests": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether to create builds for commits that are part of a pull request. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create builds for commits that are part of a pull request. Defaults to `true` when `trigger_mode` is set to `code`.",
 					},
 					"pull_request_branch_filter_enabled": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Filter pull request builds. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Filter pull request builds.",
 					},
 					"pull_request_branch_filter_configuration": schema.StringAttribute{
 						Computed:            true,
 						Optional:            true,
 						MarkdownDescription: "Filter pull requests builds by the branch filter.",
-						Default:             stringdefault.StaticString(""),
 					},
 					"skip_builds_for_existing_commits": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository.",
 					},
 					"skip_pull_request_builds_for_existing_commits": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.  Defaults to `true` when `trigger_mode` is set to `code`.",
 					},
 					"build_pull_request_ready_for_review": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create a build when a pull request changes to \"Ready for review\". Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create a build when a pull request changes to \"Ready for review\".",
 					},
 					"build_pull_request_labels_changed": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds for pull requests when labels are added or removed. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create builds for pull requests when labels are added or removed.",
 					},
 					"build_pull_request_forks": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds for pull requests from third-party forks. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create builds for pull requests from third-party forks.",
 					},
 					"prefix_pull_request_fork_branch_names": schema.BoolAttribute{
 						Computed: true,
 						Optional: true,
 						MarkdownDescription: "Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions." +
-							" For example, the main branch from some-user will become some-user:main. Defaults to `false`.",
-						Default: booldefault.StaticBool(false),
+							" For example, the main branch from some-user will become some-user:main.",
 					},
 					"build_branches": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether to create builds when branches are pushed. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create builds when branches are pushed. Defaults to `true` when `trigger_mode` is set to `code`.",
 					},
 					"build_tags": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds when tags are pushed. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create builds when tags are pushed.",
 					},
 					"cancel_deleted_branch_builds": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Automatically cancel running builds for a branch if the branch is deleted. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Automatically cancel running builds for a branch if the branch is deleted.",
 					},
 					"filter_enabled": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to filter builds to only run when the condition in `filter_condition` is true. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to filter builds to only run when the condition in `filter_condition` is true.",
 					},
 					"filter_condition": schema.StringAttribute{
 						Computed: true,
 						Optional: true,
 						MarkdownDescription: "The condition to evaluate when deciding if a build should run." +
-							" More details available in the [documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines).",
-						Default: stringdefault.StaticString(""),
+							" More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines).",
 					},
 					"publish_commit_status": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether to update the status of commits in Bitbucket or GitHub. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to update the status of commits in Bitbucket or GitHub. Defaults to `true` when `trigger_mode` is set to `code`.",
 					},
 					"publish_blocked_as_pending": schema.BoolAttribute{
 						Computed: true,
 						Optional: true,
 						MarkdownDescription: "The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks)" +
-							" to prevent merging pull requests with blocked builds. Defaults to `false`.",
-						Default: booldefault.StaticBool(false),
+							" to prevent merging pull requests with blocked builds.",
 					},
 					"publish_commit_status_per_step": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub. Defaults to `false`.",
-						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.",
 					},
 					"separate_pull_request_statuses": schema.BoolAttribute{
 						Computed: true,
 						Optional: true,
 						MarkdownDescription: "Whether to create a separate status for pull request builds, allowing you to require a passing pull request" +
-							" build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub. Defaults to `false`.",
-						Default: booldefault.StaticBool(false),
+							" build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.",
 					},
 				},
 			},
@@ -909,26 +854,29 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		)
 		return
 	}
-	setPipelineModel(&state, &response.PipelineUpdate.Pipeline)
 
-	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
-	if len(plan.Slug.ValueString()) > 0 && plan.Slug != state.Slug {
-		useSlugValue := plan.Slug.ValueString()
-
-		_, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
-			return
-		}
-
-		state.Slug = types.StringValue(useSlugValue)
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
+	var useSlugValue string
+	if len(plan.Slug.ValueString()) > 0 {
+		useSlugValue = plan.Slug.ValueString()
+	} else {
+		useSlugValue = response.PipelineUpdate.Pipeline.Slug
 	}
 
-	pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, response.PipelineUpdate.Pipeline.Slug, plan.ProviderSettings, p.client, timeouts)
+	pipelineExtraInfo, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
+
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
+		resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
 		return
+	}
+
+	updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+	setPipelineModel(&state, &response.PipelineUpdate.Pipeline)
+
+	state.Slug = types.StringValue(useSlugValue)
+	if len(plan.Slug.ValueString()) > 0 {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
 	}
 
 	if plan.DefaultTeamId.IsNull() && !state.DefaultTeamId.IsNull() {
@@ -966,11 +914,38 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		}
 	}
 
-	state.BadgeUrl = types.StringValue(pipelineExtraInfo.BadgeUrl)
-	state.WebhookUrl = types.StringValue(pipelineExtraInfo.Provider.WebhookUrl)
-	state.Slug = types.StringValue(pipelineExtraInfo.Slug)
+	if plan.ProviderSettings != nil {
+		pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, response.PipelineUpdate.Pipeline.Slug, plan.ProviderSettings, p.client, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
+			return
+		}
 
-	updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+		// set the webhook url if its not empty
+		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
+		// state value alone assuming it was previously set correctly
+		if pipelineExtraInfo.Provider.WebhookUrl != "" {
+			state.WebhookUrl = types.StringValue(pipelineExtraInfo.Provider.WebhookUrl)
+		}
+	} else {
+		// no provider_settings provided, but we still need to read in the badge url
+
+		extraInfo, err := getPipelineExtraInfo(ctx, p.client, response.PipelineUpdate.Pipeline.Slug, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to read pipeline info from REST", err.Error())
+			return
+		}
+		state.BadgeUrl = types.StringValue(extraInfo.BadgeUrl)
+		state.ProviderSettings = plan.ProviderSettings
+		// set the webhook url if its not empty
+		// the value can be empty if not using a token with appropriate permissions. in this case, we just leave the
+		// state value alone assuming it was previously set correctly
+		if extraInfo.Provider.WebhookUrl != "" {
+			state.WebhookUrl = types.StringValue(extraInfo.Provider.WebhookUrl)
+		}
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -1268,7 +1243,7 @@ func pipelineSchemaV0() schema.Schema {
 		MarkdownDescription: heredoc.Doc(`
 			This resource allows you to create and manage pipelines for repositories.
 
-			More information on pipelines can be found in the [documentation](https://buildkite.com/docs/pipelines).
+			More information on pipelines can be found in the documentation](https://buildkite.com/docs/pipelines).
 		`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -918,13 +918,6 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					Config:                   configNested,
 					ProtoV6ProviderFactories: protoV6ProviderFactories(),
 					Check:                    checkNested,
-					// We expect an empty plan and no action on the pipeline resource before applying nested provider_settings config
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PreApply: []plancheck.PlanCheck{
-							plancheck.ExpectEmptyPlan(),
-							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionNoop),
-						},
-					},
 				},
 			},
 		})

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -103,31 +103,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", ""),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprint(strings.ToLower(pipelineName))),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
-
-						// check tags are empty
+						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
-
-						// check default provider_settings
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "0"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#"),
 					),
 				},
 				{
@@ -236,31 +216,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", ""),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", slugName),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "steps", defaultSteps),
-
-						// check tags are empty
+						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
-
-						// check default provider_settings
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "0"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#"),
 					),
 				},
 			},
@@ -488,30 +448,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", ""),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "slug", fmt.Sprint(strings.ToLower(pipelineName))),
 
-						// check tags are empty
+						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
-
-						// check default provider_settings
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "0"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#"),
 					),
 				},
 			},
@@ -551,31 +492,14 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							}
 							return nil
 						},
-
-						// check tags are empty
+						// check lists are empty
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
-
-						// check default provider_settings
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", ""),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
 					),
 				},
 			},
@@ -607,25 +531,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 				skip_intermediate_builds_branch_filter = "!main"
 				tags = ["llama"]
 				provider_settings = {
-					build_branches = true
-					build_pull_requests = true
-					build_pull_request_forks = true
-					build_pull_request_labels_changed = true
-					build_pull_request_ready_for_review = true
-					build_tags = true
-					cancel_deleted_branch_builds = true
-					filter_condition = ""
-					filter_enabled = true
-					prefix_pull_request_fork_branch_names = true
-					publish_blocked_as_pending = true
-					publish_commit_status = true
-					publish_commit_status_per_step = true
-					pull_request_branch_filter_configuration = ""
-					pull_request_branch_filter_enabled = true
-					separate_pull_request_statuses = true
-					skip_builds_for_existing_commits = true
-					skip_pull_request_builds_for_existing_commits = true
 					trigger_mode = "code"
+					build_pull_requests = true
+					skip_builds_for_existing_commits = true
+					build_branches = true
+					build_tags = true
+					build_pull_request_ready_for_review = true
+					cancel_deleted_branch_builds = true
+					filter_enabled = true
+					filter_condition = "true"
+					publish_commit_status = true
+					publish_blocked_as_pending = true
+					publish_commit_status_per_step = true
+					separate_pull_request_statuses = true
 				}
 			}
 		`, clusterName, pipelineName)
@@ -651,25 +569,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "emoji", ":buildkite:"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", "!main"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
-						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "code"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "true"),
 					),
 				},
 			},
@@ -721,25 +633,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							skip_intermediate_builds_branch_filter = "!main"
 							tags = ["llama"]
 							provider_settings = {
-								build_branches = true
-								build_pull_requests = true
-								build_pull_request_forks = true
-								build_pull_request_labels_changed = true
-								build_pull_request_ready_for_review = true
-								build_tags = true
-								cancel_deleted_branch_builds = true
-								filter_condition = ""
-								filter_enabled = true
-								prefix_pull_request_fork_branch_names = true
-								publish_blocked_as_pending = true
-								publish_commit_status = true
-								publish_commit_status_per_step = true
-								pull_request_branch_filter_configuration = ""
-								pull_request_branch_filter_enabled = true
-								separate_pull_request_statuses = true
-								skip_builds_for_existing_commits = true
-								skip_pull_request_builds_for_existing_commits = true
 								trigger_mode = "code"
+								build_pull_requests = true
+								skip_builds_for_existing_commits = true
+								build_branches = true
+								build_tags = true
+								build_pull_request_ready_for_review = true
+								cancel_deleted_branch_builds = true
+								filter_enabled = true
+								filter_condition = "true"
+								publish_commit_status = true
+								publish_blocked_as_pending = true
+								publish_commit_status_per_step = true
+								separate_pull_request_statuses = true
 							}
 						}
 					`, clusterName, pipelineName),
@@ -882,25 +788,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-Provider-buildkite.git"),
 			// Ensure that v1 pipeline's provider_settings defaulted attributes are nested in state when upgraded from v0
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "none"),
+			resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings"),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{
@@ -955,25 +843,19 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 				name = "%s"
 				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
 				provider_settings = {
-					build_branches = true
-					build_pull_requests = true
-					build_pull_request_forks = true
-					build_pull_request_labels_changed = true
-					build_pull_request_ready_for_review = true
-					build_tags = true
-					cancel_deleted_branch_builds = true
-					filter_condition = ""
-					filter_enabled = true
-					prefix_pull_request_fork_branch_names = true
-					publish_blocked_as_pending = true
-					publish_commit_status = true
-					publish_commit_status_per_step = true
-					pull_request_branch_filter_configuration = ""
-					pull_request_branch_filter_enabled = true
-					separate_pull_request_statuses = true
-					skip_builds_for_existing_commits = true
-					skip_pull_request_builds_for_existing_commits = true
 					trigger_mode = "code"
+					build_pull_requests = true
+					skip_builds_for_existing_commits = true
+					build_branches = true
+					build_tags = true
+					build_pull_request_ready_for_review = true
+					cancel_deleted_branch_builds = true
+					filter_enabled = true
+					filter_condition = "true"
+					publish_commit_status = true
+					publish_blocked_as_pending = true
+					publish_commit_status_per_step = true
+					separate_pull_request_statuses = true
 				}
 			}
 		`, pipelineName)
@@ -985,19 +867,14 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.#", "1"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_branches", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_requests", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_forks", "false"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_labels_changed", "false"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_pull_request_ready_for_review", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.build_tags", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.cancel_deleted_branch_builds", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_condition", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.filter_enabled", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.prefix_pull_request_fork_branch_names", "false"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_blocked_as_pending", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.publish_commit_status_per_step", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.pull_request_branch_filter_configuration", ""),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.pull_request_branch_filter_enabled", "false"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.separate_pull_request_statuses", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_builds_for_existing_commits", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.0.skip_pull_request_builds_for_existing_commits", "true"),
@@ -1010,19 +887,14 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			// Ensure that v1 pipeline's provider_settings set attributes are nested in state when upgraded from v0
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_forks", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_labels_changed", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_deleted_branch_builds", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", ""),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_condition", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.filter_enabled", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.prefix_pull_request_fork_branch_names", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_blocked_as_pending", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status_per_step", "true"),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_configuration", ""),
-			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.pull_request_branch_filter_enabled", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.separate_pull_request_statuses", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "true"),
@@ -1046,6 +918,13 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					Config:                   configNested,
 					ProtoV6ProviderFactories: protoV6ProviderFactories(),
 					Check:                    checkNested,
+					// We expect an empty plan and no action on the pipeline resource before applying nested provider_settings config
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionNoop),
+						},
+					},
 				},
 			},
 		})

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -103,24 +103,24 @@ resource "buildkite_pipeline" "signed-pipeline" {
 
 Optional:
 
-- `build_branches` (Boolean) Whether to create builds when branches are pushed. Defaults to `false`.
-- `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks. Defaults to `false`.
-- `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed. Defaults to `false`.
-- `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review". Defaults to `false`.
-- `build_pull_requests` (Boolean) Whether to create builds for commits that are part of a pull request. Defaults to `false`.
-- `build_tags` (Boolean) Whether to create builds when tags are pushed. Defaults to `false`.
-- `cancel_deleted_branch_builds` (Boolean) Automatically cancel running builds for a branch if the branch is deleted. Defaults to `false`.
-- `filter_condition` (String) The condition to evaluate when deciding if a build should run. More details available in the [documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines).
-- `filter_enabled` (Boolean) Whether to filter builds to only run when the condition in `filter_condition` is true. Defaults to `false`.
-- `prefix_pull_request_fork_branch_names` (Boolean) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the main branch from some-user will become some-user:main. Defaults to `false`.
-- `publish_blocked_as_pending` (Boolean) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds. Defaults to `false`.
-- `publish_commit_status` (Boolean) Whether to update the status of commits in Bitbucket or GitHub. Defaults to `false`.
-- `publish_commit_status_per_step` (Boolean) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub. Defaults to `false`.
+- `build_branches` (Boolean) Whether to create builds when branches are pushed. Defaults to `true` when `trigger_mode` is set to `code`.
+- `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
+- `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
+- `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review".
+- `build_pull_requests` (Boolean) Whether to create builds for commits that are part of a pull request. Defaults to `true` when `trigger_mode` is set to `code`.
+- `build_tags` (Boolean) Whether to create builds when tags are pushed.
+- `cancel_deleted_branch_builds` (Boolean) Automatically cancel running builds for a branch if the branch is deleted.
+- `filter_condition` (String) The condition to evaluate when deciding if a build should run. More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines).
+- `filter_enabled` (Boolean) Whether to filter builds to only run when the condition in `filter_condition` is true.
+- `prefix_pull_request_fork_branch_names` (Boolean) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the main branch from some-user will become some-user:main.
+- `publish_blocked_as_pending` (Boolean) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.
+- `publish_commit_status` (Boolean) Whether to update the status of commits in Bitbucket or GitHub. Defaults to `true` when `trigger_mode` is set to `code`.
+- `publish_commit_status_per_step` (Boolean) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.
 - `pull_request_branch_filter_configuration` (String) Filter pull requests builds by the branch filter.
-- `pull_request_branch_filter_enabled` (Boolean) Filter pull request builds. Defaults to `false`.
-- `separate_pull_request_statuses` (Boolean) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub. Defaults to `false`.
-- `skip_builds_for_existing_commits` (Boolean) Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository. Defaults to `false`.
-- `skip_pull_request_builds_for_existing_commits` (Boolean) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists. Defaults to `false`.
+- `pull_request_branch_filter_enabled` (Boolean) Filter pull request builds.
+- `separate_pull_request_statuses` (Boolean) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
+- `skip_builds_for_existing_commits` (Boolean) Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository.
+- `skip_pull_request_builds_for_existing_commits` (Boolean) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.  Defaults to `true` when `trigger_mode` is set to `code`.
 - `trigger_mode` (String) What type of event to trigger builds on. Must be one of:
 	- `code` will create builds when code is pushed to GitHub.
 	- `deployment` will create builds when a deployment is created in GitHub.
@@ -128,7 +128,7 @@ Optional:
 	- `none` will not create any builds based on GitHub activity.
 
 	-> `trigger_mode` is only valid if the pipeline uses a GitHub repository.
-	-> If not set, the default value is `none` and other provider settings defaults are applied.
+	-> If not set, the default value is `code` and other provider settings defaults are applied.
 
 ## Import
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -103,24 +103,24 @@ resource "buildkite_pipeline" "signed-pipeline" {
 
 Optional:
 
-- `build_branches` (Boolean) Whether to create builds when branches are pushed. Defaults to `true` when `trigger_mode` is set to `code`.
+- `build_branches` (Boolean) Whether to create builds when branches are pushed.
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review".
-- `build_pull_requests` (Boolean) Whether to create builds for commits that are part of a pull request. Defaults to `true` when `trigger_mode` is set to `code`.
+- `build_pull_requests` (Boolean) Whether to create builds for commits that are part of a pull request.
 - `build_tags` (Boolean) Whether to create builds when tags are pushed.
 - `cancel_deleted_branch_builds` (Boolean) Automatically cancel running builds for a branch if the branch is deleted.
 - `filter_condition` (String) The condition to evaluate when deciding if a build should run. More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines).
 - `filter_enabled` (Boolean) Whether to filter builds to only run when the condition in `filter_condition` is true.
 - `prefix_pull_request_fork_branch_names` (Boolean) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the main branch from some-user will become some-user:main.
 - `publish_blocked_as_pending` (Boolean) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.
-- `publish_commit_status` (Boolean) Whether to update the status of commits in Bitbucket or GitHub. Defaults to `true` when `trigger_mode` is set to `code`.
+- `publish_commit_status` (Boolean) Whether to update the status of commits in Bitbucket or GitHub.
 - `publish_commit_status_per_step` (Boolean) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.
 - `pull_request_branch_filter_configuration` (String) Filter pull requests builds by the branch filter.
 - `pull_request_branch_filter_enabled` (Boolean) Filter pull request builds.
 - `separate_pull_request_statuses` (Boolean) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
 - `skip_builds_for_existing_commits` (Boolean) Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository.
-- `skip_pull_request_builds_for_existing_commits` (Boolean) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.  Defaults to `true` when `trigger_mode` is set to `code`.
+- `skip_pull_request_builds_for_existing_commits` (Boolean) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.
 - `trigger_mode` (String) What type of event to trigger builds on. Must be one of:
 	- `code` will create builds when code is pushed to GitHub.
 	- `deployment` will create builds when a deployment is created in GitHub.

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -32,8 +32,6 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 
 	var slugSource map[string]interface{}
 	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
-		// Return unknown if slugSource missing from private state
-		resp.PlanValue = types.StringUnknown()
 		return
 	}
 	slugSourceVal := slugSource["source"].(string)
@@ -49,20 +47,15 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 
 	// Check if slug is user-provided attribute
 	if req.ConfigValue.IsNull() {
-		// Return unknown if slug not defined and previous slug source not API (re-generate slug from API)
-		if slugSourceVal != "api" {
-			resp.PlanValue = types.StringUnknown()
-			return
-		}
 		// Return unknown if name is changing (re-generate slug from API)
 		if planValueName != stateValueName {
 			resp.PlanValue = types.StringUnknown()
-			return
-		} else {
-			// Name not changed, Config provided matches value in state, set value to state (NoOp)
-			resp.PlanValue = req.StateValue
-			return
 		}
+		// Return unknown if slug not defined and previous slug source not API (re-generate slug from API)
+		if slugSourceVal != "api" {
+			resp.PlanValue = types.StringUnknown()
+		}
+		return
 	}
 }
 

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -32,6 +32,8 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 
 	var slugSource map[string]interface{}
 	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
+		// Return unknown if slugSource missing from private state and state is different
+		resp.PlanValue = types.StringUnknown()
 		return
 	}
 	slugSourceVal := slugSource["source"].(string)

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -32,8 +32,10 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 
 	var slugSource map[string]interface{}
 	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
-		// Return unknown if slugSource missing from private state
-		resp.PlanValue = types.StringUnknown()
+		if resp.PlanValue != req.StateValue {
+			// Return unknown if slugSource missing from private state and state is different
+			resp.PlanValue = types.StringUnknown()
+		}
 		return
 	}
 	slugSourceVal := slugSource["source"].(string)

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -32,10 +32,6 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 
 	var slugSource map[string]interface{}
 	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
-		if resp.PlanValue != req.StateValue {
-			// Return unknown if slugSource missing from private state and state is different
-			resp.PlanValue = types.StringUnknown()
-		}
 		return
 	}
 	slugSourceVal := slugSource["source"].(string)


### PR DESCRIPTION
Reverts the changes to `provider_settings` brought in via PR https://github.com/buildkite/terraform-provider-buildkite/pull/607 and released in version [v1.15.5](https://github.com/buildkite/terraform-provider-buildkite/releases/tag/v1.15.5). Will revisit `provider_settings` management at a later time when additional functionality is enabled in our GraphQL API.
Keeps the fixes implemented to ensure the `slug` attribute is correctly reconciled with state, whether user-defined or derived from the API.