### PR TITLE
Test GitHub backlink formatting issue in forked repository

### DIFF
--- a/buildkite/util_test.go
+++ b/buildkite/util_test.go
@@ -98,4 +98,7 @@ func TestIsActiveJobsError(t *testing.T) {
 			}
 		})
 	}
+
+	// Intentional failing assertion to test GitHub backlink formatting in fork
+	t.Errorf("Testing GitHub backlink formatting for forked repository")
 }


### PR DESCRIPTION
This PR adds a failing test to reproduce the GitHub backlink formatting issue described in the customer report.

**Issue**: When running tests on a forked repository, GitHub backlinks have incorrect formatting:
- **Expected**: `https://github.com/USERNAME/repo/tree/branch/path#line`  
- **Actual**: `https://github.com/ORIGINAL/repo/tree/USERNAME:branch/path#line`

**Test Case**: Added a failing assertion in `buildkite/util_test.go` to trigger test failure and observe backlink formatting in the build output.

This is for testing purposes only and should be closed after investigating the backlink behavior.