### PR TITLE
Adding v1.24.0 to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.24.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.23.0...v1.24.0)
+
+- Improve default team handling for pipeline resource by @JoeColeman95 in https://github.com/buildkite/terraform-provider-buildkite/pull/969
+- New data sources - buildkite_clusters, buildkite_teams by @petetomasik in https://github.com/buildkite/terraform-provider-buildkite/pull/971
+- Switch buildkite_cluster_queue read to use Node ID by @petetomasik in https://github.com/buildkite/terraform-provider-buildkite/pull/972
+
 ## [v1.23.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.22.1...v1.23.0)
 
 - Fix wrong `slug` value set during pipeline updates by @petetomasik in https://github.com/buildkite/terraform-provider-buildkite/pull/956
@@ -159,7 +165,7 @@
 ## [v1.13.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.13.0...v1.13.1)
 
 - SUP-1816 - Signed pipeline steps documentation updates [[PR #579](https://github.com/buildkite/terraform-provider-buildkite/pull/579)] @petetomasik
-- Document that the PS512 and ES512 algorithms are nondeterministic [[PR #583](https://github.com/buildkite/terraform-provider-buildkite/pull/583)] @petetomasik 
+- Document that the PS512 and ES512 algorithms are nondeterministic [[PR #583](https://github.com/buildkite/terraform-provider-buildkite/pull/583)] @petetomasik
 - SUP-2774: Stop panicking on organization rule updates [[PR #584](https://github.com/buildkite/terraform-provider-buildkite/pull/584)] @james2791
 
 ## [v1.13.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.12.0...v1.13.0)


### PR DESCRIPTION
Adds the following PR's to the Changelog for version v1.24.0:

- Improve default team handling for pipeline resource by @JoeColeman95 in https://github.com/buildkite/terraform-provider-buildkite/pull/969
- New data sources - buildkite_clusters, buildkite_teams by @petetomasik in https://github.com/buildkite/terraform-provider-buildkite/pull/971
- Switch buildkite_cluster_queue read to use Node ID by @petetomasik in https://github.com/buildkite/terraform-provider-buildkite/pull/972
