### PR TITLE
Fix pipeline webhook acceptance tests for updated API error messages

### DIFF
--- a/buildkite/resource_pipeline_webhook_test.go
+++ b/buildkite/resource_pipeline_webhook_test.go
@@ -287,7 +287,7 @@ func TestAccBuildkitePipelineWebhook_UnsupportedProvider(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      configUnsupportedProvider(pipelineName),
-					ExpectError: regexp.MustCompile(`Auto-creating webhooks is not\s+supported for your repository provider`),
+					ExpectError: regexp.MustCompile(`Auto-creating webhooks is only\s+supported for GitHub and GitHub Enterprise repositories`),
 				},
 			},
 		})


### PR DESCRIPTION
The pipelineCreateMuatation now returns further detail if the repository webhook could not be created because the repository provider does not support webhooks.

https://github.com/buildkite/terraform-provider-buildkite/pull/1021 wasn't re-run before merging against the new API changes. 