### PR TITLE
Fix: Hosted Linux cluster queue resource example / docs alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: Hosted Linux cluster queue resource example / docs alignment [[PR #875](https://github.com/buildkite/terraform-provider-buildkite/pull/875)] @james2791
+
 ## [v1.16.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.16.0...v1.16.1)
 
 - SUP-3318 - Fix cluster default queue state [[PR #873](https://github.com/buildkite/terraform-provider-buildkite/pull/873)] @petetomasik

--- a/docs/resources/cluster_queue.md
+++ b/docs/resources/cluster_queue.md
@@ -49,7 +49,7 @@ resource "buildkite_cluster_queue" "hosted_agents_macos" {
 }
 
 # create a hosted agent queue with linux agents
-resource "buildkite_cluster_queue" "hosted_agents_macos" {
+resource "buildkite_cluster_queue" "hosted_agents_linux" {
   cluster_id = buildkite_cluster.primary.id
   key        = "hosted-agents-linux"
 

--- a/examples/resources/buildkite_cluster_queue/resource.tf
+++ b/examples/resources/buildkite_cluster_queue/resource.tf
@@ -34,7 +34,7 @@ resource "buildkite_cluster_queue" "hosted_agents_macos" {
 }
 
 # create a hosted agent queue with linux agents
-resource "buildkite_cluster_queue" "hosted_agents_macos" {
+resource "buildkite_cluster_queue" "hosted_agents_linux" {
   cluster_id = buildkite_cluster.primary.id
   key        = "hosted-agents-linux"
 


### PR DESCRIPTION
Fix (Hosted Linux cluster queue resource docs/example): Small fix for the `buildkite_cluster_queue` Linux variety example to be named accordingly 