### PR TITLE
chore: enable parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,17 @@ RUN apt-get update \
 
 COPY --from=hashicorp/terraform:1.4@sha256:4dcb45513699e652c771b914f41ec1cc2a0ba9c8d1afa2e8e4aa2ba071b63151 /bin/terraform /usr/local/bin/terraform
 COPY --from=goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3 /usr/bin/goreleaser /usr/local/bin/goreleaser
+
+WORKDIR /work
+
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+
+# Download dependencies - this layer will be cached unless
+# go.mod/go.sum changes
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+# Configure build caching
+ENV GOCACHE=/root/.cache/go-build

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ vet:
 	go vet $(go list ./...)
 
 test:
-	go test ./...
+	go test ./... -parallel=4
 
 # Acceptance tests. This will create, manage and delete real resources in a real
 # Buildkite organization!
 testacc:
-	TF_ACC=1 go run gotest.tools/gotestsum --format testname --junitfile "junit-${BUILDKITE_JOB_ID}.xml" ./...
+	TF_ACC=1 go run gotest.tools/gotestsum --format testname --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -parallel=4 ./...
 
 # Generate the Buildkite GraphQL schema file
 schema:

--- a/buildkite/resource_test_suite_team_test.go
+++ b/buildkite/resource_test_suite_team_test.go
@@ -24,14 +24,14 @@ func TestAccBuildkiteTestSuiteTeamResource(t *testing.T) {
 		}
 
 		resource "buildkite_team" "ownerteam" {
-			name = "Test Suite Team %s"
+			name = "Test Suite Owner Team %s"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
 		}
 
 		resource "buildkite_team" "newteam" {
-			name = "Test Suite Team %s"
+			name = "Test Suite New Team %s"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -25,7 +25,7 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 		}
 
 		resource "buildkite_team" "team" {
-			name = "test suite team"
+			name = "test suite team %s"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
@@ -35,7 +35,7 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 			default_branch = "main"
 			team_owner_id = resource.buildkite_team.team.id
 		}
-		`, name)
+		`, name, name)
 	}
 
 	testSuiteWithTwoTeams := func(name string) string {
@@ -50,13 +50,13 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 		}
 
 		resource "buildkite_team" "ateam" {
-			name = "a team"
+			name = "a team %s-a"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
 		}
 		resource "buildkite_team" "bteam" {
-			name = "b team"
+			name = "b team %s-b"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
@@ -66,7 +66,7 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 			default_branch = "main"
 			team_owner_id = resource.buildkite_team.bteam.id
 		}
-		`, name)
+		`, name, name, name)
 	}
 
 	testSuiteTeamAddition := func(name string) string {
@@ -81,13 +81,13 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 		}
 
 		resource "buildkite_team" "ateam" {
-			name = "a team"
+			name = "a team %s-a"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
 		}
 		resource "buildkite_team" "bteam" {
-			name = "b team"
+			name = "b team %s-b"
 			default_team = false
 			privacy = "VISIBLE"
 			default_member_role = "MAINTAINER"
@@ -102,7 +102,7 @@ func TestAccBuildkiteTestSuiteResource(t *testing.T) {
 			team_id = buildkite_team.ateam.id
 			access_level = "MANAGE_AND_READ"
 		}
-		`, name)
+		`, name, name, name)
 	}
 
 	t.Run("creates a test suite", func(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,15 @@ services:
   go:
     build:
       context: .
+      dockerfile: Dockerfile
     volumes:
       - .:/work
+      - go-pkg-mod:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
     working_dir: /work
     environment:
+      - BUILDKIT_PROGRESS=plain
+      - DOCKER_BUILDKIT=1
       - BUILDKITE_ANALYTICS_TOKEN
       - BUILDKITE_API_TOKEN
       - BUILDKITE_BRANCH
@@ -20,3 +25,7 @@ services:
       - BUILDKITE_TAG
       - GITHUB_TOKEN
       - GPG_SECRET_KEY_BASE64
+
+volumes:
+  go-pkg-mod:
+  go-build-cache:


### PR DESCRIPTION
chore: actually support parallelism

## Changes

- just setting `t.Parallel()` doesn't mean tests run in parallel
- sets the `-parallel` flag to test commands
