### PR TITLE
fix(config): misleading error when cluster name changed

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -632,9 +632,6 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"cluster_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the cluster the pipeline is (optionally) attached to.",
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseNonNullStateForUnknown(),
-				},
 			},
 			"default_team_id": schema.StringAttribute{
 				MarkdownDescription: "The GraphQL ID of a team to initially assign to the pipeline. This is required by the Buildkite API when creating a new pipeline. The team assigned here will be given 'Manage Build and Read' access. Further team associations can be managed with the `buildkite_pipeline_team` resource after the pipeline is created.",

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -857,6 +857,55 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 		})
 	})
 
+	t.Run("changing cluster_id updates cluster_name without inconsistency error", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		clusterNameA := acctest.RandString(12)
+		clusterNameB := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineDestroyFunc,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_cluster" "cluster_a" {
+							name = "%s"
+						}
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+							cluster_id = buildkite_cluster.cluster_a.id
+						}
+					`, clusterNameA, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_id", "buildkite_cluster.cluster_a", "id"),
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_name", "buildkite_cluster.cluster_a", "name"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(`
+						resource "buildkite_cluster" "cluster_a" {
+							name = "%s"
+						}
+						resource "buildkite_cluster" "cluster_b" {
+							name = "%s"
+						}
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+							cluster_id = buildkite_cluster.cluster_b.id
+						}
+					`, clusterNameA, clusterNameB, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_id", "buildkite_cluster.cluster_b", "id"),
+						resource.TestCheckResourceAttrPair("buildkite_pipeline.pipeline", "cluster_name", "buildkite_cluster.cluster_b", "name"),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("pipeline is recreated if removed", func(t *testing.T) {
 		pipelineName := acctest.RandString(12)
 		config := fmt.Sprintf(`


### PR DESCRIPTION
## Description

Fixes a misleading planning error when the cluster name of a pipeline is changed, but applied successfully.

## Changes

- removes `stringplanmodifier.UseNonNullStateForUnknown` from `cluster_name` in resource
- adds a unit test for cluster name change action

