### PR TITLE
SUP-4151: Add description for instance_shape with deprecation notice 

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -203,6 +204,14 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 					},
 					"instance_shape": resource_schema.StringAttribute{
 						Required: true,
+						MarkdownDescription: heredoc.Doc(`
+								The instance shape to use for the Hosted Agent cluster queue. This can be a MacOS instance shape or a Linux instance shape.
+								Valid values are:
+								- ` + strings.Join(MacInstanceShapes, "\n								- ") + `
+								- ` + strings.Join(LinuxInstanceShapes, "\n								- ") + `
+
+								MacOS M4-based shapes (MACOS_ARM64_M4_6X28 and MACOS_ARM64_M4_12X56) supersede the legacy M2-based shapes (MACOS_M2_4X7, MACOS_M2_6X14, MACOS_M2_12X28, MACOS_M4_12X56), which will be deprecated on **July 31 2025**. We advise to update any existing queues to use the new M4 shapes ahead of time to avoid disruption. The legacy M2-based shapes options will be removed in future versions of this Provider. Check the [Buildkite CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) for more details.
+							`),
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								append(MacInstanceShapes, LinuxInstanceShapes...)...,

--- a/docs/resources/cluster_queue.md
+++ b/docs/resources/cluster_queue.md
@@ -91,7 +91,24 @@ resource "buildkite_cluster_queue" "hosted_agents_linux" {
 
 Required:
 
-- `instance_shape` (String)
+- `instance_shape` (String) The instance shape to use for the Hosted Agent cluster queue. This can be a MacOS instance shape or a Linux instance shape.
+Valid values are:
+- MACOS_M2_4X7
+- MACOS_M2_6X14
+- MACOS_M2_12X28
+- MACOS_M4_12X56
+- MACOS_ARM64_M4_6X28
+- MACOS_ARM64_M4_12X56
+- LINUX_AMD64_2X4
+- LINUX_AMD64_4X16
+- LINUX_AMD64_8X32
+- LINUX_AMD64_16X64
+- LINUX_ARM64_2X4
+- LINUX_ARM64_4X16
+- LINUX_ARM64_8X32
+- LINUX_ARM64_16X64
+
+MacOS M4-based shapes (MACOS_ARM64_M4_6X28 and MACOS_ARM64_M4_12X56) supersede the legacy M2-based shapes (MACOS_M2_4X7, MACOS_M2_6X14, MACOS_M2_12X28, MACOS_M4_12X56), which will be deprecated on **July 31 2025**. We advise to update any existing queues to use the new M4 shapes ahead of time to avoid disruption. The legacy M2-based shapes options will be removed in future versions of this Provider. Check the [Buildkite CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) for more details.
 
 Optional:
 


### PR DESCRIPTION
Per [CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) M4 Shapes will supersede M2 Shapes so updating the docs to add such information.