### PR TITLE
Extra logic around missing private state

### DIFF
--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -28,12 +28,15 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 		return
 	}
 
+	// Retrieve slugSource from private state
 	privateSlugSource, _ := req.Private.GetKey(ctx, "slugSource")
 
 	var slugSource map[string]interface{}
 	if err := json.Unmarshal(privateSlugSource, &slugSource); err != nil {
-		// Return unknown if slugSource missing from private state and state is different
-		resp.PlanValue = types.StringUnknown()
+		// Return unknown if slugSource missing from private state AND not user-defined
+		if req.ConfigValue.IsNull() {
+			resp.PlanValue = types.StringUnknown()
+		}
 		return
 	}
 	slugSourceVal := slugSource["source"].(string)


### PR DESCRIPTION
Addresses a condition where private state to manage `slug` attribute source does not exist AND `slug` is a user-defined attribute.

Fixes https://github.com/buildkite/terraform-provider-buildkite/issues/903