### PR TITLE
Fix bug with empty `env` map

### DIFF
--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -103,11 +103,9 @@ func (ps *pipelineSchedule) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "The message the builds show for builds created by this schedule.",
 			},
 			"env": resource_schema.MapAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				MarkdownDescription: "The environment variables that scheduled builds should use. " +
-					"An empty map (`{}`) is equivalent to omitting this attribute at the API level, " +
-					"though Terraform preserves whichever shape you wrote in your configuration.",
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "The environment variables that scheduled builds should use. An empty map (`{}`) is equivalent to omitting this attribute at the API level.",
 			},
 			"enabled": resource_schema.BoolAttribute{
 				Optional:            true,
@@ -355,9 +353,9 @@ func updatePipelineScheduleNode(ctx context.Context, psState *pipelineScheduleRe
 	psState.Enabled = types.BoolValue(psNode.Enabled)
 	newEnv := envVarsArrayToMap(ctx, psNode.Env)
 	// API returns empty for both `env = {}` and omitted env; preserve the
-	// prior state's shape when there are no env vars to avoid drift (#1152).
+	// prior state's shape when there are no env vars to avoid drift.
 	priorIsEmptyMap := !psState.Env.IsNull() && len(psState.Env.Elements()) == 0
-	if !newEnv.IsNull() || !priorIsEmptyMap {
+	if !(newEnv.IsNull() && priorIsEmptyMap) {
 		psState.Env = newEnv
 	}
 	psState.PipelineId = types.StringValue(psNode.Pipeline.Id)

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -355,7 +355,8 @@ func updatePipelineScheduleNode(ctx context.Context, psState *pipelineScheduleRe
 	// API returns empty for both `env = {}` and omitted env; preserve the
 	// prior state's shape when there are no env vars to avoid drift.
 	priorIsEmptyMap := !psState.Env.IsNull() && len(psState.Env.Elements()) == 0
-	if !(newEnv.IsNull() && priorIsEmptyMap) {
+	preserveEmptyMap := newEnv.IsNull() && priorIsEmptyMap
+	if !preserveEmptyMap {
 		psState.Env = newEnv
 	}
 	psState.PipelineId = types.StringValue(psNode.Pipeline.Id)

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -103,9 +103,11 @@ func (ps *pipelineSchedule) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "The message the builds show for builds created by this schedule.",
 			},
 			"env": resource_schema.MapAttribute{
-				ElementType:         types.StringType,
-				Optional:            true,
-				MarkdownDescription: "The environment variables that scheduled builds should use.",
+				ElementType: types.StringType,
+				Optional:    true,
+				MarkdownDescription: "The environment variables that scheduled builds should use. " +
+					"An empty map (`{}`) is equivalent to omitting this attribute at the API level, " +
+					"though Terraform preserves whichever shape you wrote in your configuration.",
 			},
 			"enabled": resource_schema.BoolAttribute{
 				Optional:            true,

--- a/buildkite/resource_pipeline_schedule.go
+++ b/buildkite/resource_pipeline_schedule.go
@@ -351,6 +351,12 @@ func updatePipelineScheduleNode(ctx context.Context, psState *pipelineScheduleRe
 	psState.Cronline = types.StringPointerValue(psNode.Cronline)
 	psState.Message = types.StringPointerValue(psNode.Message)
 	psState.Enabled = types.BoolValue(psNode.Enabled)
-	psState.Env = envVarsArrayToMap(ctx, psNode.Env)
+	newEnv := envVarsArrayToMap(ctx, psNode.Env)
+	// API returns empty for both `env = {}` and omitted env; preserve the
+	// prior state's shape when there are no env vars to avoid drift (#1152).
+	priorIsEmptyMap := !psState.Env.IsNull() && len(psState.Env.Elements()) == 0
+	if !newEnv.IsNull() || !priorIsEmptyMap {
+		psState.Env = newEnv
+	}
 	psState.PipelineId = types.StringValue(psNode.Pipeline.Id)
 }

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -208,6 +208,40 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 		})
 	})
 
+	t.Run("pipeline schedule env transitions between empty and populated", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		label := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineScheduleDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(pipelineName, "0 * * * *", label, "", true),
+					Check:  resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.%", "0"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+				{
+					Config: config(pipelineName, "0 * * * *", label, "FOO = \"bar\"", true),
+					Check:  resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.FOO", "bar"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+				{
+					Config: config(pipelineName, "0 * * * *", label, "", true),
+					Check:  resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.%", "0"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("pipeline schedule is recreated if removed", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 		label := acctest.RandString(12)

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -184,30 +184,6 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 		})
 	})
 
