### PR TITLE
chore: add make docs to pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Buildkite Terraform Provider is licensed under the MIT license.
 Contributions are welcome.
 
 If you wish to work on the provider, you'll first need Go installed on your machine (version 1.21+ is required). Dependencies are managed via gomodules and installed automatically as required.
+Git hooks are managed with [Lefthook](https://lefthook.dev).
 
 To compile the provider:
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,6 +3,9 @@ pre-commit:
     gofmt:
       glob: "*.go"
       run: gofmt -s -w buildkite
+    docs:
+      glob: "*.go"
+      run: make docs
     gomodtidy:
       glob: "*.go"
       run: go mod tidy


### PR DESCRIPTION
Run `make docs` as pre-commit hook, so we have nice and fresh docs.