### PR TITLE
Set Hosted Agent OS shapes to `null` for `cluster_queue`, use `omitempty` to align with GQL processing

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -660,9 +660,9 @@ func (v *HostedAgentsMacosPlatformSettingsInput) GetXcodeVersion() *string { ret
 // Settings for hosted agents on this queue
 type HostedAgentsPlatformSettingsInput struct {
 	// Settings for hosted agents on this queue
-	Linux *HostedAgentsLinuxPlatformSettingsInput `json:"linux"`
+	Linux *HostedAgentsLinuxPlatformSettingsInput `json:"linux,omitempty"`
 	// Settings for hosted agents on this queue
-	Macos *HostedAgentsMacosPlatformSettingsInput `json:"macos"`
+	Macos *HostedAgentsMacosPlatformSettingsInput `json:"macos,omitempty"`
 }
 
 // GetLinux returns HostedAgentsPlatformSettingsInput.Linux, and is useful for accessing the field via an interface.
@@ -813,11 +813,11 @@ func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSetti
 // Configuration options specific to Linux hosted agent instances.
 type HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsLinuxHostedAgentLinuxSettings struct {
 	// The image reference of a custom agent base image used by the hosted agent instances in this cluster queue. Note: this must be a public image, or image stored within the hosted agents internal registry.
-	AgentImageRef *string `json:"agentImageRef"`
+	AgentImageRef string `json:"agentImageRef"`
 }
 
 // GetAgentImageRef returns HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsLinuxHostedAgentLinuxSettings.AgentImageRef, and is useful for accessing the field via an interface.
-func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsLinuxHostedAgentLinuxSettings) GetAgentImageRef() *string {
+func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsLinuxHostedAgentLinuxSettings) GetAgentImageRef() string {
 	return v.AgentImageRef
 }
 
@@ -827,11 +827,11 @@ func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSetti
 // Configuration options for the base image of hosted agent instances on macOS platforms.
 type HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsMacosHostedAgentMacOSSettingsType struct {
 	// The Xcode version to pre-select (via xcode-select) on macOS hosted agent instances for this cluster queue.
-	XcodeVersion *string `json:"xcodeVersion"`
+	XcodeVersion string `json:"xcodeVersion"`
 }
 
 // GetXcodeVersion returns HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsMacosHostedAgentMacOSSettingsType.XcodeVersion, and is useful for accessing the field via an interface.
-func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsMacosHostedAgentMacOSSettingsType) GetXcodeVersion() *string {
+func (v *HostedAgentsQueueSettingsValuesPlatformSettingsHostedAgentPlatformSettingsMacosHostedAgentMacOSSettingsType) GetXcodeVersion() string {
 	return v.XcodeVersion
 }
 

--- a/buildkite/graphql/cluster_queue.graphql
+++ b/buildkite/graphql/cluster_queue.graphql
@@ -1,5 +1,3 @@
-# @genqlient(for: "HostedAgentLinuxSettings.agentImageRef", pointer: true)
-# @genqlient(for: "HostedAgentMacOSSettingsType.xcodeVersion", pointer: true)
 fragment HostedAgentsQueueSettingsValues on HostedAgentQueueSettings {
     instanceShape {
         architecture
@@ -67,8 +65,8 @@ query getClusterQueues(
     }
 }
 
-# @genqlient(for: "HostedAgentsPlatformSettingsInput.linux", pointer: true)
-# @genqlient(for: "HostedAgentsPlatformSettingsInput.macos", pointer: true)
+# @genqlient(for: "HostedAgentsPlatformSettingsInput.linux", pointer: true, omitempty: true)
+# @genqlient(for: "HostedAgentsPlatformSettingsInput.macos", pointer: true, omitempty: true)
 # @genqlient(for: "HostedAgentsLinuxPlatformSettingsInput.agentImageRef", pointer: true)
 # @genqlient(for: "HostedAgentsMacosPlatformSettingsInput.xcodeVersion", pointer: true)
 mutation createClusterQueue(
@@ -95,8 +93,8 @@ mutation createClusterQueue(
     }
 }
 
-# @genqlient(for: "HostedAgentsPlatformSettingsInput.linux", pointer: true)
-# @genqlient(for: "HostedAgentsPlatformSettingsInput.macos", pointer: true)
+# @genqlient(for: "HostedAgentsPlatformSettingsInput.linux", pointer: true, omitempty: true)
+# @genqlient(for: "HostedAgentsPlatformSettingsInput.macos", pointer: true, omitempty: true)
 # @genqlient(for: "HostedAgentsLinuxPlatformSettingsInput.agentImageRef", pointer: true)
 # @genqlient(for: "HostedAgentsMacosPlatformSettingsInput.xcodeVersion", pointer: true)
 mutation updateClusterQueue(


### PR DESCRIPTION
Instead of `agentImageRef` and `xcodeVersion` being set to `null` for create/update mutations, allow `platformSettings.linux` and `platformSettings.macos` to be set to `null` and have genqlient omit them when not set.

This fix now fully resolves https://github.com/buildkite/terraform-provider-buildkite/issues/869, where https://github.com/buildkite/terraform-provider-buildkite/pull/898 only fixed the issue when an Organization had the `Feature::BUILDKITE_HOSTED_AGENTS_BASE_IMAGE_URL` feature enabled.