### PR TITLE
chore: use disable: true for changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,4 +59,4 @@ release:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## Changes

- As per https://goreleaser.com/deprecations/#changelogskip, we should use `disable: true` instead of `skip: true` in the `changelog` section of the Go Releaser config file 
