### PR TITLE
Revert "warn on plan for duplicate pipeline name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## [v1.24.1](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.24.0...v1.24.1)
-
-- Warn on `plan` when a pipeline with the same name already exists by @mcncl in https://github.com/buildkite/terraform-provider-buildkite/pull/975
-
 ## [v1.24.0](https://github.com/buildkite/terraform-provider-buildkite/compare/v1.23.0...v1.24.0)
 
 - Improve default team handling for pipeline resource by @JoeColeman95 in https://github.com/buildkite/terraform-provider-buildkite/pull/969

--- a/buildkite/data_source_registry.go
+++ b/buildkite/data_source_registry.go
@@ -17,10 +17,8 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces
-var (
-	_ datasource.DataSource              = &registryDatasource{}
-	_ datasource.DataSourceWithConfigure = &registryDatasource{}
-)
+var _ datasource.DataSource = &registryDatasource{}
+var _ datasource.DataSourceWithConfigure = &registryDatasource{}
 
 func newRegistryDatasource() datasource.DataSource {
 	return &registryDatasource{}
@@ -220,6 +218,7 @@ func (d *registryDatasource) Read(ctx context.Context, req datasource.ReadReques
 
 		return nil
 	})
+
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to query Registry", fmt.Sprintf("Failed to query Registry with slug '%s' after multiple attempts: %s", state.Slug.ValueString(), err.Error()))
 		return

