### PR TITLE
Add GitHub webhook trigger settings to pipeline resource

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -133,6 +133,16 @@ type providerSettingsModel struct {
 	BuildIssueCommentCreated                types.Bool   `tfsdk:"build_issue_comment_created"`
 	IssueCommentCommandWord                 types.String `tfsdk:"issue_comment_command_word"`
 	IssueCommentMatchMode                   types.String `tfsdk:"issue_comment_match_mode"`
+	BuildCheckRunCompleted                  types.Bool   `tfsdk:"build_check_run_completed"`
+	BuildCreateEvent                        types.Bool   `tfsdk:"build_create_event"`
+	BuildDeploymentStatusCreated            types.Bool   `tfsdk:"build_deployment_status_created"`
+	BuildPullRequestConvertedToDraft        types.Bool   `tfsdk:"build_pull_request_converted_to_draft"`
+	BuildPullRequestReviewRequested         types.Bool   `tfsdk:"build_pull_request_review_requested"`
+	BuildPullRequestReviewDismissed         types.Bool   `tfsdk:"build_pull_request_review_dismissed"`
+	BuildPullRequestReviewSubmitted         types.Bool   `tfsdk:"build_pull_request_review_submitted"`
+	BuildReleaseCreated                     types.Bool   `tfsdk:"build_release_created"`
+	BuildReleasePublished                   types.Bool   `tfsdk:"build_release_published"`
+	BuildReleaseReleased                    types.Bool   `tfsdk:"build_release_released"`
 }
 
 type pipelineResource struct {
@@ -1027,6 +1037,86 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							stringvalidator.OneOf("exact", "contains"),
 						},
 					},
+					"build_check_run_completed": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a GitHub check run completes. Useful for chaining CI workflows by triggering a Buildkite pipeline after another CI system finishes.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_create_event": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a branch or tag is created on GitHub.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_deployment_status_created": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a GitHub deployment status is created.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_pull_request_converted_to_draft": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a pull request is converted to a draft.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_pull_request_review_requested": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a review is requested on a pull request.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_pull_request_review_dismissed": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a pull request review is dismissed.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_pull_request_review_submitted": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a pull request review is submitted.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_release_created": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a GitHub release is created (including drafts).",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_release_published": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a GitHub release is published.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_release_released": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a GitHub release is published as final (excludes pre-releases and drafts).",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
 				},
 			},
 		},
@@ -1393,6 +1483,16 @@ type PipelineExtraSettings struct {
 	BuildIssueCommentCreated                *bool   `json:"build_issue_comment_created,omitempty"`
 	IssueCommentCommandWord                 *string `json:"issue_comment_command_word,omitempty"`
 	IssueCommentMatchMode                   *string `json:"issue_comment_match_mode,omitempty"`
+	BuildCheckRunCompleted                  *bool   `json:"build_check_run_completed,omitempty"`
+	BuildCreateEvent                        *bool   `json:"build_create_event,omitempty"`
+	BuildDeploymentStatusCreated            *bool   `json:"build_deployment_status_created,omitempty"`
+	BuildPullRequestConvertedToDraft        *bool   `json:"build_pull_request_converted_to_draft,omitempty"`
+	BuildPullRequestReviewRequested         *bool   `json:"build_pull_request_review_requested,omitempty"`
+	BuildPullRequestReviewDismissed         *bool   `json:"build_pull_request_review_dismissed,omitempty"`
+	BuildPullRequestReviewSubmitted         *bool   `json:"build_pull_request_review_submitted,omitempty"`
+	BuildReleaseCreated                     *bool   `json:"build_release_created,omitempty"`
+	BuildReleasePublished                   *bool   `json:"build_release_published,omitempty"`
+	BuildReleaseReleased                    *bool   `json:"build_release_released,omitempty"`
 }
 
 func getPipelineExtraInfo(ctx context.Context, client *Client, slug string, timeouts time.Duration) (*PipelineExtraInfo, error) {
@@ -1460,6 +1560,16 @@ func updatePipelineExtraInfo(ctx context.Context, slug string, settings *provide
 			BuildIssueCommentCreated:                settings.BuildIssueCommentCreated.ValueBoolPointer(),
 			IssueCommentCommandWord:                 settings.IssueCommentCommandWord.ValueStringPointer(),
 			IssueCommentMatchMode:                   settings.IssueCommentMatchMode.ValueStringPointer(),
+			BuildCheckRunCompleted:                  settings.BuildCheckRunCompleted.ValueBoolPointer(),
+			BuildCreateEvent:                        settings.BuildCreateEvent.ValueBoolPointer(),
+			BuildDeploymentStatusCreated:            settings.BuildDeploymentStatusCreated.ValueBoolPointer(),
+			BuildPullRequestConvertedToDraft:        settings.BuildPullRequestConvertedToDraft.ValueBoolPointer(),
+			BuildPullRequestReviewRequested:         settings.BuildPullRequestReviewRequested.ValueBoolPointer(),
+			BuildPullRequestReviewDismissed:         settings.BuildPullRequestReviewDismissed.ValueBoolPointer(),
+			BuildPullRequestReviewSubmitted:         settings.BuildPullRequestReviewSubmitted.ValueBoolPointer(),
+			BuildReleaseCreated:                     settings.BuildReleaseCreated.ValueBoolPointer(),
+			BuildReleasePublished:                   settings.BuildReleasePublished.ValueBoolPointer(),
+			BuildReleaseReleased:                    settings.BuildReleaseReleased.ValueBoolPointer(),
 		},
 	}
 
