### PR TITLE
feat(pipeline): add retry logic for delete with active jobs

### DIFF
--- a/buildkite/util.go
+++ b/buildkite/util.go
@@ -14,6 +14,7 @@ import (
 )
 
 var resourceNotFoundRegex = regexp.MustCompile(`(?i)(No\s+\w+(\s+\w+)*\s+found|not\s+found|no\s+longer\s+exists)`)
+var activeJobsRegex = regexp.MustCompile(`(?i)(active\s+(builds|jobs)|running\s+(builds|jobs)|builds?\s+are\s+running|jobs?\s+are\s+running)`)
 
 // isResourceNotFoundError returns true if the error indicates the resource was not found
 func isResourceNotFoundError(err error) bool {
@@ -21,6 +22,14 @@ func isResourceNotFoundError(err error) bool {
 		return false
 	}
 	return resourceNotFoundRegex.MatchString(err.Error())
+}
+
+// isActiveJobsError returns true if the error indicates the pipeline has active jobs/builds preventing deletion
+func isActiveJobsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return activeJobsRegex.MatchString(err.Error())
 }
 
 // GetOrganizationID retrieves the Buildkite organization ID associated with the supplied slug

--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -23,5 +24,78 @@ func TestGetOrganizationIDMissing(t *testing.T) {
 	}
 	if org != nil {
 		t.Fatalf("Nonexistent organization found")
+	}
+}
+
+func TestIsActiveJobsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		shouldMatch bool
+	}{
+		{
+			name:        "nil error",
+			err:         nil,
+			shouldMatch: false,
+		},
+		{
+			name:        "active builds error",
+			err:         errors.New("Cannot delete pipeline with active builds"),
+			shouldMatch: true,
+		},
+		{
+			name:        "running builds error",
+			err:         errors.New("Pipeline has running builds"),
+			shouldMatch: true,
+		},
+		{
+			name:        "active jobs error",
+			err:         errors.New("Cannot delete pipeline with active jobs"),
+			shouldMatch: true,
+		},
+		{
+			name:        "running jobs error",
+			err:         errors.New("Pipeline has running jobs"),
+			shouldMatch: true,
+		},
+		{
+			name:        "builds are running error",
+			err:         errors.New("builds are running"),
+			shouldMatch: true,
+		},
+		{
+			name:        "jobs are running error",
+			err:         errors.New("jobs are running"),
+			shouldMatch: true,
+		},
+		{
+			name:        "case insensitive active builds",
+			err:         errors.New("ACTIVE BUILDS prevent deletion"),
+			shouldMatch: true,
+		},
+		{
+			name:        "case insensitive running builds",
+			err:         errors.New("Running Builds Found"),
+			shouldMatch: true,
+		},
+		{
+			name:        "unrelated error",
+			err:         errors.New("Network connection failed"),
+			shouldMatch: false,
+		},
+		{
+			name:        "permission error",
+			err:         errors.New("Insufficient permissions"),
+			shouldMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isActiveJobsError(tt.err)
+			if result != tt.shouldMatch {
+				t.Errorf("isActiveJobsError(%v) = %v, want %v", tt.err, result, tt.shouldMatch)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add retry mechanism for pipeline deletion when active jobs prevent immediate deletion.

To adjust timeout for `delete` operations, adjust `delete` attribute in `timeouts` settings for the provider – https://registry.terraform.io/providers/buildkite/buildkite/latest/docs#delete-1, example:
```HCL
provider "buildkite" {
  organization = "my-magic-org"
  timeouts = {
    delete = "10m"
  }
}
```

___
Expected output during `terraform apply` when deleting pipeline resource(s):
```
buildkite_pipeline.test: Still destroying... [id=UGlwZWxpbmUtLS0wMTk3YzVmMC1lM2QxLTQyYzItYmI5NS0xZWYzNTg4NDg3ZTE=, 08m00s elapsed]
buildkite_pipeline.test: Destruction complete after 8m8s
```

Closes #504