### PR TITLE
docs: clarify `default_team_id` while creating new pipeline

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -429,6 +429,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			This resource allows you to create and manage pipelines for repositories.
 
 			More information on pipelines can be found in the [documentation](https://buildkite.com/docs/pipelines).
+
+			-> **Note:** When creating a new pipeline, the Buildkite API requires at least one team to be associated with it. You must use the 'default_team_id' attribute to specify this initial team. The 'buildkite_pipeline_team' resource can then be used to manage team access for existing pipelines.
 		`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -483,7 +485,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:            true,
 			},
 			"default_team_id": schema.StringAttribute{
-				MarkdownDescription: "The GraphQL ID of the team to use as the default owner of the pipeline.",
+				MarkdownDescription: "The GraphQL ID of a team to initially assign to the pipeline. This is required by the Buildkite API when creating a new pipeline. The team assigned here will be given 'Manage Build and Read' access. Further team associations can be managed with the `buildkite_pipeline_team` resource after the pipeline is created.",
 				Optional:            true,
 			},
 			"default_branch": schema.StringAttribute{

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   This resource allows you to create and manage pipelines for repositories.
   More information on pipelines can be found in the documentation https://buildkite.com/docs/pipelines.
+  -> Note: When creating a new pipeline, the Buildkite API requires at least one team to be associated with it. You must use the 'default_team_id' attribute to specify this initial team. The 'buildkite_pipeline_team' resource can then be used to manage team access for existing pipelines.
 ---
 
 # buildkite_pipeline (Resource)
@@ -12,6 +13,8 @@ description: |-
 This resource allows you to create and manage pipelines for repositories.
 
 More information on pipelines can be found in the [documentation](https://buildkite.com/docs/pipelines).
+
+-> **Note:** When creating a new pipeline, the Buildkite API requires at least one team to be associated with it. You must use the 'default_team_id' attribute to specify this initial team. The 'buildkite_pipeline_team' resource can then be used to manage team access for existing pipelines.
 
 ## Example Usage
 
@@ -143,7 +146,7 @@ resource "github_repository_webhook" "my_webhook" {
 - `cluster_id` (String) Attach this pipeline to the given cluster GraphQL ID.
 - `color` (String) A color hex code to represent this pipeline.
 - `default_branch` (String) Default branch of the pipeline.
-- `default_team_id` (String) The GraphQL ID of the team to use as the default owner of the pipeline.
+- `default_team_id` (String) The GraphQL ID of a team to initially assign to the pipeline. This is required by the Buildkite API when creating a new pipeline. The team assigned here will be given 'Manage Build and Read' access. Further team associations can be managed with the `buildkite_pipeline_team` resource after the pipeline is created.
 - `default_timeout_in_minutes` (Number) Set pipeline wide timeout for command steps.
 - `description` (String) Description for the pipeline. Can include emoji 🙌.
 - `emoji` (String) An emoji that represents this pipeline.


### PR DESCRIPTION
The Buildkite API requires at least one team to be associated with a new pipeline. 
The `default_team_id` attribute must be used to specify this initial team.

Closes #889 