### PR TITLE
Add Cursor Origin provider_settings GraphQL support

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -2588,6 +2588,7 @@ func (v *RepositoryProviderSettingsFields) __premarshalJSON() (*__premarshalRepo
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderBitbucket
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderBitbucketServer
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebase
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterprise
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlab
@@ -2607,6 +2608,8 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderBitbucket) im
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderBitbucketServer) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebase) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
+}
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
@@ -2646,6 +2649,9 @@ func __unmarshalRepositoryProviderSettingsFieldsProviderRepositoryProvider(b []b
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderCodebase":
 		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebase)
+		return json.Unmarshal(b, *v)
+	case "RepositoryProviderCursorOrigin":
+		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin)
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderGithub":
 		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub)
@@ -2708,6 +2714,14 @@ func __marshalRepositoryProviderSettingsFieldsProviderRepositoryProvider(v *Repo
 		result := struct {
 			TypeName string `json:"__typename"`
 			*RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebase
+		}{typename, v}
+		return json.Marshal(result)
+	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin:
+		typename = "RepositoryProviderCursorOrigin"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin
 		}{typename, v}
 		return json.Marshal(result)
 	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub:
@@ -3026,6 +3040,61 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebaseSetti
 // GetFilterEnabled returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebaseSettings.FilterEnabled, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebaseSettings) GetFilterEnabled() *bool {
 	return v.FilterEnabled
+}
+
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin includes the requested fields of the GraphQL type RepositoryProviderCursorOrigin.
+// The GraphQL type's documentation follows.
+//
+// A pipeline's repository is being provided by Cursor Origin
+type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin struct {
+	Typename string `json:"__typename"`
+	// The repository’s provider settings
+	Settings RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings `json:"settings"`
+}
+
+// GetTypename returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin.Typename, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin) GetTypename() string {
+	return v.Typename
+}
+
+// GetSettings returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin.Settings, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin) GetSettings() RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings {
+	return v.Settings
+}
+
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings includes the requested fields of the GraphQL type RepositoryProviderCursorOriginSettings.
+// The GraphQL type's documentation follows.
+//
+// Settings for a Cursor Origin repository
+type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings struct {
+	// Whether to create builds when branches are pushed.
+	BuildBranches *bool `json:"buildBranches"`
+	// The conditions under which this pipeline will trigger a build.
+	FilterCondition *string `json:"filterCondition"`
+	// Whether the filter is enabled
+	FilterEnabled *bool `json:"filterEnabled"`
+	// Whether to publish build results to Cursor Origin as a check run.
+	PublishCommitStatus *bool `json:"publishCommitStatus"`
+}
+
+// GetBuildBranches returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.BuildBranches, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetBuildBranches() *bool {
+	return v.BuildBranches
+}
+
+// GetFilterCondition returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.FilterCondition, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetFilterCondition() *string {
+	return v.FilterCondition
+}
+
+// GetFilterEnabled returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.FilterEnabled, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetFilterEnabled() *bool {
+	return v.FilterEnabled
+}
+
+// GetPublishCommitStatus returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.PublishCommitStatus, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetPublishCommitStatus() *bool {
+	return v.PublishCommitStatus
 }
 
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub includes the requested fields of the GraphQL type RepositoryProviderGithub.
@@ -18839,6 +18908,7 @@ func (v *getPipelineWebhookNodePipelineRepository) __premarshalJSON() (*__premar
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderBitbucket
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderBitbucketServer
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase
+// getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGithub
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGithubEnterprise
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlab
@@ -18858,6 +18928,8 @@ func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderBitbu
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderBitbucketServer) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
+}
+func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGithub) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
@@ -18897,6 +18969,9 @@ func __unmarshalgetPipelineWebhookNodePipelineRepositoryProvider(b []byte, v *ge
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderCodebase":
 		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase)
+		return json.Unmarshal(b, *v)
+	case "RepositoryProviderCursorOrigin":
+		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin)
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderGithub":
 		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGithub)
@@ -18959,6 +19034,14 @@ func __marshalgetPipelineWebhookNodePipelineRepositoryProvider(v *getPipelineWeb
 		result := struct {
 			TypeName string `json:"__typename"`
 			*getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase
+		}{typename, v}
+		return json.Marshal(result)
+	case *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin:
+		typename = "RepositoryProviderCursorOrigin"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin
 		}{typename, v}
 		return json.Marshal(result)
 	case *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGithub:
@@ -19066,6 +19149,19 @@ type getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase 
 
 // GetTypename returns getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase.Typename, and is useful for accessing the field via an interface.
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodebase) GetTypename() string {
+	return v.Typename
+}
+
+// getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin includes the requested fields of the GraphQL type RepositoryProviderCursorOrigin.
+// The GraphQL type's documentation follows.
+//
+// A pipeline's repository is being provided by Cursor Origin
+type getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin struct {
+	Typename string `json:"__typename"`
+}
+
+// GetTypename returns getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin.Typename, and is useful for accessing the field via an interface.
+func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin) GetTypename() string {
 	return v.Typename
 }
 
