### PR TITLE
Ensure new macOS shapes are actually usable

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -27,6 +27,8 @@ const (
 	MacInstanceMedium        string = "MACOS_M2_6X14"
 	MacInstanceLarge         string = "MACOS_M2_12X28"
 	MacInstanceXLarge        string = "MACOS_M4_12X56"
+	MacARM64InstanceM4Medium string = "MACOS_ARM64_M4_6X28"
+	MacARM64InstanceM4Large  string = "MACOS_ARM64_M4_12X56"
 	LinuxAMD64InstanceSmall  string = "LINUX_AMD64_2X4"
 	LinuxAMD64InstanceMedium string = "LINUX_AMD64_4X16"
 	LinuxAMD64InstanceLarge  string = "LINUX_AMD64_8X32"
@@ -42,6 +44,8 @@ var MacInstanceShapes = []string{
 	MacInstanceMedium,
 	MacInstanceLarge,
 	MacInstanceXLarge,
+	MacARM64InstanceM4Medium,
+	MacARM64InstanceM4Large,
 }
 
 var LinuxInstanceShapes = []string{

--- a/tf-proj/main.tf
+++ b/tf-proj/main.tf
@@ -28,24 +28,24 @@ resource "buildkite_cluster_queue" "hosted_linux_small" {
   description = "Terraform queue for Hosted Linux"
 
   hosted_agents = {
-    instance_shape = "LINUX_ARM64_2X4"
+    instance_shape = "LINUX_AMD64_2X4"
 
     linux = {
-      agent_image_ref = "elixir:1.17.3-slim"
+      agent_image_ref = "ubuntu:24.04"
     }
   }
 }
 
-resource "buildkite_cluster_queue" "hosted_macos_small" {
+resource "buildkite_cluster_queue" "hosted_macos_medium" {
   cluster_id  = buildkite_cluster.test_cluster.id
-  key         = "hosted-macos-small"
+  key         = "hosted-macos-medium"
   description = "MacOS hosted agents via Terraform"
 
   hosted_agents = {
-    instance_shape = "MACOS_M2_4X7"
+    instance_shape = "MACOS_ARM64_M4_6X28"
 
     mac = {
-      xcode_version = "16.2"
+      xcode_version = "16.3"
     }
   }
 }


### PR DESCRIPTION
Now that we have the updated graph to include the new shapes, we also need to bring these through to the provider to use.

I've brought the internal naming inline with the Linux shapes, with the addition of the `M4` to differentiate specifically with macOS.

Also updated the `tf-proj/` with better defaults and valid config for the new macOS capabilities.