@@ -1518,6 +1628,16 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
 		IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
 		IssueCommentMatchMode:                   types.StringPointerValue(s.IssueCommentMatchMode),
+		BuildCheckRunCompleted:                  types.BoolPointerValue(s.BuildCheckRunCompleted),
+		BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
+		BuildDeploymentStatusCreated:            types.BoolPointerValue(s.BuildDeploymentStatusCreated),
+		BuildPullRequestConvertedToDraft:        types.BoolPointerValue(s.BuildPullRequestConvertedToDraft),
+		BuildPullRequestReviewRequested:         types.BoolPointerValue(s.BuildPullRequestReviewRequested),
+		BuildPullRequestReviewDismissed:         types.BoolPointerValue(s.BuildPullRequestReviewDismissed),
+		BuildPullRequestReviewSubmitted:         types.BoolPointerValue(s.BuildPullRequestReviewSubmitted),
+		BuildReleaseCreated:                     types.BoolPointerValue(s.BuildReleaseCreated),
+		BuildReleasePublished:                   types.BoolPointerValue(s.BuildReleasePublished),
+		BuildReleaseReleased:                    types.BoolPointerValue(s.BuildReleaseReleased),
 	}
 }
 
@@ -1795,6 +1915,46 @@ func pipelineSchemaV0() schema.Schema {
 							Optional: true,
 						},
 						"issue_comment_match_mode": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_check_run_completed": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_create_event": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_deployment_status_created": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_converted_to_draft": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_review_requested": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_review_dismissed": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_review_submitted": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_release_created": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_release_published": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_release_released": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
 						},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -661,6 +661,16 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					build_issue_comment_created = true
 					issue_comment_command_word = "ci-force-rerun"
 					issue_comment_match_mode = "exact"
+					build_check_run_completed = true
+					build_create_event = true
+					build_deployment_status_created = true
+					build_pull_request_converted_to_draft = true
+					build_pull_request_review_requested = true
+					build_pull_request_review_dismissed = true
+					build_pull_request_review_submitted = true
+					build_release_created = true
+					build_release_published = true
+					build_release_released = true
 				}
 			}
 		`, clusterName, pipelineName)
@@ -709,6 +719,16 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "exact"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_check_run_completed", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_converted_to_draft", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_requested", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_dismissed", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_submitted", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_published", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_released", "true"),
 					),
 				},
 			},
@@ -785,6 +805,16 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 								build_issue_comment_created = true
 								issue_comment_command_word = "/deploy"
 								issue_comment_match_mode = "contains"
+								build_check_run_completed = true
+								build_create_event = true
+								build_deployment_status_created = true
+								build_pull_request_converted_to_draft = true
+								build_pull_request_review_requested = true
+								build_pull_request_review_dismissed = true
+								build_pull_request_review_submitted = true
+								build_release_created = true
+								build_release_published = true
+								build_release_released = true
 							}
 						}
 					`, clusterName, pipelineName),
@@ -810,6 +840,16 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "/deploy"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "contains"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_check_run_completed", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_converted_to_draft", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_requested", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_dismissed", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_submitted", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_published", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_release_released", "true"),
 						aggregateRemoteCheck(&pipeline),
 					),
 				},

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -203,14 +203,24 @@ resource "github_repository_webhook" "my_webhook" {
 Optional:
 
 - `build_branches` (Boolean) Whether to create builds when branches are pushed.
+- `build_check_run_completed` (Boolean) Whether to create a build when a GitHub check run completes. Useful for chaining CI workflows by triggering a Buildkite pipeline after another CI system finishes.
+- `build_create_event` (Boolean) Whether to create a build when a branch or tag is created on GitHub.
+- `build_deployment_status_created` (Boolean) Whether to create a build when a GitHub deployment status is created.
 - `build_issue_comment_created` (Boolean) Whether to create builds when an issue comment is created on a pull request.
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
+- `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_merge_commits` (Boolean) Whether to build the test merge commit (the merged result of a pull request with its base branch).
 - `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review".
+- `build_pull_request_review_dismissed` (Boolean) Whether to create a build when a pull request review is dismissed.
+- `build_pull_request_review_requested` (Boolean) Whether to create a build when a review is requested on a pull request.
+- `build_pull_request_review_submitted` (Boolean) Whether to create a build when a pull request review is submitted.
 - `build_pull_requests` (Boolean) Whether to create builds for commits that are part of a pull request.
+- `build_release_created` (Boolean) Whether to create a build when a GitHub release is created (including drafts).
+- `build_release_published` (Boolean) Whether to create a build when a GitHub release is published.
+- `build_release_released` (Boolean) Whether to create a build when a GitHub release is published as final (excludes pre-releases and drafts).
 - `build_tags` (Boolean) Whether to create builds when tags are pushed.
 - `cancel_deleted_branch_builds` (Boolean) Automatically cancel running builds for a branch if the branch is deleted.
 - `cancel_when_merge_group_destroyed` (Boolean) Whether to cancel any running builds belonging to a removed merge group.


### PR DESCRIPTION
We recently shipped a bunch of new GitHub webhook triggers (see the changelog:
https://buildkite.com/resources/changelog/352-trigger-pipelines-from-more-github-events/). This adds the 10 matching pipeline settings to the Terraform provider:

- build_check_run_completed
- build_create_event
- build_deployment_status_created
- build_pull_request_converted_to_draft
- build_pull_request_review_requested
- build_pull_request_review_dismissed
- build_pull_request_review_submitted
- build_release_created
- build_release_published
- build_release_released