### PR TITLE
fix(organization): skip allowlist and 2FA mutations when unchanged

### DIFF
--- a/buildkite/resource_organization.go
+++ b/buildkite/resource_organization.go
@@ -110,7 +110,13 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	log.Printf("Creating settings for organization %s ...", *org)
-	if err := o.updateAllowedApiIpAddresses(ctx, *org, plan.AllowedApiIpAddresses, types.ListNull(types.StringType)); err != nil {
+	// compare with the organization's current allowlist so a matching one is left as it is
+	current, diags := allowedApiIpAddressesFromAPI(ctx, organization.Organization.AllowedApiIpAddresses, plan.AllowedApiIpAddresses)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := o.updateAllowedApiIpAddresses(ctx, *org, plan.AllowedApiIpAddresses, current); err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Organization settings",
 			fmt.Sprintf("Unable to create Organization settings: %s", err.Error()),

--- a/buildkite/resource_organization.go
+++ b/buildkite/resource_organization.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -91,9 +92,6 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	// Create CIDR slice from AllowedApiIpAddresses
-	cidrs := createCidrSliceFromList(plan.AllowedApiIpAddresses)
-
 	org, err := o.client.GetOrganizationID()
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -102,14 +100,17 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 		)
 		return
 	}
-	log.Printf("Creating settings for organization %s ...", *org)
-	apiResponse, err := setApiIpAddresses(
-		ctx,
-		o.client.genqlient,
-		*org,
-		strings.Join(cidrs, " "),
-	)
+	organization, err := getOrganization(ctx, o.client.genqlient, o.client.organization)
 	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to obtain Organization",
+			fmt.Sprintf("Unable to obtain Organization: %s", err.Error()),
+		)
+		return
+	}
+
+	log.Printf("Creating settings for organization %s ...", *org)
+	if err := o.updateAllowedApiIpAddresses(ctx, *org, plan.AllowedApiIpAddresses, types.ListNull(types.StringType)); err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Organization settings",
 			fmt.Sprintf("Unable to create Organization settings: %s", err.Error()),
@@ -117,7 +118,7 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if !plan.Enforce2FA.IsNull() && !plan.Enforce2FA.IsUnknown() {
+	if !plan.Enforce2FA.IsNull() && !plan.Enforce2FA.IsUnknown() && plan.Enforce2FA.ValueBool() != organization.Organization.MembersRequireTwoFactorAuthentication {
 		_, err = setOrganization2FA(ctx, o.client.genqlient, *org, plan.Enforce2FA.ValueBool())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to set 2FA", err.Error())
@@ -125,8 +126,8 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 		}
 	}
 
-	state.ID = types.StringValue(apiResponse.OrganizationApiIpAllowlistUpdate.Organization.Id)
-	state.UUID = types.StringValue(apiResponse.OrganizationApiIpAllowlistUpdate.Organization.Uuid)
+	state.ID = types.StringValue(*org)
+	state.UUID = types.StringValue(organization.Organization.Uuid)
 	state.Enforce2FA = plan.Enforce2FA
 	state.AllowedApiIpAddresses = plan.AllowedApiIpAddresses
 
