### PR TITLE
fix(pipeline): support both Origin GraphQL type names

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -2609,6 +2609,7 @@ func (v *RepositoryProviderSettingsFields) __premarshalJSON() (*__premarshalRepo
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlab
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabCommunity
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabEnterprise
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown
 type RepositoryProviderSettingsFieldsProviderRepositoryProvider interface {
 	implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider()
@@ -2635,6 +2636,8 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlab) imple
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabCommunity) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabEnterprise) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
+}
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown) implementsGraphQLInterfaceRepositoryProviderSettingsFieldsProviderRepositoryProvider() {
 }
@@ -2682,6 +2685,9 @@ func __unmarshalRepositoryProviderSettingsFieldsProviderRepositoryProvider(b []b
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderGitlabEnterprise":
 		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabEnterprise)
+		return json.Unmarshal(b, *v)
+	case "RepositoryProviderOrigin":
+		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin)
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderUnknown":
 		*v = new(RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown)
@@ -2777,6 +2783,14 @@ func __marshalRepositoryProviderSettingsFieldsProviderRepositoryProvider(v *Repo
 		result := struct {
 			TypeName string `json:"__typename"`
 			*RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabEnterprise
+		}{typename, v}
+		return json.Marshal(result)
+	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin:
+		typename = "RepositoryProviderOrigin"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin
 		}{typename, v}
 		return json.Marshal(result)
 	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown:
@@ -3060,7 +3074,7 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCodebaseSetti
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin includes the requested fields of the GraphQL type RepositoryProviderCursorOrigin.
 // The GraphQL type's documentation follows.
 //
-// A pipeline's repository is being provided by Cursor Origin
+// A pipeline's repository is being provided by Origin
 type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin struct {
 	Typename string `json:"__typename"`
 	// The repository’s provider settings
@@ -3080,7 +3094,7 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin)
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings includes the requested fields of the GraphQL type RepositoryProviderCursorOriginSettings.
 // The GraphQL type's documentation follows.
 //
-// Settings for a Cursor Origin repository
+// Settings for an Origin repository
 type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSettings struct {
 	// Whether to create builds when branches are pushed.
 	BuildBranches *bool `json:"buildBranches"`
@@ -3092,7 +3106,7 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOriginSetti
 	FilterCondition *string `json:"filterCondition"`
 	// Whether the filter is enabled
 	FilterEnabled *bool `json:"filterEnabled"`
-	// Whether to publish build results to Cursor Origin as a check run.
+	// Whether to publish build results to Origin as a check run.
 	PublishCommitStatus *bool `json:"publishCommitStatus"`
 }
 
@@ -3847,6 +3861,75 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabSetting
 // GetFilterEnabled returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabSettings.FilterEnabled, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGitlabSettings) GetFilterEnabled() *bool {
 	return v.FilterEnabled
+}
+
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin includes the requested fields of the GraphQL type RepositoryProviderOrigin.
+// The GraphQL type's documentation follows.
+//
+// A pipeline's repository is being provided by Origin
+type RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin struct {
+	Typename string `json:"__typename"`
+	// The repository’s provider settings
+	Settings RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings `json:"settings"`
+}
+
+// GetTypename returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin.Typename, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin) GetTypename() string {
+	return v.Typename
+}
+
+// GetSettings returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin.Settings, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin) GetSettings() RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings {
+	return v.Settings
+}
+
+// RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings includes the requested fields of the GraphQL type RepositoryProviderOriginSettings.
+// The GraphQL type's documentation follows.
+//
+// Settings for an Origin repository
+type RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings struct {
+	// Whether to create builds when branches are pushed.
+	BuildBranches *bool `json:"buildBranches"`
+	// Whether to create builds for commits that are part of a pull request.
+	BuildPullRequests *bool `json:"buildPullRequests"`
+	// Whether to create builds when tags are pushed.
+	BuildTags *bool `json:"buildTags"`
+	// The conditions under which this pipeline will trigger a build.
+	FilterCondition *string `json:"filterCondition"`
+	// Whether the filter is enabled
+	FilterEnabled *bool `json:"filterEnabled"`
+	// Whether to publish build results to Origin as a check run.
+	PublishCommitStatus *bool `json:"publishCommitStatus"`
+}
+
+// GetBuildBranches returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.BuildBranches, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetBuildBranches() *bool {
+	return v.BuildBranches
+}
+
+// GetBuildPullRequests returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.BuildPullRequests, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetBuildPullRequests() *bool {
+	return v.BuildPullRequests
+}
+
+// GetBuildTags returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.BuildTags, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetBuildTags() *bool {
+	return v.BuildTags
+}
+
+// GetFilterCondition returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.FilterCondition, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetFilterCondition() *string {
+	return v.FilterCondition
+}
+
+// GetFilterEnabled returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.FilterEnabled, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetFilterEnabled() *bool {
+	return v.FilterEnabled
+}
+
+// GetPublishCommitStatus returns RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings.PublishCommitStatus, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings) GetPublishCommitStatus() *bool {
+	return v.PublishCommitStatus
 }
 
 // RepositoryProviderSettingsFieldsProviderRepositoryProviderUnknown includes the requested fields of the GraphQL type RepositoryProviderUnknown.
