### PR TITLE
Fix wrong `slug` value set during pipeline updates

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -898,15 +898,13 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
 	if len(plan.Slug.ValueString()) > 0 {
 		useSlugValue = plan.Slug.ValueString()
-		if plan.Slug != state.Slug {
-			_, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
-			if err != nil {
-				resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
-				return
-			}
-
-			resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
+		_, err := updatePipelineSlug(ctx, response.PipelineUpdate.Pipeline.Slug, useSlugValue, p.client, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to set pipeline slug from REST", err.Error())
+			return
 		}
+
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
 	}
 
 	setPipelineModel(&state, &response.PipelineUpdate.Pipeline)

--- a/internal/planmodifier/use_derived_pipeline_slug.go
+++ b/internal/planmodifier/use_derived_pipeline_slug.go
@@ -57,13 +57,9 @@ func (m useDerivedPipelineSlugModifier) PlanModifyString(ctx context.Context, re
 			resp.PlanValue = types.StringUnknown()
 			return
 		}
-		// Return unknown if name is changing (re-generate slug from API)
+		// Return unknown if pipeline name is changing (re-generate slug from API)
 		if planValueName != stateValueName {
 			resp.PlanValue = types.StringUnknown()
-			return
-		} else {
-			// Name not changed, Config provided matches value in state, set value to state (NoOp)
-			resp.PlanValue = req.StateValue
 			return
 		}
 	}


### PR DESCRIPTION
The additional comparison between plan and state for `slug` is unnecessary during updates. This was resulting in the `slug` becoming derived from the pipeline name during updates and leaving `slug` value in state as user-defined. Also removed an unnecessary condition in the `planmodifier` used to evaluate user- vs. api-defined `slug` attribute.

Fixes https://github.com/buildkite/terraform-provider-buildkite/issues/954