### PR TITLE
Fix pipeline import leaving provider_settings and slug unset

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -443,7 +443,17 @@ func (p *pipelineResource) Read(ctx context.Context, req resource.ReadRequest, r
 		// (kept out of the shared PipelineFields fragment so unrelated reads aren't coupled to the
 		// provider settings subtree). Errors are surfaced, never swallowed, to avoid persisting stale
 		// state.
-		if state.ProviderSettings != nil {
+		//
+		// The state-based check above can't see a value that hasn't been imported into state yet, so
+		// also check the marker ImportState sets on the read that immediately follows an import - this
+		// makes sure a freshly imported pipeline's provider_settings gets fetched at least once.
+		importPending, diags := req.Private.GetKey(ctx, "importRefreshProviderSettings")
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if state.ProviderSettings != nil || len(importPending) > 0 {
 			var providerSettingsResponse *getPipelineProviderSettingsResponse
 			err := retry.RetryContext(ctx, timeouts, func() *retry.RetryError {
 				var err error
@@ -459,6 +469,10 @@ func (p *pipelineResource) Read(ctx context.Context, req resource.ReadRequest, r
 				if mapped := mapProviderSettingsFromGraphQL(psPipeline.Repository.RepositoryProviderSettingsFields); mapped != nil {
 					state.ProviderSettings = mapped
 				}
+			}
+
+			if len(importPending) > 0 {
+				resp.Diagnostics.Append(resp.Private.SetKey(ctx, "importRefreshProviderSettings", nil)...)
 			}
 		}
 
@@ -1409,6 +1423,12 @@ func (p *pipelineResource) findAndRemoveTeam(ctx context.Context, teamID string,
 
 func (*pipelineResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+
+	// ImportStatePassthroughID only seeds the id attribute, so state.ProviderSettings
+	// is always nil on the Read that follows import regardless of what's actually
+	// configured on the pipeline. Mark this so Read knows to fetch provider_settings
+	// once even though its state-based "did the user configure this" check can't see it yet.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "importRefreshProviderSettings", []byte(`{"pending": true}`))...)
 }
 
 func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
@@ -1434,6 +1454,7 @@ func setPipelineModel(model *pipelineResourceModel, data pipelineResponse) {
 	model.Repository = types.StringValue(data.GetRepository().Url)
 	model.SkipIntermediateBuilds = types.BoolValue(data.GetSkipIntermediateBuilds())
 	model.SkipIntermediateBuildsBranchFilter = types.StringValue(data.GetSkipIntermediateBuildsBranchFilter())
+	model.Slug = types.StringValue(data.GetSlug())
 	model.UUID = types.StringValue(data.GetPipelineUuid())
 	model.Visibility = types.StringValue(string(data.GetVisibility()))
 	model.WebhookUrl = types.StringValue(data.GetWebhookURL())

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -817,6 +817,15 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.use_step_key_as_commit_status", "true"),
 					),
 				},
+				{
+					// SUP-2592: importing a pipeline must populate provider_settings from the
+					// API, not just leave it as whatever was (or wasn't) in prior state.
+					// ImportStateVerify diffs every flatmapped attribute - including
+					// provider_settings.* - between pre-import and post-import state.
+					ResourceName:      "buildkite_pipeline.pipeline",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
 		})
 	})


### PR DESCRIPTION
  ## Summary

Importing a `buildkite_pipeline` left `provider_settings` as `null` in state, even when the pipeline genuinely had VCS integration settings configured on the Buildkite side. `Read` only fetches `provider_settings` via a dedicated GraphQL call when `state.ProviderSettings != nil` which is an optimization to skip the call for pipelines the user never configured this on.
But `ImportStatePassthroughID` only ever seeds the `id` attribute, so that check is always false immediately after import, regardless of what's actually configured. The fetch never fires and `null` gets written to state permanently.

Fixed by having `ImportState` set a private-state marker (matching this file's existing `slugSource` pattern), which `Read` checks in addition to the state-based condition , forcing the fetch once on the read that follows an import, then clearing the marker so normal reads keep the existing optimization with no behavior change.

While verifying this with a real `ImportStateVerify` test (previously the only import test for this resource lacked it), a second, unrelated bug surfaced: `setPipelineModel` never set `Slug` from the API response, for any pipeline, under any circumstance - only `Create`/`Update` ever set it. This was invisible in normal usage because `Read` never clears `state.Slug` either, so it silently persisted from Create. Import starts from empty state, so this was equally broken there. Fixed with one line, since `PipelineFields.GetSlug()` was already generated/available with no GraphQL schema change needed.

  ## Testing
  
- Reproduced live against a real pipeline before/after the fix (import showed `provider_settings: null` before, fully populated matching real values after).
- Added an `ImportStateVerify: true` step to the existing `TestAccBuildkitePipelineResource/create_pipeline_setting_all_attributes` subtest — reuses its existing real GitHub-connected pipeline and rich `provider_settings` config rather than adding a new fixture. 
