### PR TITLE
SUP-4151: Remove deprecated Mac Instance shapes

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -24,10 +24,6 @@ import (
 
 const (
 	// Available instance shapes
-	MacInstanceSmall         string = "MACOS_M2_4X7"
-	MacInstanceMedium        string = "MACOS_M2_6X14"
-	MacInstanceLarge         string = "MACOS_M2_12X28"
-	MacInstanceXLarge        string = "MACOS_M4_12X56"
 	MacARM64InstanceM4Medium string = "MACOS_ARM64_M4_6X28"
 	MacARM64InstanceM4Large  string = "MACOS_ARM64_M4_12X56"
 	LinuxAMD64InstanceSmall  string = "LINUX_AMD64_2X4"
@@ -46,10 +42,6 @@ const (
 )
 
 var MacInstanceShapes = []string{
-	MacInstanceSmall,
-	MacInstanceMedium,
-	MacInstanceLarge,
-	MacInstanceXLarge,
 	MacARM64InstanceM4Medium,
 	MacARM64InstanceM4Large,
 }

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -217,8 +217,6 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 								Valid values are:
 								- ` + strings.Join(MacInstanceShapes, "\n								- ") + `
 								- ` + strings.Join(LinuxInstanceShapes, "\n								- ") + `
-
-								MacOS M4-based shapes (MACOS_ARM64_M4_6X28 and MACOS_ARM64_M4_12X56) supersede the legacy M2-based shapes (MACOS_M2_4X7, MACOS_M2_6X14, MACOS_M2_12X28, MACOS_M4_12X56), which will be deprecated on **July 31 2025**. We advise to update any existing queues to use the new M4 shapes ahead of time to avoid disruption. The legacy M2-based shapes options will be removed in future versions of this Provider. Check the [Buildkite CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) for more details.
 							`),
 						Validators: []validator.String{
 							stringvalidator.OneOf(

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -86,7 +86,7 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
             mac = {
                 xcode_version = "14.3.1"
             }
-            instance_shape = "MACOS_M2_4X7"
+            instance_shape = "MACOS_ARM64_M4_6X28"
         }
     }
     `, fields[0], fields[1], fields[2])
@@ -179,7 +179,7 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
             linux = {
                 agent_image_ref = "buildkite/agent:latest"
             }
-            instance_shape = "MACOS_M2_4X7"
+            instance_shape = "MACOS_ARM64_M4_6X28"
         }
     }
     `, fields[0], fields[1], fields[2])
@@ -213,7 +213,7 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
             linux = {
                 agent_image_ref = "buildkite/agent:latest"
             }
-            instance_shape = "MACOS_M2_4X7"
+            instance_shape = "MACOS_ARM64_M4_6X28"
         }
     }
     `, fields[0], fields[1], fields[2])
@@ -386,7 +386,7 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 
 		check := resource.ComposeAggregateTestCheckFunc(
 			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
-			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.instance_shape", "MACOS_M2_4X7"),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.instance_shape", "MACOS_ARM64_M4_6X28"),
 			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.mac.xcode_version", "14.3.1"),
 		)
 

--- a/docs/resources/cluster_queue.md
+++ b/docs/resources/cluster_queue.md
@@ -93,10 +93,6 @@ Required:
 
 - `instance_shape` (String) The instance shape to use for the Hosted Agent cluster queue. This can be a MacOS instance shape or a Linux instance shape.
 Valid values are:
-- MACOS_M2_4X7
-- MACOS_M2_6X14
-- MACOS_M2_12X28
-- MACOS_M4_12X56
 - MACOS_ARM64_M4_6X28
 - MACOS_ARM64_M4_12X56
 - LINUX_AMD64_2X4
@@ -107,8 +103,6 @@ Valid values are:
 - LINUX_ARM64_4X16
 - LINUX_ARM64_8X32
 - LINUX_ARM64_16X64
-
-MacOS M4-based shapes (MACOS_ARM64_M4_6X28 and MACOS_ARM64_M4_12X56) supersede the legacy M2-based shapes (MACOS_M2_4X7, MACOS_M2_6X14, MACOS_M2_12X28, MACOS_M4_12X56), which will be deprecated on **July 31 2025**. We advise to update any existing queues to use the new M4 shapes ahead of time to avoid disruption. The legacy M2-based shapes options will be removed in future versions of this Provider. Check the [Buildkite CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) for more details.
 
 Optional:
 

--- a/docs/resources/cluster_queue.md
+++ b/docs/resources/cluster_queue.md
@@ -44,7 +44,7 @@ resource "buildkite_cluster_queue" "hosted_agents_macos" {
   dispatch_paused = true
 
   hosted_agents = {
-    instance_shape = "MACOS_M2_4X7"
+    instance_shape = "MACOS_ARM64_M4_6X28"
   }
 }
 

--- a/examples/resources/buildkite_cluster_queue/resource.tf
+++ b/examples/resources/buildkite_cluster_queue/resource.tf
@@ -29,7 +29,7 @@ resource "buildkite_cluster_queue" "hosted_agents_macos" {
   dispatch_paused = true
 
   hosted_agents = {
-    instance_shape = "MACOS_M2_4X7"
+    instance_shape = "MACOS_ARM64_M4_6X28"
   }
 }
 


### PR DESCRIPTION
**CREATED AS DRAFT TO BE MERGED AFTER 31 JULY 2025**

Per [CHANGELOG](https://buildkite.com/resources/changelog/293-mac-hosted-agents-now-running-on-m4-pro-hardware/) M2 Instances Shapes have been superseded and no longer valid so removing them and updating docs.

Will need to be rebased as based as Built upon changes from https://github.com/buildkite/terraform-provider-buildkite/pull/952

- [x] `schema.graphql` to be updated
- [x] `generated.go` to be updated
