### PR TITLE
Auto retries for ossf scanning

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,6 +76,10 @@ steps:
     plugins:
       - ossf-scorecard#v1.0.1:
           github_token: $$GITHUB_TOKEN
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
 
   - label: build
     command: "make build-snapshot"


### PR DESCRIPTION
Adding automatic retries to the OSSF security scan to account for transient network issues to `scorecard.dev`.