-	t.Run("pipeline schedule can be created with an empty env map", func(t *testing.T) {
-		pipelineName := acctest.RandString(12)
-		label := acctest.RandString(12)
-
-		resource.ParallelTest(t, resource.TestCase{
-			PreCheck:                 func() { testAccPreCheck(t) },
-			ProtoV6ProviderFactories: protoV6ProviderFactories(),
-			CheckDestroy:             testAccCheckPipelineScheduleDestroy,
-			Steps: []resource.TestStep{
-				{
-					Config: config(pipelineName, "0 * * * *", label, "", true),
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.%", "0"),
-					),
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PostApplyPostRefresh: []plancheck.PlanCheck{
-							plancheck.ExpectEmptyPlan(),
-						},
-					},
-				},
-			},
-		})
-	})
-
 	t.Run("pipeline schedule env transitions between empty and populated", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 		label := acctest.RandString(12)
@@ -236,6 +212,46 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 					Check:  resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.%", "0"),
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("pipeline schedule detects out-of-band env deletion", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		label := acctest.RandString(12)
+		cronline := "0 * * * *"
+		branch := "main"
+		enabled := true
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineScheduleDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(pipelineName, cronline, label, "FOO = \"bar\"", enabled),
+					Check: func(s *terraform.State) error {
+						ps := s.RootModule().Resources["buildkite_pipeline_schedule.pipeline"]
+						emptyEnv := ""
+						_, err := updatePipelineSchedule(context.Background(),
+							genqlientGraphql,
+							PipelineScheduleUpdateInput{
+								Id:       ps.Primary.ID,
+								Label:    &label,
+								Cronline: &cronline,
+								Branch:   &branch,
+								Enabled:  &enabled,
+								Env:      &emptyEnv,
+							})
+						return err
+					},
+					ExpectNonEmptyPlan: true,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("buildkite_pipeline_schedule.pipeline", plancheck.ResourceActionUpdate),
+						},
 					},
 				},
 			},

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -184,6 +184,30 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 		})
 	})
 
+	t.Run("pipeline schedule can be created with an empty env map", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		label := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineScheduleDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: config(pipelineName, "0 * * * *", label, "", true),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline_schedule.pipeline", "env.%", "0"),
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("pipeline schedule is recreated if removed", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 		label := acctest.RandString(12)

--- a/buildkite/resource_pipeline_schedule_test.go
+++ b/buildkite/resource_pipeline_schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -218,46 +219,6 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 		})
 	})
 
