### PR TITLE
Validate pipeline color as hex color format

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -479,6 +479,12 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"color": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "A color hex code to represent this pipeline.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\#[a-zA-Z0-9]{6}$`),
+						"must be a valid color hex code (#000000)",
+					),
+				},
 			},
 			"cluster_id": schema.StringAttribute{
 				MarkdownDescription: "Attach this pipeline to the given cluster GraphQL ID.",


### PR DESCRIPTION
Ensure that a pipeline's `color` argument is either `null` or valid hex color format (`#abc123`). The GQL mutations to create/update a pipeline will return `null` if an empty string (`""`) is provided for the `color` field. Setting this validation on the TF argument will eliminate having to transform the plan (converting `""` -> `null`) in order to handle data inconsistencies.