### PR TITLE
Support all Cursor Origin UI provider settings

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -3084,6 +3084,10 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin)
 type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings struct {
 	// Whether to create builds when branches are pushed.
 	BuildBranches *bool `json:"buildBranches"`
+	// Whether to create builds for commits that are part of a pull request.
+	BuildPullRequests *bool `json:"buildPullRequests"`
+	// Whether to create builds when tags are pushed.
+	BuildTags *bool `json:"buildTags"`
 	// The conditions under which this pipeline will trigger a build.
 	FilterCondition *string `json:"filterCondition"`
 	// Whether the filter is enabled
@@ -3095,6 +3099,16 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSetti
 // GetBuildBranches returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.BuildBranches, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetBuildBranches() *bool {
 	return v.BuildBranches
+}
+
+// GetBuildPullRequests returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.BuildPullRequests, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetBuildPullRequests() *bool {
+	return v.BuildPullRequests
+}
+
+// GetBuildTags returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.BuildTags, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings) GetBuildTags() *bool {
+	return v.BuildTags
 }
 
 // GetFilterCondition returns RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings.FilterCondition, and is useful for accessing the field via an interface.
@@ -26309,6 +26323,8 @@ fragment RepositoryProviderSettingsFields on Repository {
 		... on RepositoryProviderCursorOrigin {
 			settings {
 				buildBranches
+				buildPullRequests
+				buildTags
 				filterCondition
 				filterEnabled
 				publishCommitStatus

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -313,6 +313,10 @@ fragment RepositoryProviderSettingsFields on Repository {
                 # @genqlient(pointer: true)
                 buildBranches
                 # @genqlient(pointer: true)
+                buildPullRequests
+                # @genqlient(pointer: true)
+                buildTags
+                # @genqlient(pointer: true)
                 filterCondition
                 # @genqlient(pointer: true)
                 filterEnabled

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1838,6 +1838,8 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 		s := provider.Settings
 		return &providerSettingsModel{
 			BuildBranches:       types.BoolPointerValue(s.BuildBranches),
+			BuildPullRequests:   types.BoolPointerValue(s.BuildPullRequests),
+			BuildTags:           types.BoolPointerValue(s.BuildTags),
 			FilterCondition:     types.StringPointerValue(s.FilterCondition),
 			FilterEnabled:       types.BoolPointerValue(s.FilterEnabled),
 			PublishCommitStatus: types.BoolPointerValue(s.PublishCommitStatus),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -183,6 +183,8 @@ func TestMapProviderSettingsFromGraphQLCursorOrigin(t *testing.T) {
 		Provider: &RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin{
 			Settings: RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings{
 				BuildBranches:       &enabled,
+				BuildPullRequests:   &enabled,
+				BuildTags:           &disabled,
 				FilterCondition:     &cond,
 				FilterEnabled:       &enabled,
 				PublishCommitStatus: &disabled,
@@ -197,14 +199,20 @@ func TestMapProviderSettingsFromGraphQLCursorOrigin(t *testing.T) {
 	if !got.BuildBranches.ValueBool() {
 		t.Fatal("build_branches: expected true")
 	}
+	if !got.BuildPullRequests.ValueBool() {
+		t.Fatal("build_pull_requests: expected true")
+	}
+	if got.BuildTags.IsNull() || got.BuildTags.ValueBool() {
+		t.Fatal("build_tags: expected false, got null or true")
+	}
 	if got.FilterCondition.ValueString() != cond {
 		t.Fatalf("filter_condition: expected %q, got %q", cond, got.FilterCondition.ValueString())
 	}
 	if !got.FilterEnabled.ValueBool() {
 		t.Fatal("filter_enabled: expected true")
 	}
-	if got.PublishCommitStatus.ValueBool() {
-		t.Fatal("publish_commit_status: expected false")
+	if got.PublishCommitStatus.IsNull() || got.PublishCommitStatus.ValueBool() {
+		t.Fatal("publish_commit_status: expected false, got null or true")
 	}
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -9739,6 +9739,14 @@ Whether to create builds when branches are pushed.
 """
 	buildBranches: Boolean!
 """
+Whether to create builds for commits that are part of a pull request.
+"""
+	buildPullRequests: Boolean!
+"""
+Whether to create builds when tags are pushed.
+"""
+	buildTags: Boolean!
+"""
 The conditions under which this pipeline will trigger a build.
 """
 	filterCondition: String


### PR DESCRIPTION
## Summary
- refresh `build_pull_requests` and `build_tags` for Cursor Origin pipelines so all current UI settings round-trip through Terraform
- preserve explicit `false` values in regression coverage instead of allowing null to look equivalent
- update the vendored GraphQL schema and generated client types

## Test plan
- [x] `go test ./...`
- [x] build the provider from this branch
- [x] apply `publish_commit_status = false` against a Cursor Origin pipeline and confirm REST and Terraform state contain `false`
- [x] refresh after apply and confirm a clean Terraform plan
- [x] configure all current Cursor Origin UI settings against the test pipeline and confirm a clean post-apply plan

Follow-up for additional applicable provider settings: [PIPE-2209](https://linear.app/buildkite/issue/PIPE-2209/support-applicable-github-pipeline-settings-for-cursor-origin)

Made with [Cursor](https://cursor.com)