-	t.Run("pipeline schedule detects out-of-band env deletion", func(t *testing.T) {
-		pipelineName := acctest.RandString(12)
-		label := acctest.RandString(12)
-		cronline := "0 * * * *"
-		branch := "main"
-		enabled := true
-
-		resource.ParallelTest(t, resource.TestCase{
-			PreCheck:                 func() { testAccPreCheck(t) },
-			ProtoV6ProviderFactories: protoV6ProviderFactories(),
-			CheckDestroy:             testAccCheckPipelineScheduleDestroy,
-			Steps: []resource.TestStep{
-				{
-					Config: config(pipelineName, cronline, label, "FOO = \"bar\"", enabled),
-					Check: func(s *terraform.State) error {
-						ps := s.RootModule().Resources["buildkite_pipeline_schedule.pipeline"]
-						emptyEnv := ""
-						_, err := updatePipelineSchedule(context.Background(),
-							genqlientGraphql,
-							PipelineScheduleUpdateInput{
-								Id:       ps.Primary.ID,
-								Label:    &label,
-								Cronline: &cronline,
-								Branch:   &branch,
-								Enabled:  &enabled,
-								Env:      &emptyEnv,
-							})
-						return err
-					},
-					ExpectNonEmptyPlan: true,
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PostApplyPostRefresh: []plancheck.PlanCheck{
-							plancheck.ExpectResourceAction("buildkite_pipeline_schedule.pipeline", plancheck.ResourceActionUpdate),
-						},
-					},
-				},
-			},
-		})
-	})
-
 	t.Run("pipeline schedule is recreated if removed", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 		label := acctest.RandString(12)
@@ -286,6 +247,94 @@ func TestAccBuildkitePipelineSchedule(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestUpdatePipelineScheduleNodeEnvDiscriminator(t *testing.T) {
+	ctx := context.Background()
+	label, cronline, branch, commit, message := "lbl", "0 * * * *", "main", "HEAD", ""
+	emptyMap, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+	populatedMap, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{"FOO": "bar"})
+	fooEqualsBar := "FOO=bar"
+
+	tests := []struct {
+		name     string
+		priorEnv types.Map
+		apiEnv   []*string
+		want     func(t *testing.T, got types.Map)
+	}{
+		{
+			name:     "empty map preserved when API returns no env vars",
+			priorEnv: emptyMap,
+			apiEnv:   nil,
+			want: func(t *testing.T, got types.Map) {
+				if got.IsNull() || len(got.Elements()) != 0 {
+					t.Errorf("expected non-null empty map, got %v", got)
+				}
+			},
+		},
+		{
+			name:     "null preserved when API returns no env vars",
+			priorEnv: types.MapNull(types.StringType),
+			apiEnv:   nil,
+			want: func(t *testing.T, got types.Map) {
+				if !got.IsNull() {
+					t.Errorf("expected null, got %v", got)
+				}
+			},
+		},
+		{
+			name:     "populated state overwritten with null on out-of-band env deletion",
+			priorEnv: populatedMap,
+			apiEnv:   nil,
+			want: func(t *testing.T, got types.Map) {
+				if !got.IsNull() {
+					t.Errorf("expected null to surface drift, got %v", got)
+				}
+			},
+		},
+		{
+			name:     "API env vars overwrite null state",
+			priorEnv: types.MapNull(types.StringType),
+			apiEnv:   []*string{&fooEqualsBar},
+			want: func(t *testing.T, got types.Map) {
+				if _, ok := got.Elements()["FOO"]; !ok {
+					t.Errorf("expected FOO in env, got %v", got)
+				}
+			},
+		},
+		{
+			name:     "API env vars overwrite empty map state",
+			priorEnv: emptyMap,
+			apiEnv:   []*string{&fooEqualsBar},
+			want: func(t *testing.T, got types.Map) {
+				if _, ok := got.Elements()["FOO"]; !ok {
+					t.Errorf("expected FOO in env, got %v", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &pipelineScheduleResourceModel{Env: tt.priorEnv}
+			node := getPipelineScheduleNodePipelineSchedule{
+				PipelineScheduleValues: PipelineScheduleValues{
+					Id:       "schedule-id",
+					Uuid:     "schedule-uuid",
+					Label:    &label,
+					Cronline: &cronline,
+					Message:  &message,
+					Commit:   &commit,
+					Branch:   &branch,
+					Env:      tt.apiEnv,
+					Enabled:  true,
+					Pipeline: PipelineScheduleValuesPipeline{Id: "pipeline-id"},
+				},
+			}
+			updatePipelineScheduleNode(ctx, state, node)
+			tt.want(t, state.Env)
+		})
+	}
 }
 
 // Testcase destroyer function

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -45,7 +45,7 @@ resource "buildkite_pipeline_schedule" "nightly" {
 
 - `commit` (String) The commit that the schedule should run on.
 - `enabled` (Boolean) Whether the schedule is enabled or not.
-- `env` (Map of String) The environment variables that scheduled builds should use. An empty map (`{}`) is equivalent to omitting this attribute at the API level, though Terraform preserves whichever shape you wrote in your configuration.
+- `env` (Map of String) The environment variables that scheduled builds should use. An empty map (`{}`) is equivalent to omitting this attribute at the API level.
 - `message` (String) The message the builds show for builds created by this schedule.
 
 ### Read-Only

--- a/docs/resources/pipeline_schedule.md
+++ b/docs/resources/pipeline_schedule.md
@@ -45,7 +45,7 @@ resource "buildkite_pipeline_schedule" "nightly" {
 
 - `commit` (String) The commit that the schedule should run on.
 - `enabled` (Boolean) Whether the schedule is enabled or not.
-- `env` (Map of String) The environment variables that scheduled builds should use.
+- `env` (Map of String) The environment variables that scheduled builds should use. An empty map (`{}`) is equivalent to omitting this attribute at the API level, though Terraform preserves whichever shape you wrote in your configuration.
 - `message` (String) The message the builds show for builds created by this schedule.
 
 ### Read-Only


### PR DESCRIPTION
## Summary

Fixes #1152. Setting `env = {}` on `buildkite_pipeline_schedule` caused infinite drift because `Read` coerced empty-map state to null, conflicting with the empty-map config on every refresh.

The fix preserves the prior state's empty-vs-null map shape in `updatePipelineScheduleNode` when the API returns no env vars. The API doesn't distinguish `env = {}` from omitted `env`, so we keep whichever shape the user wrote.

## Changes

- Skip overwriting `psState.Env` when the API returns no env vars and prior state was a non-null empty map (`buildkite/resource_pipeline_schedule.go`)
- Add regression test for `env = {}` with `PostApplyPostRefresh.ExpectEmptyPlan()`
- Add transition test exercising empty -> populated -> empty
- Document the empty-map equivalence on the `env` attribute