### PR TITLE
Add support for build triggering on issue comments.

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -129,6 +129,9 @@ type providerSettingsModel struct {
 	BuildMergeGroupChecksRequested          types.Bool   `tfsdk:"build_merge_group_checks_requested"`
 	CancelWhenMergeGroupDestroyed           types.Bool   `tfsdk:"cancel_when_merge_group_destroyed"`
 	UseMergeGroupBaseCommitForGitDiffBase   types.Bool   `tfsdk:"use_merge_group_base_commit_for_git_diff_base"`
+	BuildIssueCommentCreated                types.Bool   `tfsdk:"build_issue_comment_created"`
+	IssueCommentCommandWord                 types.String `tfsdk:"issue_comment_command_word"`
+	IssueCommentMatchMode                   types.String `tfsdk:"issue_comment_match_mode"`
 }
 
 type pipelineResource struct {
@@ -988,6 +991,33 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
 					},
+					"build_issue_comment_created": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create builds when an issue comment is created on a pull request.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"issue_comment_command_word": schema.StringAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "The command word used to trigger builds from issue comments (e.g. \"/bk\"). Only comments starting with or containing this word will trigger builds. Defaults to \"/bk\".",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"issue_comment_match_mode": schema.StringAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "The match mode for the issue comment command word. Valid values are \"exact\" and \"contains\". Defaults to \"exact\".",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseNonNullStateForUnknown(),
+						},
+						Validators: []validator.String{
+							stringvalidator.OneOf("exact", "contains"),
+						},
+					},
 				},
 			},
 		},
@@ -1350,6 +1380,9 @@ type PipelineExtraSettings struct {
 	BuildMergeGroupChecksRequested          *bool   `json:"build_merge_group_checks_requested,omitempty"`
 	CancelWhenMergeGroupDestroyed           *bool   `json:"cancel_when_merge_group_destroyed,omitempty"`
 	UseMergeGroupBaseCommitForGitDiffBase   *bool   `json:"use_merge_group_base_commit_for_git_diff_base,omitempty"`
+	BuildIssueCommentCreated                *bool   `json:"build_issue_comment_created,omitempty"`
+	IssueCommentCommandWord                 *string `json:"issue_comment_command_word,omitempty"`
+	IssueCommentMatchMode                   *string `json:"issue_comment_match_mode,omitempty"`
 }
 
 func getPipelineExtraInfo(ctx context.Context, client *Client, slug string, timeouts time.Duration) (*PipelineExtraInfo, error) {
@@ -1413,6 +1446,9 @@ func updatePipelineExtraInfo(ctx context.Context, slug string, settings *provide
 			BuildMergeGroupChecksRequested:          settings.BuildMergeGroupChecksRequested.ValueBoolPointer(),
 			CancelWhenMergeGroupDestroyed:           settings.CancelWhenMergeGroupDestroyed.ValueBoolPointer(),
 			UseMergeGroupBaseCommitForGitDiffBase:   settings.UseMergeGroupBaseCommitForGitDiffBase.ValueBoolPointer(),
+			BuildIssueCommentCreated:                settings.BuildIssueCommentCreated.ValueBoolPointer(),
+			IssueCommentCommandWord:                 settings.IssueCommentCommandWord.ValueStringPointer(),
+			IssueCommentMatchMode:                   settings.IssueCommentMatchMode.ValueStringPointer(),
 		},
 	}
 
@@ -1467,6 +1503,9 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		BuildMergeGroupChecksRequested:          types.BoolPointerValue(s.BuildMergeGroupChecksRequested),
 		CancelWhenMergeGroupDestroyed:           types.BoolPointerValue(s.CancelWhenMergeGroupDestroyed),
 		UseMergeGroupBaseCommitForGitDiffBase:   types.BoolPointerValue(s.UseMergeGroupBaseCommitForGitDiffBase),
+		BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
+		IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
+		IssueCommentMatchMode:                   types.StringPointerValue(s.IssueCommentMatchMode),
 	}
 }
 
@@ -1728,6 +1767,18 @@ func pipelineSchemaV0() schema.Schema {
 							Optional: true,
 						},
 						"use_merge_group_base_commit_for_git_diff_base": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_issue_comment_created": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"issue_comment_command_word": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"issue_comment_match_mode": schema.StringAttribute{
 							Computed: true,
 							Optional: true,
 						},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -614,6 +614,9 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					build_merge_group_checks_requested = true
 					cancel_when_merge_group_destroyed = true
 					use_merge_group_base_commit_for_git_diff_base = true
+					build_issue_comment_created = true
+					issue_comment_command_word = "ci-force-rerun"
+					issue_comment_match_mode = "exact"
 				}
 			}
 		`, clusterName, pipelineName)
@@ -658,6 +661,9 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_merge_group_checks_requested", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_when_merge_group_destroyed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.use_merge_group_base_commit_for_git_diff_base", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "exact"),
 					),
 				},
 			},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -736,6 +736,9 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 								build_merge_group_checks_requested = true
 								cancel_when_merge_group_destroyed = true
 								use_merge_group_base_commit_for_git_diff_base = true
+								build_issue_comment_created = true
+								issue_comment_command_word = "/deploy"
+								issue_comment_match_mode = "contains"
 							}
 						}
 					`, clusterName, pipelineName),
@@ -757,6 +760,9 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_merge_group_checks_requested", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.cancel_when_merge_group_destroyed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.use_merge_group_base_commit_for_git_diff_base", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "/deploy"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "contains"),
 						aggregateRemoteCheck(&pipeline),
 					),
 				},

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -203,6 +203,7 @@ resource "github_repository_webhook" "my_webhook" {
 Optional:
 
 - `build_branches` (Boolean) Whether to create builds when branches are pushed.
+- `build_issue_comment_created` (Boolean) Whether to create builds when an issue comment is created on a pull request.
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
@@ -216,6 +217,8 @@ Optional:
 - `filter_condition` (String) The condition to evaluate when deciding if a build should run. This is only valid when `trigger_mode` is `code`. More details available in [the documentation](https://buildkite.com/docs/pipelines/conditionals).
 - `filter_enabled` (Boolean) Whether to filter builds to only run when the condition in `filter_condition` is true.
 - `ignore_default_branch_pull_requests` (Boolean) Whether to prevent caching pull requests with the source branch matching the default branch.
+- `issue_comment_command_word` (String) The command word used to trigger builds from issue comments (e.g. "/bk"). Only comments starting with or containing this word will trigger builds. Defaults to "/bk".
+- `issue_comment_match_mode` (String) The match mode for the issue comment command word. Valid values are "exact" and "contains". Defaults to "exact".
 - `prefix_pull_request_fork_branch_names` (Boolean) Prefix branch names for third-party fork builds to ensure they don't trigger branch conditions. For example, the main branch from some-user will become some-user:main.
 - `publish_blocked_as_pending` (Boolean) The status to use for blocked builds. Pending can be used with [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) to prevent merging pull requests with blocked builds.
 - `publish_commit_status` (Boolean) Whether to update the status of commits in Bitbucket, GitHub, or GitLab.


### PR DESCRIPTION
Buildkite now supports issue comment triggers on pipelines. Add support for this to our Terraform provider. Fixes #1138. I've tested this locally, works as expected.