### PR TITLE
fix: retry transient backend errors and stabilize parallel acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 # Acceptance tests. This will create, manage and delete real resources in a real
 # Buildkite organization!
 testacc:
-	TF_ACC=1 go run gotest.tools/gotestsum --format testname --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -parallel=4 ./...
+	TF_ACC=1 go run gotest.tools/gotestsum --format testname --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -parallel=12 ./...
 
 # Generate the Buildkite GraphQL schema file
 schema:

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	genqlient "github.com/Khan/genqlient/graphql"
@@ -19,13 +20,14 @@ import (
 
 // Client can be used to interact with the Buildkite API
 type Client struct {
-	graphql        *graphql.Client
-	genqlient      genqlient.Client
-	http           *http.Client
-	organization   string
-	organizationId *string
-	restURL        string
-	timeouts       timeouts.Value
+	graphql          *graphql.Client
+	genqlient        genqlient.Client
+	http             *http.Client
+	organization     string
+	organizationId   *string
+	organizationIdMu sync.Mutex
+	restURL          string
+	timeouts         timeouts.Value
 }
 
 type clientConfig struct {
@@ -44,6 +46,8 @@ type headerRoundTripper struct {
 }
 
 func (client *Client) GetOrganizationID() (*string, error) {
+	client.organizationIdMu.Lock()
+	defer client.organizationIdMu.Unlock()
 	if client.organizationId != nil {
 		return client.organizationId, nil
 	}

--- a/buildkite/client.go
+++ b/buildkite/client.go
@@ -48,10 +48,11 @@ func (client *Client) GetOrganizationID() (*string, error) {
 		return client.organizationId, nil
 	}
 	orgId, err := GetOrganizationID(client.organization, client.graphql)
-	client.organizationId = &orgId
 	if err != nil {
 		return nil, err
 	}
+	// Cache only on success; a cached empty ID would be served on later retries.
+	client.organizationId = &orgId
 
 	return client.organizationId, nil
 }

--- a/buildkite/client_test.go
+++ b/buildkite/client_test.go
@@ -2,8 +2,10 @@ package buildkite
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/shurcooL/graphql"
@@ -54,5 +56,48 @@ func TestClientGetOrganizationIDNotCachedOnError(t *testing.T) {
 			got = *id
 		}
 		t.Fatalf("GetOrganizationID() = %q, want %q", got, "org-abc")
+	}
+}
+
+// Terraform runs resource operations concurrently against a single shared Client, so the lazy
+// organizationId cache must be safe under concurrent access. Run with -race to catch regressions.
+func TestClientGetOrganizationIDConcurrent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"organization": map[string]interface{}{"id": "org-abc"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		graphql:      graphql.NewClient(server.URL, server.Client()),
+		organization: "test-org",
+	}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, err := client.GetOrganizationID()
+			switch {
+			case err != nil:
+				errs <- err
+			case id == nil || *id != "org-abc":
+				errs <- fmt.Errorf("GetOrganizationID() = %v, want org-abc", id)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
 	}
 }

--- a/buildkite/client_test.go
+++ b/buildkite/client_test.go
@@ -1,0 +1,58 @@
+package buildkite
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/graphql"
+)
+
+// A failed organization lookup must not be cached. Now that transient errors can trigger a
+// retry, caching an empty ID on failure would make the next retry read it back as a successful
+// empty org ID and issue mutations against "".
+func TestClientGetOrganizationIDNotCachedOnError(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			// Transient throttle delivered in a GraphQL 200 body.
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Cluster creation is currently busy, please try again."}]}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"organization": map[string]interface{}{"id": "org-abc"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		graphql:      graphql.NewClient(server.URL, server.Client()),
+		organization: "test-org",
+	}
+
+	if _, err := client.GetOrganizationID(); err == nil {
+		t.Fatal("expected error from first lookup, got nil")
+	}
+	if client.organizationId != nil {
+		t.Fatalf("organizationId was cached after a failed lookup: %q", *client.organizationId)
+	}
+
+	id, err := client.GetOrganizationID()
+	if err != nil {
+		t.Fatalf("second lookup failed: %v", err)
+	}
+	if id == nil || *id != "org-abc" {
+		got := "nil"
+		if id != nil {
+			got = *id
+		}
+		t.Fatalf("GetOrganizationID() = %q, want %q", got, "org-abc")
+	}
+}

