### PR TITLE
Add cluster attributes to pipeline resource, data source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
+FROM golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
 
 RUN apt-get update \
     && apt-get install -y unzip

--- a/buildkite/data_source_pipeline.go
+++ b/buildkite/data_source_pipeline.go
@@ -20,6 +20,8 @@ type pipelineDataSourceModel struct {
 	Slug          types.String `tfsdk:"slug"`
 	UUID          types.String `tfsdk:"uuid"`
 	WebhookUrl    types.String `tfsdk:"webhook_url"`
+	ClusterId     types.String `tfsdk:"cluster_id"`
+	ClusterName   types.String `tfsdk:"cluster_name"`
 }
 
 type pipelineDatasource struct {
@@ -82,6 +84,14 @@ func (*pipelineDatasource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:            true,
 				MarkdownDescription: "The Buildkite webhook URL that triggers builds on this pipeline.",
 			},
+			"cluster_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The GraphQL ID of the cluster the pipeline is (optionally) attached to.",
+			},
+			"cluster_name": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The name of the cluster the pipeline is (optionally) attached to.",
+			},
 		},
 	}
 }
@@ -123,6 +133,8 @@ func (c *pipelineDatasource) Read(ctx context.Context, req datasource.ReadReques
 	state.Slug = types.StringValue(pipeline.Pipeline.Slug)
 	state.UUID = types.StringValue(pipeline.Pipeline.PipelineUuid)
 	state.WebhookUrl = types.StringValue(pipeline.Pipeline.WebhookURL)
+	state.ClusterId = types.StringPointerValue(pipeline.Pipeline.Cluster.Id)
+	state.ClusterName = types.StringPointerValue(pipeline.Pipeline.Cluster.Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -1445,10 +1445,15 @@ func (v *PipelineFields) GetTeams() PipelineFieldsTeamsTeamPipelineConnection { 
 // PipelineFieldsCluster includes the requested fields of the GraphQL type Cluster.
 type PipelineFieldsCluster struct {
 	Id *string `json:"id"`
+	// Name of the cluster
+	Name *string `json:"name"`
 }
 
 // GetId returns PipelineFieldsCluster.Id, and is useful for accessing the field via an interface.
 func (v *PipelineFieldsCluster) GetId() *string { return v.Id }
+
+// GetName returns PipelineFieldsCluster.Name, and is useful for accessing the field via an interface.
+func (v *PipelineFieldsCluster) GetName() *string { return v.Name }
 
 // PipelineFieldsPipelineTemplate includes the requested fields of the GraphQL type PipelineTemplate.
 // The GraphQL type's documentation follows.
@@ -15149,6 +15154,7 @@ fragment PipelineFields on Pipeline {
 	cancelIntermediateBuildsBranchFilter
 	cluster {
 		id
+		name
 	}
 	color
 	defaultBranch
@@ -16161,6 +16167,7 @@ fragment PipelineFields on Pipeline {
 	cancelIntermediateBuildsBranchFilter
 	cluster {
 		id
+		name
 	}
 	color
 	defaultBranch
@@ -16481,6 +16488,7 @@ fragment PipelineFields on Pipeline {
 	cancelIntermediateBuildsBranchFilter
 	cluster {
 		id
+		name
 	}
 	color
 	defaultBranch
@@ -17605,6 +17613,7 @@ fragment PipelineFields on Pipeline {
 	cancelIntermediateBuildsBranchFilter
 	cluster {
 		id
+		name
 	}
 	color
 	defaultBranch

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -9,6 +9,8 @@ fragment PipelineFields on Pipeline {
     cluster {
         # @genqlient(pointer: true)
         id
+        # @genqlient(pointer: true)
+        name
     }
     # @genqlient(pointer: true)
     color

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -77,6 +77,7 @@ type pipelineResourceModel struct {
 	CancelIntermediateBuildsBranchFilter types.String           `tfsdk:"cancel_intermediate_builds_branch_filter"`
 	Color                                types.String           `tfsdk:"color"`
 	ClusterId                            types.String           `tfsdk:"cluster_id"`
+	ClusterName                          types.String           `tfsdk:"cluster_name"`
 	DefaultTeamId                        types.String           `tfsdk:"default_team_id"`
 	DefaultBranch                        types.String           `tfsdk:"default_branch"`
 	DefaultTimeoutInMinutes              types.Int64            `tfsdk:"default_timeout_in_minutes"`
@@ -489,6 +490,10 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"cluster_id": schema.StringAttribute{
 				MarkdownDescription: "Attach this pipeline to the given cluster GraphQL ID.",
 				Optional:            true,
+			},
+			"cluster_name": schema.StringAttribute{
+				MarkdownDescription: "The name of the cluster the pipeline is (optionally) attached to.",
+				Computed:            true,
 			},
 			"default_team_id": schema.StringAttribute{
 				MarkdownDescription: "The GraphQL ID of the team to use as the default owner of the pipeline.",
@@ -998,6 +1003,7 @@ func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
 	model.CancelIntermediateBuilds = types.BoolValue(data.GetCancelIntermediateBuilds())
 	model.CancelIntermediateBuildsBranchFilter = types.StringValue(data.GetCancelIntermediateBuildsBranchFilter())
 	model.ClusterId = types.StringPointerValue(data.GetCluster().Id)
+	model.ClusterName = types.StringPointerValue(data.GetCluster().Name)
 	model.Color = types.StringPointerValue(data.GetColor())
 	model.DefaultBranch = types.StringValue(data.GetDefaultBranch())
 	model.DefaultTimeoutInMinutes = types.Int64PointerValue(defaultTimeoutInMinutes)

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -90,6 +90,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check state values are correct
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "branch_configuration"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_id"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_name"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "allow_rebuilds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds_branch_filter", ""),
@@ -203,6 +204,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check state values are correct
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "branch_configuration"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_id"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_name"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "allow_rebuilds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds_branch_filter", ""),
@@ -435,6 +437,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						// check state values are correct
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "branch_configuration"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_id"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "cluster_name"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "allow_rebuilds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds_branch_filter", ""),
@@ -556,6 +559,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					Config: config,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_id", "buildkite_cluster.cluster", "id"),
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_name", "buildkite_cluster.cluster", "name"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.0", "llama"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "allow_rebuilds", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "cancel_intermediate_builds", "true"),
@@ -660,6 +664,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 							return nil
 						},
 						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_id", "buildkite_cluster.cluster", "id"),
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_name", "buildkite_cluster.cluster", "name"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.ignore_default_branch_pull_requests", "true"),
 						aggregateRemoteCheck(&pipeline),
 					),

--- a/docs/data-sources/pipeline.md
+++ b/docs/data-sources/pipeline.md
@@ -30,6 +30,8 @@ data "buildkite_pipeline" "pipeline" {
 
 ### Read-Only
 
+- `cluster_id` (String) The GraphQL ID of the cluster the pipeline is (optionally) attached to.
+- `cluster_name` (String) The name of the cluster the pipeline is (optionally) attached to.
 - `default_branch` (String) The default branch to prefill when new builds are created or triggered.
 - `description` (String) The description of the pipeline.
 - `id` (String) The GraphQL ID of the pipeline.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -159,6 +159,7 @@ resource "github_repository_webhook" "my_webhook" {
 ### Read-Only
 
 - `badge_url` (String) The badge URL showing build state.
+- `cluster_name` (String) The name of the cluster the pipeline is (optionally) attached to.
 - `id` (String) The GraphQL ID of the pipeline.
 - `uuid` (String) The UUID of the pipeline.
 - `webhook_url` (String) The webhook URL used to trigger builds from VCS providers.


### PR DESCRIPTION
* Add `cluster_name` attribute to `buildkite_pipeline` resource
* Add `cluster_id` attribute to `buildkite_pipeline` data source
* Add `cluster_name` attribute to `buildkite_pipeline` data source
* Switch from `public.ecr.aws` to Docker registry to avoid `429 Too Many Requests - Server message: toomanyrequests: Data limit exceeded` errors from `hosted` queue