@@ -18963,6 +19046,7 @@ func (v *getPipelineWebhookNodePipelineRepository) __premarshalJSON() (*__premar
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlab
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabCommunity
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise
+// getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderUnknown
 type getPipelineWebhookNodePipelineRepositoryProvider interface {
 	implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider()
@@ -18989,6 +19073,8 @@ func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitla
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabCommunity) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
+}
+func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderUnknown) implementsGraphQLInterfacegetPipelineWebhookNodePipelineRepositoryProvider() {
 }
@@ -19036,6 +19122,9 @@ func __unmarshalgetPipelineWebhookNodePipelineRepositoryProvider(b []byte, v *ge
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderGitlabEnterprise":
 		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise)
+		return json.Unmarshal(b, *v)
+	case "RepositoryProviderOrigin":
+		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin)
 		return json.Unmarshal(b, *v)
 	case "RepositoryProviderUnknown":
 		*v = new(getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderUnknown)
@@ -19133,6 +19222,14 @@ func __marshalgetPipelineWebhookNodePipelineRepositoryProvider(v *getPipelineWeb
 			*getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise
 		}{typename, v}
 		return json.Marshal(result)
+	case *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin:
+		typename = "RepositoryProviderOrigin"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin
+		}{typename, v}
+		return json.Marshal(result)
 	case *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderUnknown:
 		typename = "RepositoryProviderUnknown"
 
@@ -19204,7 +19301,7 @@ func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCodeb
 // getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin includes the requested fields of the GraphQL type RepositoryProviderCursorOrigin.
 // The GraphQL type's documentation follows.
 //
-// A pipeline's repository is being provided by Cursor Origin
+// A pipeline's repository is being provided by Origin
 type getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderCursorOrigin struct {
 	Typename string `json:"__typename"`
 }
@@ -19420,6 +19517,19 @@ type getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnt
 
 // GetTypename returns getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise.Typename, and is useful for accessing the field via an interface.
 func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderGitlabEnterprise) GetTypename() string {
+	return v.Typename
+}
+
+// getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin includes the requested fields of the GraphQL type RepositoryProviderOrigin.
+// The GraphQL type's documentation follows.
+//
+// A pipeline's repository is being provided by Origin
+type getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin struct {
+	Typename string `json:"__typename"`
+}
+
+// GetTypename returns getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin.Typename, and is useful for accessing the field via an interface.
+func (v *getPipelineWebhookNodePipelineRepositoryProviderRepositoryProviderOrigin) GetTypename() string {
 	return v.Typename
 }
 
