### PR TITLE
SUP-7447: Fix buildkite_organization data source silently returning empty on unresolved org slug

### DIFF
--- a/buildkite/data_source_organization.go
+++ b/buildkite/data_source_organization.go
@@ -53,6 +53,14 @@ func (o *organizationDatasource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	if response.Organization.Id == "" {
+		resp.Diagnostics.AddError(
+			"Unable to find organization",
+			fmt.Sprintf("Could not find organization with slug \"%s\"", o.client.organization),
+		)
+		return
+	}
+
 	state.ID = types.StringValue(response.Organization.Id)
 	state.UUID = types.StringValue(response.Organization.Uuid)
 	ips, diag := types.ListValueFrom(ctx, types.StringType, strings.Split(response.Organization.AllowedApiIpAddresses, " "))


### PR DESCRIPTION
The buildkite_organization data source doesn't error when the configured org slug can't be resolved — it silently succeeds with blank output instead. terraform plan/apply exits 0 with no warning, giving no signal that anything's wrong.

**Root cause**: getOrganization() only returns an error on transport-level failures. The GraphQL organization(slug:) query field is nullable ,when it resolves to null, err is nil and the code proceeds to read .Id/.Uuid off a zero-valued struct.

**Fix**: add a not-found check after the existing error check, matching the pattern already used correctly in data_source_pipeline.go.

**Verification**

  - Live-tested against real Buildkite infra with the built provider binary: a stale/wrong org slug now produces Error: Unable to findorganization; a correct slug is unaffected.
  
  - go build ./..., gofmt, and go vet ./... all clean across the whole module.
  
  - Independently reviewed; confirmed via schema.graphql that Organization.id is non-nullable on the type, so the check can't false-positive.