### PR TITLE
fix: archive pipeline after REST updates in Create and Update

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -308,6 +308,21 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "user"}`))...)
 	}
 
+	if plan.ProviderSettings != nil {
+		pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, useSlugValue, plan.ProviderSettings, p.client, timeouts)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
+			return
+		}
+
+		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
+	} else {
+		// no provider_settings provided
+		state.ProviderSettings = plan.ProviderSettings
+	}
+
+	// Archive last: the REST API rejects updates to archived pipelines, so all REST
+	// calls (slug, provider settings) must complete before the pipeline is archived.
 	if plan.Archived.ValueBool() {
 		err = retry.RetryContext(ctx, timeouts, func() *retry.RetryError {
 			_, archiveErr := archivePipeline(ctx, p.client.genqlient, state.Id.ValueString())
@@ -321,19 +336,6 @@ func (p *pipelineResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 		state.Archived = types.BoolValue(true)
-	}
-
-	if plan.ProviderSettings != nil {
-		pipelineExtraInfo, err := updatePipelineExtraInfo(ctx, useSlugValue, plan.ProviderSettings, p.client, timeouts)
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to set pipeline info from REST", err.Error())
-			return
-		}
-
-		updatePipelineResourceExtraInfo(&state, &pipelineExtraInfo)
-	} else {
-		// no provider_settings provided
-		state.ProviderSettings = plan.ProviderSettings
 	}
 
 	state.Slug = types.StringValue(useSlugValue)
@@ -1274,20 +1276,10 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	// Archive after updating (archiving before would block other field updates too).
-	if !state.Archived.ValueBool() && plan.Archived.ValueBool() {
-		err = retry.RetryContext(ctx, timeouts, func() *retry.RetryError {
-			_, archiveErr := archivePipeline(ctx, p.client.genqlient, plan.Id.ValueString())
-			return retryContextError(archiveErr)
-		})
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update pipeline archive state",
-				fmt.Sprintf("Unable to update pipeline archive state: %s", err.Error()),
-			)
-			return
-		}
-	}
+	// Archive last (see below): the REST API rejects updates to archived pipelines, so
+	// the slug and provider settings REST calls must complete before archiving. Capture
+	// the decision here because state.Archived is synced to plan further down.
+	needsArchive := !state.Archived.ValueBool() && plan.Archived.ValueBool()
 
 	useSlugValue := response.PipelineUpdate.Pipeline.Slug
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "slugSource", []byte(`{"source": "api"}`))...)
@@ -1355,6 +1347,22 @@ func (p *pipelineResource) Update(ctx context.Context, req resource.UpdateReques
 	} else {
 		// no provider_settings provided
 		state.ProviderSettings = plan.ProviderSettings
+	}
+
+	// Archive after all other updates: archiving earlier would make the REST calls
+	// above fail with "Cannot update an archived pipeline".
+	if needsArchive {
+		err = retry.RetryContext(ctx, timeouts, func() *retry.RetryError {
+			_, archiveErr := archivePipeline(ctx, p.client.genqlient, plan.Id.ValueString())
+			return retryContextError(archiveErr)
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to update pipeline archive state",
+				fmt.Sprintf("Unable to update pipeline archive state: %s", err.Error()),
+			)
+			return
+		}
 	}
 
 	state.Slug = types.StringValue(useSlugValue)

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -1851,4 +1851,101 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("archives pipeline with provider_settings", func(t *testing.T) {
+		// Regression test: archiving must happen after the provider_settings REST
+		// PATCH, otherwise the API rejects it with "Cannot update an archived
+		// pipeline".
+		pipelineName := acctest.RandString(12)
+		configFor := func(archived bool) string {
+			return fmt.Sprintf(`
+				resource "buildkite_pipeline" "pipeline" {
+					name = "%s"
+					repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+					archived = %t
+
+					provider_settings = {
+						build_branches = true
+						build_pull_requests = false
+					}
+				}
+			`, pipelineName, archived)
+		}
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineDestroyFunc,
+			Steps: []resource.TestStep{
+				{
+					Config: configFor(false),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "archived", "false"),
+					),
+				},
+				{
+					Config: configFor(true),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("buildkite_pipeline.pipeline", plancheck.ResourceActionUpdate),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "archived", "true"),
+						func(s *terraform.State) error {
+							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
+							if err != nil {
+								return err
+							}
+							if !resp.Pipeline.Archived {
+								return fmt.Errorf("expected pipeline to be archived, got archived = false")
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("creates archived pipeline with provider_settings", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		config := fmt.Sprintf(`
+			resource "buildkite_pipeline" "pipeline" {
+				name = "%s"
+				repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+				archived = true
+
+				provider_settings = {
+					build_branches = true
+				}
+			}
+		`, pipelineName)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineDestroyFunc,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "archived", "true"),
+						func(s *terraform.State) error {
+							slug := fmt.Sprintf("%s/%s", getenv("BUILDKITE_ORGANIZATION_SLUG"), pipelineName)
+							resp, err := getPipeline(context.Background(), genqlientGraphql, slug)
+							if err != nil {
+								return err
+							}
+							if !resp.Pipeline.Archived {
+								return fmt.Errorf("expected pipeline to be archived, got archived = false")
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
The REST API rejects any update to an archived pipeline (422 "Cannot update an archived pipeline"). `Create` and `Update` archived the pipeline before calling `updatePipelineExtraInfo`, so setting `archived = true` on any pipeline with `provider_settings` always failed mid-apply (and left the pipeline archived but the apply errored).

Move the archive mutation to the end of both flows, after the slug and provider settings REST calls. Add acceptance tests covering `archived` together with `provider_settings` for both create and update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)