@@ -26321,6 +26431,16 @@ fragment RepositoryProviderSettingsFields on Repository {
 			}
 		}
 		... on RepositoryProviderCursorOrigin {
+			settings {
+				buildBranches
+				buildPullRequests
+				buildTags
+				filterCondition
+				filterEnabled
+				publishCommitStatus
+			}
+		}
+		... on RepositoryProviderOrigin {
 			settings {
 				buildBranches
 				buildPullRequests

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -324,6 +324,22 @@ fragment RepositoryProviderSettingsFields on Repository {
                 publishCommitStatus
             }
         }
+        ... on RepositoryProviderOrigin {
+            settings {
+                # @genqlient(pointer: true)
+                buildBranches
+                # @genqlient(pointer: true)
+                buildPullRequests
+                # @genqlient(pointer: true)
+                buildTags
+                # @genqlient(pointer: true)
+                filterCondition
+                # @genqlient(pointer: true)
+                filterEnabled
+                # @genqlient(pointer: true)
+                publishCommitStatus
+            }
+        }
         ... on RepositoryProviderUnknown {
             settings {
                 # @genqlient(pointer: true)

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1834,6 +1834,16 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			FilterCondition: types.StringPointerValue(s.FilterCondition),
 			FilterEnabled:   types.BoolPointerValue(s.FilterEnabled),
 		}
+	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin:
+		s := provider.Settings
+		return &providerSettingsModel{
+			BuildBranches:       types.BoolPointerValue(s.BuildBranches),
+			BuildPullRequests:   types.BoolPointerValue(s.BuildPullRequests),
+			BuildTags:           types.BoolPointerValue(s.BuildTags),
+			FilterCondition:     types.StringPointerValue(s.FilterCondition),
+			FilterEnabled:       types.BoolPointerValue(s.FilterEnabled),
+			PublishCommitStatus: types.BoolPointerValue(s.PublishCommitStatus),
+		}
 	case *RepositoryProviderSettingsFieldsProviderRepositoryProviderCursorOrigin:
 		s := provider.Settings
 		return &providerSettingsModel{

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -174,6 +174,27 @@ func TestMapProviderSettingsFromGraphQLGitlabEnterprise(t *testing.T) {
 	}
 }
 
+func TestMapProviderSettingsFromGraphQLOrigin(t *testing.T) {
+	cond := `build.branch == "main"`
+	enabled := true
+	disabled := false
+
+	repo := RepositoryProviderSettingsFields{
+		Provider: &RepositoryProviderSettingsFieldsProviderRepositoryProviderOrigin{
+			Settings: RepositoryProviderSettingsFieldsProviderRepositoryProviderOriginSettings{
+				BuildBranches:       &enabled,
+				BuildPullRequests:   &enabled,
+				BuildTags:           &disabled,
+				FilterCondition:     &cond,
+				FilterEnabled:       &enabled,
+				PublishCommitStatus: &disabled,
+			},
+		},
+	}
+
+	assertOriginProviderSettings(t, repo, cond)
+}
+
 func TestMapProviderSettingsFromGraphQLCursorOrigin(t *testing.T) {
 	cond := `build.branch == "main"`
 	enabled := true
@@ -192,9 +213,15 @@ func TestMapProviderSettingsFromGraphQLCursorOrigin(t *testing.T) {
 		},
 	}
 
+	assertOriginProviderSettings(t, repo, cond)
+}
+
+func assertOriginProviderSettings(t *testing.T, repo RepositoryProviderSettingsFields, cond string) {
+	t.Helper()
+
 	got := mapProviderSettingsFromGraphQL(repo)
 	if got == nil {
-		t.Fatal("expected Cursor Origin provider settings to be mapped, got nil")
+		t.Fatal("expected Origin provider settings to be mapped, got nil")
 	}
 	if !got.BuildBranches.ValueBool() {
 		t.Fatal("build_branches: expected true")

--- a/schema.graphql
+++ b/schema.graphql
@@ -9709,7 +9709,7 @@ Whether to use step keys as commit status names for per-step commit statuses. Re
 }
 
 """
-A pipeline's repository is being provided by Cursor Origin
+A pipeline's repository is being provided by Origin
 """
 type RepositoryProviderCursorOrigin implements RepositoryProvider{
 """
@@ -9731,7 +9731,7 @@ The URL to use when setting up webhooks from the provider to trigger Buildkite b
 }
 
 """
-Settings for a Cursor Origin repository
+Settings for an Origin repository
 """
 type RepositoryProviderCursorOriginSettings implements RepositoryProviderSettings{
 """
@@ -9755,7 +9755,59 @@ Whether the filter is enabled
 """
 	filterEnabled: Boolean
 """
-Whether to publish build results to Cursor Origin as a check run.
+Whether to publish build results to Origin as a check run.
+"""
+	publishCommitStatus: Boolean!
+}
+
+"""
+A pipeline's repository is being provided by Origin
+"""
+type RepositoryProviderOrigin implements RepositoryProvider{
+"""
+The name of the provider
+"""
+	name: String!
+"""
+The repository’s provider settings
+"""
+	settings: RepositoryProviderOriginSettings
+"""
+This URL to the provider’s web interface
+"""
+	url: String
+"""
+The URL to use when setting up webhooks from the provider to trigger Buildkite builds
+"""
+	webhookUrl: String
+}
+
+"""
+Settings for an Origin repository
+"""
+type RepositoryProviderOriginSettings implements RepositoryProviderSettings{
+"""
+Whether to create builds when branches are pushed.
+"""
+	buildBranches: Boolean!
+"""
+Whether to create builds for commits that are part of a pull request.
+"""
+	buildPullRequests: Boolean!
+"""
+Whether to create builds when tags are pushed.
+"""
+	buildTags: Boolean!
+"""
+The conditions under which this pipeline will trigger a build.
+"""
+	filterCondition: String
+"""
+Whether the filter is enabled
+"""
+	filterEnabled: Boolean
+"""
+Whether to publish build results to Origin as a check run.
 """
 	publishCommitStatus: Boolean!
 }
@@ -12818,5 +12870,3 @@ scalar XML
 A blob of YAML
 """
 scalar YAML
-
-


### PR DESCRIPTION
### Description

- supports both the existing `CursorOrigin` and new `Origin` GraphQL type names
- this lets the provider span the additive schema rollout and a later `__typename` switch

### Context

- https://linear.app/buildkite/issue/PB-2846/rename-graphql-types-without-breaking-terraform-provider
- coordinated Buildkite change: https://github.com/buildkite/buildkite/pull/32363

### Changes

- queries provider settings through inline fragments for both type names
- maps both generated provider variants into Terraform state
- updates the checked-in schema and generated GraphQL client
- covers both mapping paths

### Verification

- `make test`

### Deployment

- merge and release only after buildkite/buildkite#32363 has deployed
- the release works before and after a later Buildkite resolver switch

### Rollback

- safe to revert while Buildkite continues returning the legacy typename
