### PR TITLE
SUP-3317 - Fix hosted agent attributes state mismatch

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -304,7 +304,7 @@ func (cq *clusterQueueResource) Create(ctx context.Context, req resource.CreateR
 		}
 		if plan.HostedAgents.Mac != nil {
 			state.HostedAgents.Mac = &macConfigModel{
-				XcodeVersion: types.StringValue(r.ClusterQueueCreate.ClusterQueue.HostedAgents.PlatformSettings.Macos.XcodeVersion),
+				XcodeVersion: plan.HostedAgents.Mac.XcodeVersion,
 			}
 		}
 	}

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -304,7 +304,7 @@ func (cq *clusterQueueResource) Create(ctx context.Context, req resource.CreateR
 		}
 		if plan.HostedAgents.Mac != nil {
 			state.HostedAgents.Mac = &macConfigModel{
-				XcodeVersion: plan.HostedAgents.Mac.XcodeVersion,
+				XcodeVersion: types.StringValue(r.ClusterQueueCreate.ClusterQueue.HostedAgents.PlatformSettings.Macos.XcodeVersion),
 			}
 		}
 	}
@@ -471,7 +471,9 @@ func (cq *clusterQueueResource) Update(ctx context.Context, req resource.UpdateR
 	state.Description = types.StringPointerValue(r.ClusterQueueUpdate.ClusterQueue.Description)
 	state.DispatchPaused = types.BoolValue(r.ClusterQueueUpdate.ClusterQueue.DispatchPaused)
 	if state.HostedAgents != nil {
-		state.HostedAgents.InstanceShape = types.StringValue(string(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.InstanceShape.Name))
+		state.HostedAgents = &hostedAgentResourceModel{
+			InstanceShape: types.StringValue(string(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.InstanceShape.Name)),
+		}
 		if plan.HostedAgents.Mac != nil {
 			state.HostedAgents.Mac = &macConfigModel{
 				XcodeVersion: types.StringValue(r.ClusterQueueUpdate.ClusterQueue.HostedAgents.PlatformSettings.Macos.XcodeVersion),


### PR DESCRIPTION
Fixes https://github.com/buildkite/terraform-provider-buildkite/issues/866
Also ensures that the value of `XcodeVersion` stored in state is sourced from the API response vs. what was provided via the plan. This was covering up another issue where the `XcodeVersion` was not actually being set via the API.