### PR TITLE
Allow for the InstanceShape of a Queue to not require re-creation

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -217,9 +217,6 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 								append(MacInstanceShapes, LinuxInstanceShapes...)...,
 							),
 						},
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description

I think we had some nuances with the GraphQL API a little while ago where it wasn't possible to update the instance shape of a Queue without destroying and creating it again. This is no longer the case, or at the very least it is now possible to change this value with an update as expected.

I'm not sure if there are tests associated with this functionality, nor if there's anything else related to this that requires, in dev when I tried to change a Queue with this code diff it was updated rather than re-created.

## Context

Fixes #960 