@@ -26162,6 +26258,14 @@ fragment RepositoryProviderSettingsFields on Repository {
 			settings {
 				filterCondition
 				filterEnabled
+			}
+		}
+		... on RepositoryProviderCursorOrigin {
+			settings {
+				buildBranches
+				filterCondition
+				filterEnabled
+				publishCommitStatus
 			}
 		}
 		... on RepositoryProviderUnknown {

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -306,6 +306,18 @@ fragment RepositoryProviderSettingsFields on Repository {
                 filterEnabled
             }
         }
+        ... on RepositoryProviderCursorOrigin {
+            settings {
+                # @genqlient(pointer: true)
+                buildBranches
+                # @genqlient(pointer: true)
+                filterCondition
+                # @genqlient(pointer: true)
+                filterEnabled
+                # @genqlient(pointer: true)
+                publishCommitStatus
+            }
+        }
         ... on RepositoryProviderUnknown {
             settings {
                 # @genqlient(pointer: true)

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1825,6 +1825,14 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			FilterCondition: types.StringPointerValue(s.FilterCondition),
 			FilterEnabled:   types.BoolPointerValue(s.FilterEnabled),
 		}
+	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin:
+		s := provider.Settings
+		return &providerSettingsModel{
+			BuildBranches:       types.BoolPointerValue(s.BuildBranches),
+			FilterCondition:     types.StringPointerValue(s.FilterCondition),
+			FilterEnabled:       types.BoolPointerValue(s.FilterEnabled),
+			PublishCommitStatus: types.BoolPointerValue(s.PublishCommitStatus),
+		}
 	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown:
 		s := provider.Settings
 		return &providerSettingsModel{

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -174,6 +174,40 @@ func TestMapProviderSettingsFromGraphQLGitlabEnterprise(t *testing.T) {
 	}
 }
 
+func TestMapProviderSettingsFromGraphQLCursorOrigin(t *testing.T) {
+	cond := `build.branch == "main"`
+	enabled := true
+	disabled := false
+
+	repo := RepositoryProviderSettingsFields{
+		Provider: &RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin{
+			Settings: RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings{
+				BuildBranches:       &enabled,
+				FilterCondition:     &cond,
+				FilterEnabled:       &enabled,
+				PublishCommitStatus: &disabled,
+			},
+		},
+	}
+
+	got := mapProviderSettingsFromGraphQL(repo)
+	if got == nil {
+		t.Fatal("expected Cursor Origin provider settings to be mapped, got nil")
+	}
+	if !got.BuildBranches.ValueBool() {
+		t.Fatal("build_branches: expected true")
+	}
+	if got.FilterCondition.ValueString() != cond {
+		t.Fatalf("filter_condition: expected %q, got %q", cond, got.FilterCondition.ValueString())
+	}
+	if !got.FilterEnabled.ValueBool() {
+		t.Fatal("filter_enabled: expected true")
+	}
+	if got.PublishCommitStatus.ValueBool() {
+		t.Fatal("publish_commit_status: expected false")
+	}
+}
+
 func testAccCheckPipelineDestroyFunc(s *terraform.State) error {
 	return testAccCheckPipelineDestroy(s)
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -9697,6 +9697,50 @@ Whether to use step keys as commit status names for per-step commit statuses. Re
 }
 
 """
+A pipeline's repository is being provided by Cursor Origin
+"""
+type RepositoryProviderCursorOrigin implements RepositoryProvider{
+"""
+The name of the provider
+"""
+	name: String!
+"""
+The repository’s provider settings
+"""
+	settings: RepositoryProviderCursorOriginSettings
+"""
+This URL to the provider’s web interface
+"""
+	url: String
+"""
+The URL to use when setting up webhooks from the provider to trigger Buildkite builds
+"""
+	webhookUrl: String
+}
+
+"""
+Settings for a Cursor Origin repository
+"""
+type RepositoryProviderCursorOriginSettings implements RepositoryProviderSettings{
+"""
+Whether to create builds when branches are pushed.
+"""
+	buildBranches: Boolean!
+"""
+The conditions under which this pipeline will trigger a build.
+"""
+	filterCondition: String
+"""
+Whether the filter is enabled
+"""
+	filterEnabled: Boolean
+"""
+Whether to publish build results to Cursor Origin as a check run.
+"""
+	publishCommitStatus: Boolean!
+}
+
+"""
 A pipeline's repository is being provided by GitHub
 """
 type RepositoryProviderGithub implements RepositoryProvider{


### PR DESCRIPTION
## Summary
- Add `RepositoryProviderCursorOrigin` to the GraphQL fragment used when reading `provider_settings`
- Map Cursor Origin settings (`build_branches`, `publish_commit_status`, `filter_enabled`, `filter_condition`) into the pipeline resource model
- Refresh the vendored schema and regenerate genqlient types so refresh/plan no longer fails on `__typename: RepositoryProviderCursorOrigin`

## Test plan
- [x] `go test ./buildkite -run TestMapProviderSettingsFromGraphQL`
- [x] `go test ./...`
- [x] Local provider override against a Cursor Origin pipeline: `terraform plan` refreshes successfully
- [x] Toggle `publish_commit_status` with a normal refresh-based apply, then restore and confirm a clean plan
- [ ] CI acceptance / unit checks on this PR