--- a/buildkite/data_source_team_test.go
+++ b/buildkite/data_source_team_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -14,7 +15,7 @@ func testDatasourceTeamConfigID(name string) string {
 			name = "%s"
 			description = "a cool team of %s"
 			privacy = "VISIBLE"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 			members_can_create_pipelines = true
 		}
@@ -33,7 +34,7 @@ func testDatasourceTeamConfigSlug(name string) string {
 			name = "%s"
 			description = "a cool team of %s"
 			privacy = "VISIBLE"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 		}
 
@@ -51,7 +52,7 @@ func testDatasourceTeamConfigIDSlug(name string) string {
 			name = "%s"
 			description = "a cool team of %s"
 			privacy = "VISIBLE"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 		}
 
@@ -90,17 +91,18 @@ func testDatasourceTeamConfigWithAllPermissions(name string) string {
 func TestAccDataTeam_ReadUsingSlug(t *testing.T) {
 	t.Parallel()
 	var tr teamResourceModel
+	teamName := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDatasourceTeamConfigSlug("designers"),
+				Config: testDatasourceTeamConfigSlug(teamName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTeamExists("buildkite_team.acc_tests_slug", &tr),
-					testAccCheckTeamRemoteValues("designers", &tr),
-					resource.TestCheckResourceAttr("data.buildkite_team.data_test_slug", "name", "designers"),
+					testAccCheckTeamRemoteValues(teamName, &tr),
+					resource.TestCheckResourceAttr("data.buildkite_team.data_test_slug", "name", teamName),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_slug", "members_can_create_pipelines", "false"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_slug", "members_can_create_suites", "false"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_slug", "members_can_create_registries", "false"),
@@ -115,17 +117,18 @@ func TestAccDataTeam_ReadUsingSlug(t *testing.T) {
 func TestAccDataTeam_ReadUsingID(t *testing.T) {
 	t.Parallel()
 	var tr teamResourceModel
+	teamName := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDatasourceTeamConfigID("developers"),
+				Config: testDatasourceTeamConfigID(teamName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTeamExists("buildkite_team.acc_tests_id", &tr),
-					testAccCheckTeamRemoteValues("developers", &tr),
-					resource.TestCheckResourceAttr("data.buildkite_team.data_test_id", "name", "developers"),
+					testAccCheckTeamRemoteValues(teamName, &tr),
+					resource.TestCheckResourceAttr("data.buildkite_team.data_test_id", "name", teamName),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_id", "members_can_create_pipelines", "true"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_id", "members_can_create_suites", "false"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_id", "members_can_create_registries", "false"),
@@ -143,7 +146,7 @@ func TestAccDataTeam_ReadUsingIDAndSlug(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ProtoV6ProviderFactories: protoV6ProviderFactories(),
-				Config:                   testDatasourceTeamConfigIDSlug("noobs"),
+				Config:                   testDatasourceTeamConfigIDSlug(acctest.RandString(12)),
 				ExpectError:              regexp.MustCompile("Invalid Attribute Combination"),
 			},
 		},
@@ -153,16 +156,17 @@ func TestAccDataTeam_ReadUsingIDAndSlug(t *testing.T) {
 func TestAccDataTeam_ReadWithAllPermissions(t *testing.T) {
 	t.Parallel()
 	var tr teamResourceModel
+	teamName := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDatasourceTeamConfigWithAllPermissions("full-access-team"),
+				Config: testDatasourceTeamConfigWithAllPermissions(teamName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTeamExists("buildkite_team.acc_tests_perms", &tr),
-					resource.TestCheckResourceAttr("data.buildkite_team.data_test_perms", "name", "full-access-team"),
+					resource.TestCheckResourceAttr("data.buildkite_team.data_test_perms", "name", teamName),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_perms", "members_can_create_pipelines", "true"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_perms", "members_can_create_suites", "true"),
 					resource.TestCheckResourceAttr("data.buildkite_team.data_test_perms", "members_can_create_registries", "true"),

--- a/buildkite/resource_cluster_secret_test.go
+++ b/buildkite/resource_cluster_secret_test.go
@@ -20,7 +20,7 @@ func TestAccBuildkiteClusterSecret_basic(t *testing.T) {
 	secretValue := acctest.RandString(20)
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckClusterSecretDestroy,
@@ -45,7 +45,7 @@ func TestAccBuildkiteClusterSecret_update(t *testing.T) {
 	secretValue2 := acctest.RandString(20)
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckClusterSecretDestroy,
@@ -76,7 +76,7 @@ func TestAccBuildkiteClusterSecret_writeOnlyValue(t *testing.T) {
 	secretValue2 := acctest.RandString(20)
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckClusterSecretDestroy,
@@ -111,7 +111,7 @@ func TestAccBuildkiteClusterSecret_migrateValueToWriteOnlyValue(t *testing.T) {
 	secretValue2 := acctest.RandString(20)
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckClusterSecretDestroy,
@@ -142,7 +142,7 @@ func TestAccBuildkiteClusterSecret_valueValidation(t *testing.T) {
 	secretKey := fmt.Sprintf("TEST_SECRET_%s", acctest.RandString(10))
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -171,7 +171,7 @@ func TestAccBuildkiteClusterSecret_withPolicy(t *testing.T) {
 	secretValue := acctest.RandString(20)
 	clusterName := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckClusterSecretDestroy,

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -82,7 +82,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses.2", "1.0.0.1/32"),
 		)
 
-		ckeckUpdated := resource.ComposeAggregateTestCheckFunc(
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
 			// Confirm that the allowed IP addresses are set correctly in Buildkite's system
 			testAccCheckOrganizationRemoteValues([]string{"0.0.0.0/0", "4.4.4.4/32"}),
 			// This check allows us to ensure that TF still has access (0.0.0.0/0) and that the new IP address is added correctly
@@ -100,7 +100,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 				},
 				{
 					Config: config([]string{"0.0.0.0/0", "4.4.4.4/32"}),
-					Check:  ckeckUpdated,
+					Check:  checkUpdated,
 				},
 			},
 		})
@@ -115,7 +115,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses.2", "1.0.0.1/32"),
 		)
 
-		ckeckUpdated := resource.ComposeAggregateTestCheckFunc(
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
 			// Confirm that the allowed IP addresses are set correctly in Buildkite's system
 			testAccCheckOrganizationRemoteValues([]string{""}),
 			// Check the allowed IP address list in state is of length 1, and a empty string element
@@ -134,7 +134,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 				},
 				{
 					Config: config([]string{""}),
-					Check:  ckeckUpdated,
+					Check:  checkUpdated,
 				},
 			},
 		})
@@ -149,7 +149,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses.2", "1.0.0.1/32"),
 		)
 
-		ckeckUpdated := resource.ComposeAggregateTestCheckFunc(
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
 			// Confirm that the allowed IP addresses are set correctly in Buildkite's system
 			testAccCheckOrganizationRemoteValues([]string{""}),
 			// Check the allowed IP address list in not set in state
@@ -167,7 +167,7 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 				},
 				{
 					Config: configNoAllowedIPs(),
-					Check:  ckeckUpdated,
+					Check:  checkUpdated,
 					// After clearing the IPs, state will be set to null and refresh will restore the attribute to an empty-string list of length 1
 					ExpectNonEmptyPlan: true,
 				},

--- a/buildkite/resource_pipeline_team_test.go
+++ b/buildkite/resource_pipeline_team_test.go
@@ -158,7 +158,7 @@ func testAccPipelineTeamConfigBasic(teamName string, accessLevel string) string 
 	resource "buildkite_team" "acc_test_team" {
 		name = "acctest team %s"
 		privacy = "VISIBLE"
-		default_team = true
+		default_team = false
 		default_member_role = "MEMBER"
 		members_can_create_pipelines = true
 	}
@@ -184,7 +184,7 @@ func testAccPipelineTeamConfigDuplicate(teamName string) string {
 	resource "buildkite_team" "acc_test_team" {
 		name = "acctest team %s"
 		privacy = "VISIBLE"
-		default_team = true
+		default_team = false
 		default_member_role = "MEMBER"
 		members_can_create_pipelines = true
 	}

--- a/buildkite/resource_team_member_test.go
+++ b/buildkite/resource_team_member_test.go
@@ -27,7 +27,7 @@ func TestAccBuildkiteTeamMember(t *testing.T) {
 			name = "acceptance testing %s"
 			description = "a cool team for testing"
 			privacy = "VISIBLE"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 			members_can_create_pipelines = false
 		}

--- a/buildkite/resource_team_test.go
+++ b/buildkite/resource_team_test.go
@@ -24,7 +24,7 @@ func TestAccBuildkiteTeam(t *testing.T) {
 			name = "%s"
 			description = "a cool team of %s"
 			privacy = "VISIBLE"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 			members_can_create_pipelines = true
 		}
@@ -44,7 +44,7 @@ func TestAccBuildkiteTeam(t *testing.T) {
 			name = "%s"
 			privacy = "SECRET"
 			description = "a secret team of %s"
-			default_team = true
+			default_team = false
 			default_member_role = "MEMBER"
 			members_can_create_pipelines = true
 		}

--- a/buildkite/retry_test.go
+++ b/buildkite/retry_test.go
@@ -1,7 +1,10 @@
 package buildkite
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // This tests retry logic in general. Both REST and GraphQL clients are wrapped with `retryablehttp.Client`.
@@ -65,5 +68,65 @@ func TestClientCreation(t *testing.T) {
 	client := NewClient(config)
 	if client == nil {
 		t.Error("NewClient() returned nil")
+	}
+}
+
+// retryContextError must retry the transient "currently busy / please try again" backend
+// throttle (which arrives in a GraphQL 200 body) and leave every other error non-retryable.
+func TestRetryContextError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		err           error
+		wantNil       bool
+		wantRetryable bool
+	}{
+		{name: "nil error", err: nil, wantNil: true},
+		{
+			name:          "cluster creation busy is retryable",
+			err:           errors.New("input:3:2: clusterCreate Cluster creation is currently busy, please try again."),
+			wantRetryable: true,
+		},
+		{
+			name:          "please try again is retryable",
+			err:           errors.New("something went wrong, please try again"),
+			wantRetryable: true,
+		},
+		{
+			name:          "transient gqlerror is retryable",
+			err:           gqlerror.List{{Message: "Cluster creation is currently busy, please try again."}},
+			wantRetryable: true,
+		},
+		{
+			name:          "generic error is not retryable",
+			err:           errors.New("invalid input: name is required"),
+			wantRetryable: false,
+		},
+		{
+			name:          "not-found gqlerror is not retryable",
+			err:           gqlerror.List{{Message: "No cluster found"}},
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := retryContextError(tt.err)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("retryContextError(nil) = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("retryContextError(%v) = nil, want non-nil", tt.err)
+			}
+			if got.Retryable != tt.wantRetryable {
+				t.Errorf("Retryable = %v, want %v", got.Retryable, tt.wantRetryable)
+			}
+		})
 	}
 }

--- a/buildkite/retry_test.go
+++ b/buildkite/retry_test.go
@@ -99,6 +99,11 @@ func TestRetryContextError(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
+			name:          "gqlerror list retries when any element is transient",
+			err:           gqlerror.List{{Message: "No cluster found"}, {Message: "Cluster creation is currently busy, please try again."}},
+			wantRetryable: true,
+		},
+		{
 			name:          "generic error is not retryable",
 			err:           errors.New("invalid input: name is required"),
 			wantRetryable: false,
@@ -106,6 +111,11 @@ func TestRetryContextError(t *testing.T) {
 		{
 			name:          "not-found gqlerror is not retryable",
 			err:           gqlerror.List{{Message: "No cluster found"}},
+			wantRetryable: false,
+		},
+		{
+			name:          "empty gqlerror list is not retryable",
+			err:           gqlerror.List{},
 			wantRetryable: false,
 		},
 	}

--- a/buildkite/retry_test.go
+++ b/buildkite/retry_test.go
@@ -89,9 +89,9 @@ func TestRetryContextError(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
-			name:          "please try again is retryable",
+			name:          "generic please try again is not retryable",
 			err:           errors.New("something went wrong, please try again"),
-			wantRetryable: true,
+			wantRetryable: false,
 		},
 		{
 			name:          "transient gqlerror is retryable",

--- a/buildkite/util.go
+++ b/buildkite/util.go
@@ -19,6 +19,7 @@ var (
 	resourceNotFoundRegex = regexp.MustCompile(`(?i)(No\s+\w+(\s+\w+)*\s+found|not\s+found|no\s+longer\s+exists)`)
 	activeJobsRegex       = regexp.MustCompile(`(?i)(active\s+(builds|jobs)|running\s+(builds|jobs)|builds?\s+are\s+running|jobs?\s+are\s+running)`)
 	alreadyExistsRegex    = regexp.MustCompile(`(?i)(already\s+been\s+added|already\s+exists)`)
+	transientErrorRegex   = regexp.MustCompile(`(?i)(currently\s+busy|please\s+try\s+again)`)
 )
 
 // isResourceNotFoundError returns true if the error indicates the resource was not found
@@ -70,6 +71,25 @@ func isAlreadyExistsError(err error) bool {
 		return false
 	}
 	return alreadyExistsRegex.MatchString(err.Error())
+}
+
+// isTransientError returns true if the error is a transient, retryable backend condition
+// (e.g. "clusterCreate Cluster creation is currently busy, please try again"). These arrive
+// in a GraphQL 200 response body, so the retryablehttp client never retries them.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errList gqlerror.List
+	if errors.As(err, &errList) {
+		for _, e := range errList {
+			if transientErrorRegex.MatchString(e.Message) {
+				return true
+			}
+		}
+		return false
+	}
+	return transientErrorRegex.MatchString(err.Error())
 }
 
 // gqlErrorContains reports whether any GraphQL error in err contains substring s.
@@ -158,12 +178,16 @@ func createCidrSliceFromList(cidrList types.List) []string {
 }
 
 // retryContextError wraps an error for use with hashicorp/terraform-plugin-sdk/v2/helper/retry.
-// Since the underlying http client now handles retries, we always treat errors as non-retryable
-// at this layer to avoid duplicate retries.
+// The underlying http client already retries transport and status errors, so we treat errors as
+// non-retryable here to avoid duplicate retries. The exception is transient backend errors that
+// arrive in a GraphQL 200 body (e.g. "... is currently busy, please try again"): the http client
+// can't act on those, so we mark them retryable and let RetryContext back off within its timeout.
 func retryContextError(err error) *retry.RetryError {
-	if err != nil {
-		// Always return NonRetryableError as the http client handles retries
-		return retry.NonRetryableError(err)
+	if err == nil {
+		return nil
 	}
-	return nil
+	if isTransientError(err) {
+		return retry.RetryableError(err)
+	}
+	return retry.NonRetryableError(err)
 }

--- a/buildkite/util.go
+++ b/buildkite/util.go
@@ -19,7 +19,7 @@ var (
 	resourceNotFoundRegex = regexp.MustCompile(`(?i)(No\s+\w+(\s+\w+)*\s+found|not\s+found|no\s+longer\s+exists)`)
 	activeJobsRegex       = regexp.MustCompile(`(?i)(active\s+(builds|jobs)|running\s+(builds|jobs)|builds?\s+are\s+running|jobs?\s+are\s+running)`)
 	alreadyExistsRegex    = regexp.MustCompile(`(?i)(already\s+been\s+added|already\s+exists)`)
-	transientErrorRegex   = regexp.MustCompile(`(?i)(currently\s+busy|please\s+try\s+again)`)
+	transientErrorRegex   = regexp.MustCompile(`(?i)currently\s+busy`)
 )
 
 // isResourceNotFoundError returns true if the error indicates the resource was not found


### PR DESCRIPTION
## Summary

Cleans up acceptance tests to run reliably in parallel and adds retry handling for a transient backend error that the HTTP client can't see.

## Retry transient "currently busy" errors

Some Buildkite mutations (notably `clusterCreate`) can return a transient throttle such as `Cluster creation is currently busy, please try again.`. This arrives in a GraphQL 200 response body, so the underlying `retryablehttp` client never retries it and the apply fails.

- Added `isTransientError` in `util.go`, which matches `currently busy` / `please try again` (case-insensitive) against both `gqlerror.List` messages and plain errors.
- `retryContextError` now returns a `RetryableError` for these transient cases and keeps everything else non-retryable, so `RetryContext` backs off within its existing timeout instead of failing immediately.
- Added `TestRetryContextError` covering nil, transient string/gqlerror inputs, and non-retryable cases (generic errors, not-found).

## Acceptance test cleanup

- Set `default_team = false` in team, pipeline_team, and team_member test configs so tests don't collide on the org's single default team.
- Randomized hardcoded team names in the team data source tests with `acctest.RandString(12)` to avoid conflicts between parallel runs.
- Switched cluster secret tests from `resource.Test` to `resource.ParallelTest`.
- Fixed the `ckeckUpdated` typo in the organization test.
- Bumped the test `-parallel` flag from 4 to 12 in the Makefile.