@@ -163,15 +164,24 @@ func (o *organizationResource) Read(ctx context.Context, req resource.ReadReques
 	state.ID = types.StringValue(*org)
 	state.UUID = types.StringValue(response.Organization.Uuid)
 	state.Enforce2FA = types.BoolValue(response.Organization.MembersRequireTwoFactorAuthentication)
-	ips, diag := types.ListValueFrom(ctx, types.StringType, strings.Split(response.Organization.AllowedApiIpAddresses, " "))
-	state.AllowedApiIpAddresses = ips
 
+	ips, diag := allowedApiIpAddressesFromAPI(ctx, response.Organization.AllowedApiIpAddresses, state.AllowedApiIpAddresses)
 	if diag.HasError() {
 		resp.Diagnostics.Append(diag...)
 		return
 	}
+	state.AllowedApiIpAddresses = ips
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+// allowedApiIpAddressesFromAPI maps the space separated allowlist from the API onto allowed_api_ip_addresses
+func allowedApiIpAddressesFromAPI(ctx context.Context, remote string, current types.List) (types.List, diag.Diagnostics) {
+	// keep an unset (or empty) attribute as is instead of reading "" back as [""]
+	if remote == "" && (current.IsNull() || len(current.Elements()) == 0) {
+		return current, nil
+	}
+	return types.ListValueFrom(ctx, types.StringType, strings.Split(remote, " "))
 }
 
 func (o *organizationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -179,16 +189,14 @@ func (o *organizationResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state organizationResourceModel
+	var plan, prior, state organizationResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Create CIDR slice from AllowedApiIpAddresses
-	cidrs := createCidrSliceFromList(plan.AllowedApiIpAddresses)
 
 	org, err := o.client.GetOrganizationID()
 	if err != nil {
@@ -199,13 +207,7 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	log.Printf("Updating settings for organization %s ...", *org)
-	apiResponse, err := setApiIpAddresses(
-		ctx,
-		o.client.genqlient,
-		*org,
-		strings.Join(cidrs, " "),
-	)
-	if err != nil {
+	if err := o.updateAllowedApiIpAddresses(ctx, *org, plan.AllowedApiIpAddresses, prior.AllowedApiIpAddresses); err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Organization settings",
 			fmt.Sprintf("Unable to update Organization settings: %s", err.Error()),
@@ -213,15 +215,8 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if !plan.Enforce2FA.IsNull() && !plan.Enforce2FA.IsUnknown() {
-		org, err := o.client.GetOrganizationID()
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to find organization",
-				fmt.Sprintf("Unable to find Organization: %s", err.Error()),
-			)
-			return
-		}
+	state.Enforce2FA = prior.Enforce2FA
+	if !plan.Enforce2FA.IsNull() && !plan.Enforce2FA.IsUnknown() && !plan.Enforce2FA.Equal(prior.Enforce2FA) {
 		twoFAResponse, err := setOrganization2FA(ctx, o.client.genqlient, *org, plan.Enforce2FA.ValueBool())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to set 2FA", err.Error())
@@ -230,14 +225,22 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 		state.Enforce2FA = types.BoolValue(twoFAResponse.OrganizationEnforceTwoFactorAuthenticationForMembersUpdate.Organization.MembersRequireTwoFactorAuthentication)
 	}
 
-	state.ID = types.StringValue(apiResponse.OrganizationApiIpAllowlistUpdate.Organization.Id)
-	state.UUID = types.StringValue(apiResponse.OrganizationApiIpAllowlistUpdate.Organization.Uuid)
+	state.ID = types.StringValue(*org)
+	state.UUID = prior.UUID
 	state.AllowedApiIpAddresses = plan.AllowedApiIpAddresses
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state organizationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	org, err := o.client.GetOrganizationID()
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -247,8 +250,7 @@ func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 	log.Printf("Deleting settings for organization %s ...", *org)
-	_, err = setApiIpAddresses(ctx, o.client.genqlient, *org, "")
-	if err != nil {
+	if err := o.updateAllowedApiIpAddresses(ctx, *org, types.ListNull(types.StringType), state.AllowedApiIpAddresses); err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Organization settings",
 			fmt.Sprintf("Unable to delete Organization settings: %s", err.Error()),
@@ -257,4 +259,15 @@ func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	resp.Diagnostics.AddAttributeWarning(path.Root("enforce_2fa"), "Enforce 2FA setting left intact", "Use the web UI if you wish to change the value")
+}
+
+// updateAllowedApiIpAddresses sets the API IP allowlist, skipping the mutation when it is unchanged
+func (o *organizationResource) updateAllowedApiIpAddresses(ctx context.Context, orgID string, planned, current types.List) error {
+	// the mutation is rejected for organizations without the allowlist feature, even for ""
+	if planned.Equal(current) {
+		return nil
+	}
+	cidrs := createCidrSliceFromList(planned)
+	_, err := setApiIpAddresses(ctx, o.client.genqlient, orgID, strings.Join(cidrs, " "))
+	return err
 }

--- a/buildkite/resource_organization.go
+++ b/buildkite/resource_organization.go
@@ -269,11 +269,16 @@ func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRe
 
 // updateAllowedApiIpAddresses sets the API IP allowlist, skipping the mutation when it is unchanged
 func (o *organizationResource) updateAllowedApiIpAddresses(ctx context.Context, orgID string, planned, current types.List) error {
+	plannedValue := allowedApiIpAddressesValue(planned)
 	// the mutation is rejected for organizations without the allowlist feature, even for ""
-	if planned.Equal(current) {
+	if plannedValue == allowedApiIpAddressesValue(current) {
 		return nil
 	}
-	cidrs := createCidrSliceFromList(planned)
-	_, err := setApiIpAddresses(ctx, o.client.genqlient, orgID, strings.Join(cidrs, " "))
+	_, err := setApiIpAddresses(ctx, o.client.genqlient, orgID, plannedValue)
 	return err
+}
+
+// allowedApiIpAddressesValue serializes the attribute for the API, where null, [] and [""] are all ""
+func allowedApiIpAddressesValue(cidrs types.List) string {
+	return strings.Join(createCidrSliceFromList(cidrs), " ")
 }

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -53,6 +53,49 @@ func TestAllowedApiIpAddressesFromAPI(t *testing.T) {
 	}
 }
 
+func TestAllowedApiIpAddressesValue(t *testing.T) {
+	t.Parallel()
+
+	list := func(cidrs ...string) types.List {
+		values := make([]attr.Value, len(cidrs))
+		for i, c := range cidrs {
+			values[i] = types.StringValue(c)
+		}
+		return types.ListValueMust(types.StringType, values)
+	}
+	null := types.ListNull(types.StringType)
+
+	// pairs that serialize to the same value must not trigger the mutation
+	testCases := []struct {
+		name    string
+		planned types.List
+		current types.List
+		changed bool
+		value   string
+	}{
+		{"null and null", null, null, false, ""},
+		{"null and empty list", null, list(), false, ""},
+		{"null and empty string", null, list(""), false, ""},
+		{"empty list and empty string", list(), list(""), false, ""},
+		{"same list", list("1.1.1.1/32"), list("1.1.1.1/32"), false, "1.1.1.1/32"},
+		{"different list", list("1.1.1.1/32"), list("0.0.0.0/0"), true, "1.1.1.1/32"},
+		{"set from nothing", list("0.0.0.0/0", "1.1.1.1/32"), null, true, "0.0.0.0/0 1.1.1.1/32"},
+		{"cleared", null, list("1.1.1.1/32"), true, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			planned, current := allowedApiIpAddressesValue(tc.planned), allowedApiIpAddressesValue(tc.current)
+			if (planned != current) != tc.changed {
+				t.Errorf("planned %q vs current %q: changed = %t, want %t", planned, current, planned != current, tc.changed)
+			}
+			if planned != tc.value {
+				t.Errorf("planned value = %q, want %q", planned, tc.value)
+			}
+		})
+	}
+}
+
 func TestAccBuildkiteOrganizationResource(t *testing.T) {
 	config := func(ip_addresses []string) string {
 		config := `

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -7,9 +7,49 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+func TestAllowedApiIpAddressesFromAPI(t *testing.T) {
+	t.Parallel()
+
+	list := func(cidrs ...string) types.List {
+		values := make([]attr.Value, len(cidrs))
+		for i, c := range cidrs {
+			values[i] = types.StringValue(c)
+		}
+		return types.ListValueMust(types.StringType, values)
+	}
+	null := types.ListNull(types.StringType)
+
+	testCases := []struct {
+		name    string
+		remote  string
+		current types.List
+		want    types.List
+	}{
+		{"unset attribute stays null for an empty allowlist", "", null, null},
+		{"empty list is kept as is", "", list(), list()},
+		{"explicit empty string round trips", "", list(""), list("")},
+		{"remote allowlist is split", "1.1.1.1/32 0.0.0.0/0", list("1.1.1.1/32"), list("1.1.1.1/32", "0.0.0.0/0")},
+		{"remote allowlist is read when unset", "1.1.1.1/32", null, list("1.1.1.1/32")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, diags := allowedApiIpAddressesFromAPI(context.Background(), tc.remote, tc.current)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestAccBuildkiteOrganizationResource(t *testing.T) {
 	config := func(ip_addresses []string) string {
@@ -168,8 +208,28 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 				{
 					Config: configNoAllowedIPs(),
 					Check:  checkUpdated,
-					// After clearing the IPs, state will be set to null and refresh will restore the attribute to an empty-string list of length 1
-					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
+
+	t.Run("manages an organization without configuring the allowed API IP address list", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testCheckOrganizationResourceRemoved,
+			Steps: []resource.TestStep{
+				{
+					Config: configNoAllowedIPs(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("buildkite_organization.let_them_in", "uuid"),
+						resource.TestCheckNoResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses"),
+					),
+				},
+				{
+					ResourceName:      "buildkite_organization.let_them_in",
+					ImportState:       true,
+					ImportStateVerify: true,
 				},
 			},
 		})

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -35,6 +36,7 @@ func TestAllowedApiIpAddressesFromAPI(t *testing.T) {
 		{"empty list is kept as is", "", list(), list()},
 		{"explicit empty string round trips", "", list(""), list("")},
 		{"remote allowlist is split", "1.1.1.1/32 0.0.0.0/0", list("1.1.1.1/32"), list("1.1.1.1/32", "0.0.0.0/0")},
+		{"matching allowlist is unchanged", "0.0.0.0/0 1.1.1.1/32", list("0.0.0.0/0", "1.1.1.1/32"), list("0.0.0.0/0", "1.1.1.1/32")},
 		{"remote allowlist is read when unset", "1.1.1.1/32", null, list("1.1.1.1/32")},
 	}
 
@@ -230,6 +232,52 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 					ResourceName:      "buildkite_organization.let_them_in",
 					ImportState:       true,
 					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("adopts an existing allowed API IP address list", func(t *testing.T) {
+		// Give the organization an allowlist before terraform manages it (0.0.0.0/0 keeps the API reachable)
+		presetAllowlist := func() {
+			org, err := getOrganization(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG"))
+			if err != nil {
+				t.Fatalf("Unable to read organization: %v", err)
+			}
+			if _, err := setApiIpAddresses(context.Background(), genqlientGraphql, org.Organization.Id, "0.0.0.0/0"); err != nil {
+				t.Fatalf("Unable to preset the allowed API IP addresses: %v", err)
+			}
+			if _, err := getOrganization(context.Background(), genqlientGraphql, getenv("BUILDKITE_ORGANIZATION_SLUG")); err != nil {
+				t.Fatalf("API unreachable after presetting the allowed API IP addresses: %v", err)
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testCheckOrganizationResourceRemoved,
+			Steps: []resource.TestStep{
+				{
+					PreConfig: presetAllowlist,
+					Config:    config([]string{"0.0.0.0/0"}),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						// Confirm the existing allowlist is kept in Buildkite's system
+						testAccCheckOrganizationRemoteValues([]string{"0.0.0.0/0"}),
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses.0", "0.0.0.0/0"),
+					),
+				},
+				{
+					Config: configNoAllowedIPs(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						// Confirm the allowlist is cleared once the attribute is removed
+						testAccCheckOrganizationRemoteValues([]string{""}),
+						resource.TestCheckNoResourceAttr("buildkite_organization.let_them_in", "allowed_api_ip_addresses"),
+					),
 				},
 			},
 		})


### PR DESCRIPTION
`buildkite_organization` can't be created on an organization whose plan lacks the API IP allowlist: even an empty `resource "buildkite_organization" "settings" {}` fails with "The API IP allowlist feature is not available for your organization", because Create/Update/Delete always send `organizationApiIpAllowlistUpdate` (with `""` when the attribute is unset). The 2FA mutation is likewise sent on every apply, and Read turned an empty allowlist into `[""]`, so an unset attribute showed a perpetual diff.

Both mutations are now only sent when the value differs from state, `id`/`uuid` come from `getOrganization`, and an empty allowlist stays null when the attribute isn't configured. Dropped `ExpectNonEmptyPlan` from the "removing the allowed API IP address list" step since the plan is now empty, added a subtest without the allowlist attribute plus a table test for the read mapping, and ran the full `TestAccBuildkiteOrganizationResource` locally against a test organization.

## PR checklist:
- [ ] `docs/` updated <-- no schema change
- [x] tests added
- [ ] an example added to `examples/` <-- no new field
- [ ] `CHANGELOG.md` updated with pending release information <-- left for the release process
