### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -2,8 +2,12 @@ steps:
   - label: release
     command: ".buildkite/steps/release.sh"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-terraform-provider-buildkite-release
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.3.0:
           account-ids: "445615400570"
           login: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,8 +45,12 @@ steps:
     concurrency_group: terraform-provider-acceptance-tests
     command: .buildkite/steps/annotate.sh
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-terraform-provider-buildkite-main
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
             BUILDKITE_ORGANIZATION_SLUG: /pipelines/buildkite/terraform-provider-buildkite-main/buildkite_organization


### PR DESCRIPTION
Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/471