### PR TITLE
Trim white space for provider config string values

### DIFF
--- a/buildkite/provider.go
+++ b/buildkite/provider.go
@@ -83,10 +83,10 @@ func (tf *terraformProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	config := clientConfig{
-		apiToken:   apiToken,
-		graphqlURL: graphqlUrl,
-		org:        organization,
-		restURL:    restURL,
+		apiToken:   strings.TrimSpace(apiToken),
+		graphqlURL: strings.TrimSpace(graphqlUrl),
+		org:        strings.TrimSpace(organization),
+		restURL:    strings.TrimSpace(restURL),
 		timeouts:   data.Timeouts,
 		userAgent:  userAgent("buildkite", tf.version, req.TerraformVersion),
 		maxRetries: maxRetries,


### PR DESCRIPTION
The `api_token`, `graphql_url`, `rest_url`, and `organization` configuration values for the provider allow white space at the beginning and end of their strings. This, at least, causes authentication failures when things like newlines sneak into the value of `api_token`. Each of these now has white space stripped value no matter the source (env var or otherwise).

This problem was discovered when attempting to read a Buildkite API token from a file on disk which contained a newline, like so:

```
provider "buildkite" {
  organization = "xxxxxxxx"
  api_token    = file(pathexpand("~/.cloud/buildkite"))
}
```

And the solution in Terraform was to wrap the file read in [`trimspace()`](https://developer.hashicorp.com/terraform/language/functions/trimspace). This PR removes the need to do this for the config values listed above.