--- a/buildkite/data_source_registry_test.go
+++ b/buildkite/data_source_registry_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestAccDataSourceRegistry_Basic(t *testing.T) {
 	randName := acctest.RandString(10)
-	resourceName := "buildkite_registry.test_reg"
-	dataSourceName := "data.buildkite_registry.data_test_reg"
+	var resourceName = "buildkite_registry.test_reg"
+	var dataSourceName = "data.buildkite_registry.data_test_reg"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/buildkite/resource_agent_token_test.go
+++ b/buildkite/resource_agent_token_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccBuildkiteAgentToken(t *testing.T) {
+
 	basic := func(name string) string {
 		return fmt.Sprintf(`
 		provider "buildkite" {

--- a/buildkite/resource_cluster_agent_token_test.go
+++ b/buildkite/resource_cluster_agent_token_test.go
@@ -228,6 +228,7 @@ func testAccCheckClusterAgentTokenDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_cluster_agent_token" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -559,6 +559,7 @@ func testAccCheckClusterQueueDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_cluster_queue" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_cluster_test.go
+++ b/buildkite/resource_cluster_test.go
@@ -201,6 +201,7 @@ func testAccCheckClusterDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_cluster" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"time"
 	"unsafe"
 
@@ -342,6 +341,7 @@ func (p *pipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 
 		return retryContextError(err)
 	})
+
 	if err != nil {
 		errorMsg := fmt.Sprintf("Could not delete pipeline: %s", err.Error())
 		if isActiveJobsError(err) {
@@ -862,36 +862,6 @@ func (p *pipelineResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 
-	// Check for duplicate pipeline names during creation
-	if req.State.Raw.IsNull() {
-		// This is a create operation
-		var planName, planSlug types.String
-		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("name"), &planName)...)
-		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("slug"), &planSlug)...)
-
-		if !planName.IsNull() && !planName.IsUnknown() {
-			// Derive slug from name if not provided
-			slugToCheck := deriveSlugFromName(planName.ValueString())
-			if !planSlug.IsNull() && !planSlug.IsUnknown() {
-				// Use the provided slug instead
-				slugToCheck = planSlug.ValueString()
-			}
-
-			// Check if a pipeline with this slug already exists
-			orgPipelineSlug := fmt.Sprintf("%s/%s", p.client.organization, slugToCheck)
-			existingPipeline, err := getPipeline(ctx, p.client.genqlient, orgPipelineSlug)
-			if err == nil && existingPipeline != nil && existingPipeline.Pipeline.Id != "" {
-				// Pipeline with this name/slug already exists
-				resp.Diagnostics.AddError(
-					"Pipeline name already exists",
-					fmt.Sprintf("A pipeline with the name '%s' (slug: '%s') already exists in the organization '%s'. Please choose a different name or slug.",
-						planName.ValueString(), slugToCheck, p.client.organization),
-				)
-				return
-			}
-		}
-	}
-
 	var configTemplate, configSteps types.String
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("pipeline_template_id"), &configTemplate)...)
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("steps"), &configSteps)...)
@@ -1241,26 +1211,6 @@ func getTagsFromSchema(plan *pipelineResourceModel) []PipelineTagInput {
 		}
 	}
 	return tags
-}
-
-// deriveSlugFromName converts a pipeline name to a slug following Buildkite's conventions
-// This mimics the API behavior: lowercase, replace spaces and special chars with hyphens
-func deriveSlugFromName(name string) string {
-	// Convert to lowercase
-	slug := strings.ToLower(name)
-
-	// Replace spaces and special characters with hyphens
-	reg := regexp.MustCompile(`[^a-z0-9-]+`)
-	slug = reg.ReplaceAllString(slug, "-")
-
-	// Remove leading/trailing hyphens
-	slug = strings.Trim(slug, "-")
-
-	// Collapse multiple hyphens into one
-	reg = regexp.MustCompile(`-+`)
-	slug = reg.ReplaceAllString(slug, "-")
-
-	return slug
 }
 
 // updatePipelineResourceExtraInfo updates the terraform resource with data received from Buildkite REST API

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -220,6 +220,7 @@ func testAccCheckPipelineScheduleDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_pipeline_schedule" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_pipeline_template_test.go
+++ b/buildkite/resource_pipeline_template_test.go
@@ -241,6 +241,7 @@ func testAccCheckPipelineTemplateDestroy(s *terraform.State) error {
 		r, err := getNode(context.Background(), genqlientGraphql, rs.Primary.ID)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
+
 				continue
 			}
 			return err

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -78,6 +77,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 	}
 	aggregateRemoteCheck := func(pipeline *getPipelinePipeline) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
+
 			var err error
 			p := s.RootModule().Resources["buildkite_pipeline.pipeline"]
 
@@ -96,6 +96,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 
 	aggregateRemoteCheckWithTemplateSteps := func(pipeline *getPipelinePipeline) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
+
 			var err error
 			p := s.RootModule().Resources["buildkite_pipeline.pipeline"]
 
@@ -1256,49 +1257,6 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "steps"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "name", pipelineName),
 					),
-				},
-			},
-		})
-	})
-
-	t.Run("detect duplicate pipeline names during plan", func(t *testing.T) {
-		pipelineName := acctest.RandString(12)
-
-		// First, create a pipeline with a unique name
-		configOriginal := fmt.Sprintf(`
-			resource "buildkite_pipeline" "original" {
-				name = "%s"
-				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
-			}
-		`, pipelineName)
-
-		// Then, try to create another pipeline with the same name
-		configDuplicate := fmt.Sprintf(`
-			resource "buildkite_pipeline" "original" {
-				name = "%s"
-				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
-			}
-			resource "buildkite_pipeline" "duplicate" {
-				name = "%s"
-				repository = "https://github.com/buildkite/terraform-provider-buildkite2.git"
-			}
-		`, pipelineName, pipelineName)
-
-		resource.ParallelTest(t, resource.TestCase{
-			PreCheck:                 func() { testAccPreCheck(t) },
-			ProtoV6ProviderFactories: protoV6ProviderFactories(),
-			CheckDestroy:             testAccCheckPipelineDestroyFunc,
-			Steps: []resource.TestStep{
-				{
-					Config: configOriginal,
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("buildkite_pipeline.original", "name", pipelineName),
-					),
-				},
-				{
-					Config:      configDuplicate,
-					ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)Pipeline name already exists.*%s", pipelineName)),
-					PlanOnly:    true,
 				},
 			},
 		})

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -219,6 +219,7 @@ func testCheckTeamMemberResourceRemoved(s *terraform.State) error {
 		if rs.Type != "buildkite_team_member" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_team_test.go
+++ b/buildkite/resource_team_test.go
@@ -225,6 +225,7 @@ func testAccCheckTeamResourceDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_team" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/resource_test_suite_test.go
+++ b/buildkite/resource_test_suite_test.go
@@ -339,6 +339,7 @@ func testTestSuiteDestroy(s *terraform.State) error {
 		if rs.Type != "buildkite_test_suite" {
 			continue
 		}
+
 	}
 	return nil
 }

--- a/buildkite/util.go
+++ b/buildkite/util.go
@@ -13,10 +13,8 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
-var (
-	resourceNotFoundRegex = regexp.MustCompile(`(?i)(No\s+\w+(\s+\w+)*\s+found|not\s+found|no\s+longer\s+exists)`)
-	activeJobsRegex       = regexp.MustCompile(`(?i)(active\s+(builds|jobs)|running\s+(builds|jobs)|builds?\s+are\s+running|jobs?\s+are\s+running)`)
-)
+var resourceNotFoundRegex = regexp.MustCompile(`(?i)(No\s+\w+(\s+\w+)*\s+found|not\s+found|no\s+longer\s+exists)`)
+var activeJobsRegex = regexp.MustCompile(`(?i)(active\s+(builds|jobs)|running\s+(builds|jobs)|builds?\s+are\s+running|jobs?\s+are\s+running)`)
 
 // isResourceNotFoundError returns true if the error indicates the resource was not found
 func isResourceNotFoundError(err error) bool {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/alexflint/go-arg v1.5.1 // indirect
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -34,7 +34,7 @@ require (
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/oleiade/reflections v1.1.0 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/suessflorian/gqlfetch v0.7.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
-github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
+github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
@@ -188,8 +188,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=


### PR DESCRIPTION
Reverts buildkite/terraform-provider-buildkite#975

## Why?

There's been some very valid discussion that this change brings up other issues;
- Do we do this for everything?
- Other providers don't do this; the AWS provider errors on `apply`
- The error will still only happen on `apply` if you don't have sufficient permissions to view the original pipeline
- Does the last one create permission/security concern where intentionally not allowing a user to see a pipeline will confirm the pipeline exists at `plan`