### PR TITLE
feat(pipeline): add build_pull_request_edited provider setting

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -3083,6 +3083,8 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseS
 	BuildDeploymentStatusCreated *bool `json:"buildDeploymentStatusCreated"`
 	// Whether to create builds when a pull request is converted to draft.
 	BuildPullRequestConvertedToDraft *bool `json:"buildPullRequestConvertedToDraft"`
+	// Whether to create builds when a pull request is edited.
+	BuildPullRequestEdited *bool `json:"buildPullRequestEdited"`
 	// Whether to create builds when a pull request review is requested.
 	BuildPullRequestReviewRequested *bool `json:"buildPullRequestReviewRequested"`
 	// Whether to create builds when a pull request review is dismissed.
@@ -3176,6 +3178,11 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpr
 // GetBuildPullRequestConvertedToDraft returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestConvertedToDraft, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestConvertedToDraft() *bool {
 	return v.BuildPullRequestConvertedToDraft
+}
+
+// GetBuildPullRequestEdited returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestEdited, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestEdited() *bool {
+	return v.BuildPullRequestEdited
 }
 
 // GetBuildPullRequestReviewRequested returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestReviewRequested, and is useful for accessing the field via an interface.
@@ -3363,6 +3370,8 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRep
 	BuildDeploymentStatusCreated *bool `json:"buildDeploymentStatusCreated"`
 	// Whether to create builds when a pull request is converted to draft.
 	BuildPullRequestConvertedToDraft *bool `json:"buildPullRequestConvertedToDraft"`
+	// Whether to create builds when a pull request is edited.
+	BuildPullRequestEdited *bool `json:"buildPullRequestEdited"`
 	// Whether to create builds when a pull request review is requested.
 	BuildPullRequestReviewRequested *bool `json:"buildPullRequestReviewRequested"`
 	// Whether to create builds when a pull request review is dismissed.
@@ -3456,6 +3465,11 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSetting
 // GetBuildPullRequestConvertedToDraft returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestConvertedToDraft, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestConvertedToDraft() *bool {
 	return v.BuildPullRequestConvertedToDraft
+}
+
+// GetBuildPullRequestEdited returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestEdited, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestEdited() *bool {
+	return v.BuildPullRequestEdited
 }
 
 // GetBuildPullRequestReviewRequested returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestReviewRequested, and is useful for accessing the field via an interface.
