### PR TITLE
fix(renovate): fixes the renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,20 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         ":disableDependencyDashboard",
-        "github>buildkite/renovate-config"
+        "config:recommended",
+        ":semanticCommits",
+        "schedule:weekdays",
+        "group:allNonMajor"
     ],
+    "labels": ["dependencies"],
+    "prConcurrentLimit": 5,
+    "prHourlyLimit": 2,
+    "minimumReleaseAge": "3 days",
+    "vulnerabilityAlerts": {
+        "labels": ["dependencies", "security"],
+        "minimumReleaseAge": "0 days",
+        "enabled": true
+    },
     "postUpdateOptions": ["gomodTidy"],
     "automerge": true,
     "automergeType": "pr",


### PR DESCRIPTION
## Description

We tried to use a centralised Renovate config, but because it's a private repo, Renovate cannot access it (default behaviour).

Rather than making that config public, we could just have the config ported back to this one.