@@ -26029,6 +26043,7 @@ fragment RepositoryProviderSettingsFields on Repository {
 				buildCreateEvent
 				buildDeploymentStatusCreated
 				buildPullRequestConvertedToDraft
+				buildPullRequestEdited
 				buildPullRequestReviewRequested
 				buildPullRequestReviewDismissed
 				buildPullRequestReviewSubmitted
@@ -26072,6 +26087,7 @@ fragment RepositoryProviderSettingsFields on Repository {
 				buildCreateEvent
 				buildDeploymentStatusCreated
 				buildPullRequestConvertedToDraft
+				buildPullRequestEdited
 				buildPullRequestReviewRequested
 				buildPullRequestReviewDismissed
 				buildPullRequestReviewSubmitted

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -68,6 +68,8 @@ fragment RepositoryProviderSettingsFields on Repository {
                 # @genqlient(pointer: true)
                 buildPullRequestConvertedToDraft
                 # @genqlient(pointer: true)
+                buildPullRequestEdited
+                # @genqlient(pointer: true)
                 buildPullRequestReviewRequested
                 # @genqlient(pointer: true)
                 buildPullRequestReviewDismissed
@@ -149,6 +151,8 @@ fragment RepositoryProviderSettingsFields on Repository {
                 buildDeploymentStatusCreated
                 # @genqlient(pointer: true)
                 buildPullRequestConvertedToDraft
+                # @genqlient(pointer: true)
+                buildPullRequestEdited
                 # @genqlient(pointer: true)
                 buildPullRequestReviewRequested
                 # @genqlient(pointer: true)

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -138,6 +138,7 @@ type providerSettingsModel struct {
 	BuildCreateEvent                        types.Bool   `tfsdk:"build_create_event"`
 	BuildDeploymentStatusCreated            types.Bool   `tfsdk:"build_deployment_status_created"`
 	BuildPullRequestConvertedToDraft        types.Bool   `tfsdk:"build_pull_request_converted_to_draft"`
+	BuildPullRequestEdited                  types.Bool   `tfsdk:"build_pull_request_edited"`
 	BuildPullRequestReviewRequested         types.Bool   `tfsdk:"build_pull_request_review_requested"`
 	BuildPullRequestReviewDismissed         types.Bool   `tfsdk:"build_pull_request_review_dismissed"`
 	BuildPullRequestReviewSubmitted         types.Bool   `tfsdk:"build_pull_request_review_submitted"`
@@ -1082,6 +1083,14 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
 					},
+					"build_pull_request_edited": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create a build when a pull request is edited (i.e. its title, description, or base branch is changed).",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
 					"build_pull_request_review_requested": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
@@ -1506,6 +1515,7 @@ type PipelineExtraSettings struct {
 	BuildCreateEvent                        *bool   `json:"build_create_event,omitempty"`
 	BuildDeploymentStatusCreated            *bool   `json:"build_deployment_status_created,omitempty"`
 	BuildPullRequestConvertedToDraft        *bool   `json:"build_pull_request_converted_to_draft,omitempty"`
+	BuildPullRequestEdited                  *bool   `json:"build_pull_request_edited,omitempty"`
 	BuildPullRequestReviewRequested         *bool   `json:"build_pull_request_review_requested,omitempty"`
 	BuildPullRequestReviewDismissed         *bool   `json:"build_pull_request_review_dismissed,omitempty"`
 	BuildPullRequestReviewSubmitted         *bool   `json:"build_pull_request_review_submitted,omitempty"`
@@ -1569,6 +1579,7 @@ func updatePipelineExtraInfo(ctx context.Context, slug string, settings *provide
 			BuildCreateEvent:                        settings.BuildCreateEvent.ValueBoolPointer(),
 			BuildDeploymentStatusCreated:            settings.BuildDeploymentStatusCreated.ValueBoolPointer(),
 			BuildPullRequestConvertedToDraft:        settings.BuildPullRequestConvertedToDraft.ValueBoolPointer(),
+			BuildPullRequestEdited:                  settings.BuildPullRequestEdited.ValueBoolPointer(),
 			BuildPullRequestReviewRequested:         settings.BuildPullRequestReviewRequested.ValueBoolPointer(),
 			BuildPullRequestReviewDismissed:         settings.BuildPullRequestReviewDismissed.ValueBoolPointer(),
 			BuildPullRequestReviewSubmitted:         settings.BuildPullRequestReviewSubmitted.ValueBoolPointer(),
@@ -1637,6 +1648,7 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
 		BuildDeploymentStatusCreated:            types.BoolPointerValue(s.BuildDeploymentStatusCreated),
 		BuildPullRequestConvertedToDraft:        types.BoolPointerValue(s.BuildPullRequestConvertedToDraft),
+		BuildPullRequestEdited:                  types.BoolPointerValue(s.BuildPullRequestEdited),
 		BuildPullRequestReviewRequested:         types.BoolPointerValue(s.BuildPullRequestReviewRequested),
 		BuildPullRequestReviewDismissed:         types.BoolPointerValue(s.BuildPullRequestReviewDismissed),
 		BuildPullRequestReviewSubmitted:         types.BoolPointerValue(s.BuildPullRequestReviewSubmitted),
@@ -1698,6 +1710,7 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
 			BuildDeploymentStatusCreated:            types.BoolPointerValue(s.BuildDeploymentStatusCreated),
 			BuildPullRequestConvertedToDraft:        types.BoolPointerValue(s.BuildPullRequestConvertedToDraft),
+			BuildPullRequestEdited:                  types.BoolPointerValue(s.BuildPullRequestEdited),
 			BuildPullRequestReviewRequested:         types.BoolPointerValue(s.BuildPullRequestReviewRequested),
 			BuildPullRequestReviewDismissed:         types.BoolPointerValue(s.BuildPullRequestReviewDismissed),
 			BuildPullRequestReviewSubmitted:         types.BoolPointerValue(s.BuildPullRequestReviewSubmitted),
@@ -1741,6 +1754,7 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
 			BuildDeploymentStatusCreated:            types.BoolPointerValue(s.BuildDeploymentStatusCreated),
 			BuildPullRequestConvertedToDraft:        types.BoolPointerValue(s.BuildPullRequestConvertedToDraft),
+			BuildPullRequestEdited:                  types.BoolPointerValue(s.BuildPullRequestEdited),
 			BuildPullRequestReviewRequested:         types.BoolPointerValue(s.BuildPullRequestReviewRequested),
 			BuildPullRequestReviewDismissed:         types.BoolPointerValue(s.BuildPullRequestReviewDismissed),
 			BuildPullRequestReviewSubmitted:         types.BoolPointerValue(s.BuildPullRequestReviewSubmitted),
@@ -2105,6 +2119,10 @@ func pipelineSchemaV0() schema.Schema {
 							Optional: true,
 						},
 						"build_pull_request_converted_to_draft": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_edited": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
 						},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -674,6 +674,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", ""),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_edited", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.publish_commit_status", "false"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -734,6 +734,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					build_create_event = true
 					build_deployment_status_created = true
 					build_pull_request_converted_to_draft = true
+					build_pull_request_edited = true
 					build_pull_request_review_requested = true
 					build_pull_request_review_dismissed = true
 					build_pull_request_review_submitted = true
@@ -792,6 +793,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_converted_to_draft", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_edited", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_requested", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_dismissed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_submitted", "true"),
@@ -895,6 +897,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 								build_create_event = true
 								build_deployment_status_created = true
 								build_pull_request_converted_to_draft = true
+								build_pull_request_edited = true
 								build_pull_request_review_requested = true
 								build_pull_request_review_dismissed = true
 								build_pull_request_review_submitted = true
@@ -930,6 +933,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_converted_to_draft", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_edited", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_requested", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_dismissed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_submitted", "true"),

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -210,6 +210,7 @@ Optional:
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.
+- `build_pull_request_edited` (Boolean) Whether to create a build when a pull request is edited (i.e. its title, description, or base branch is changed).
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_merge_commits` (Boolean) Whether to build the test merge commit (the merged result of a pull request with its base branch).

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -210,7 +210,7 @@ Optional:
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.
-- `build_pull_request_edited` (Boolean) Whether to create a build when a pull request is edited (i.e. its title, description, or base branch is changed).
+- `build_pull_request_edited` (Boolean) Whether to create a build when a pull request is edited (i.e. its title or description).
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_merge_commits` (Boolean) Whether to build the test merge commit (the merged result of a pull request with its base branch).


### PR DESCRIPTION
# context

hey folks, i saw the blog post that [pipelines support triggering when a PR's title or description is edited](https://buildkite.com/resources/changelog/352-trigger-pipelines-from-more-github-events/). we'd like to control that from our IaC!

it does seem to already be in the schema, but i didn't see support for it in the terraform provider https://github.com/buildkite/terraform-provider-buildkite/blob/600205e1623d71f0261b71e64e60cf592e901223/schema.graphql#L9359-L9362

so this PR attempts to wire the requisite support for `build_pull_request_edited`

# testing

i manually ran the acceptance test that sets the edited flag against a test org, and it passed 🎉 ! ( i couldn't run that whole file cuz other tests were complaining about `cluster` in my test org, which i believe is unrelated to my change?)

```shell
TF_ACC=1 go test ./buildkite/ -v -run \
  'TestAccBuildkitePipelineResource/create_pipeline_setting_all_attributes'
```

<img width="756" height="214" alt="image" src="https://github.com/user-attachments/assets/50724bc6-7943-40ed-aceb-d6c2a4d41532" />


