### PR TITLE
Add more GitHub trigger settings to pipeline provider_settings

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -3181,6 +3181,12 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseS
 	BuildDeploymentStatusCreated *bool `json:"buildDeploymentStatusCreated"`
 	// Whether to create builds when a pull request is converted to draft.
 	BuildPullRequestConvertedToDraft *bool `json:"buildPullRequestConvertedToDraft"`
+	// Whether to create builds when a pull request is removed from a merge queue.
+	BuildPullRequestDequeued *bool `json:"buildPullRequestDequeued"`
+	// Whether to create builds when a pull request is reopened.
+	BuildPullRequestReopened *bool `json:"buildPullRequestReopened"`
+	// Whether to create builds when an inline review comment is created on a pull request.
+	BuildPullRequestReviewCommentCreated *bool `json:"buildPullRequestReviewCommentCreated"`
 	// Whether to create builds when a pull request review is requested.
 	BuildPullRequestReviewRequested *bool `json:"buildPullRequestReviewRequested"`
 	// Whether to create builds when a pull request review is dismissed.
@@ -3237,6 +3243,10 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseS
 	PullRequestBranchFilterConfiguration *string `json:"pullRequestBranchFilterConfiguration"`
 	// Whether to limit the creation of builds to specific branches or patterns.
 	PullRequestBranchFilterEnabled *bool `json:"pullRequestBranchFilterEnabled"`
+	// The command word used to trigger builds from inline PR review comments (e.g. "/bk"). Only comments containing this word will trigger builds.
+	ReviewCommentCommandWord *string `json:"reviewCommentCommandWord"`
+	// The match mode for review comment command words.
+	ReviewCommentMatchMode *CommandWordMatchMode `json:"reviewCommentMatchMode"`
 	// Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your required status checks in GitHub.
 	SeparatePullRequestStatuses *bool `json:"separatePullRequestStatuses"`
 	// Whether to skip creating a new build if a build for the commit and branch already exists.
@@ -3274,6 +3284,21 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpr
 // GetBuildPullRequestConvertedToDraft returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestConvertedToDraft, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestConvertedToDraft() *bool {
 	return v.BuildPullRequestConvertedToDraft
+}
+
+// GetBuildPullRequestDequeued returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestDequeued, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestDequeued() *bool {
+	return v.BuildPullRequestDequeued
+}
+
+// GetBuildPullRequestReopened returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestReopened, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestReopened() *bool {
+	return v.BuildPullRequestReopened
+}
+
+// GetBuildPullRequestReviewCommentCreated returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestReviewCommentCreated, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildPullRequestReviewCommentCreated() *bool {
+	return v.BuildPullRequestReviewCommentCreated
 }
 
 // GetBuildPullRequestReviewRequested returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildPullRequestReviewRequested, and is useful for accessing the field via an interface.
@@ -3416,6 +3441,16 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpr
 	return v.PullRequestBranchFilterEnabled
 }
 
+// GetReviewCommentCommandWord returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.ReviewCommentCommandWord, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetReviewCommentCommandWord() *string {
+	return v.ReviewCommentCommandWord
+}
+
+// GetReviewCommentMatchMode returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.ReviewCommentMatchMode, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetReviewCommentMatchMode() *CommandWordMatchMode {
+	return v.ReviewCommentMatchMode
+}
+
 // GetSeparatePullRequestStatuses returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.SeparatePullRequestStatuses, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetSeparatePullRequestStatuses() *bool {
 	return v.SeparatePullRequestStatuses
@@ -3461,6 +3496,12 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRep
 	BuildDeploymentStatusCreated *bool `json:"buildDeploymentStatusCreated"`
 	// Whether to create builds when a pull request is converted to draft.
 	BuildPullRequestConvertedToDraft *bool `json:"buildPullRequestConvertedToDraft"`
+	// Whether to create builds when a pull request is removed from a merge queue.
+	BuildPullRequestDequeued *bool `json:"buildPullRequestDequeued"`
+	// Whether to create builds when a pull request is reopened.
+	BuildPullRequestReopened *bool `json:"buildPullRequestReopened"`
+	// Whether to create builds when an inline review comment is created on a pull request.
+	BuildPullRequestReviewCommentCreated *bool `json:"buildPullRequestReviewCommentCreated"`
 	// Whether to create builds when a pull request review is requested.
 	BuildPullRequestReviewRequested *bool `json:"buildPullRequestReviewRequested"`
 	// Whether to create builds when a pull request review is dismissed.
@@ -3517,6 +3558,10 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRep
 	PullRequestBranchFilterConfiguration *string `json:"pullRequestBranchFilterConfiguration"`
 	// Whether to limit the creation of builds to specific branches or patterns.
 	PullRequestBranchFilterEnabled *bool `json:"pullRequestBranchFilterEnabled"`
+	// The command word used to trigger builds from inline PR review comments (e.g. "/bk"). Only comments containing this word will trigger builds.
+	ReviewCommentCommandWord *string `json:"reviewCommentCommandWord"`
+	// The match mode for review comment command words.
+	ReviewCommentMatchMode *CommandWordMatchMode `json:"reviewCommentMatchMode"`
 	// Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your required status checks in GitHub.
 	SeparatePullRequestStatuses *bool `json:"separatePullRequestStatuses"`
 	// Whether to skip creating a new build if a build for the commit and branch already exists.
@@ -3554,6 +3599,21 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSetting
 // GetBuildPullRequestConvertedToDraft returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestConvertedToDraft, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestConvertedToDraft() *bool {
 	return v.BuildPullRequestConvertedToDraft
+}
+
+// GetBuildPullRequestDequeued returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestDequeued, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestDequeued() *bool {
+	return v.BuildPullRequestDequeued
+}
+
+// GetBuildPullRequestReopened returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestReopened, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestReopened() *bool {
+	return v.BuildPullRequestReopened
+}
+
+// GetBuildPullRequestReviewCommentCreated returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestReviewCommentCreated, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildPullRequestReviewCommentCreated() *bool {
+	return v.BuildPullRequestReviewCommentCreated
 }
 
 // GetBuildPullRequestReviewRequested returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildPullRequestReviewRequested, and is useful for accessing the field via an interface.
@@ -3694,6 +3754,16 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSetting
 // GetPullRequestBranchFilterEnabled returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.PullRequestBranchFilterEnabled, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetPullRequestBranchFilterEnabled() *bool {
 	return v.PullRequestBranchFilterEnabled
+}
+
+// GetReviewCommentCommandWord returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.ReviewCommentCommandWord, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetReviewCommentCommandWord() *string {
+	return v.ReviewCommentCommandWord
+}
+
+// GetReviewCommentMatchMode returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.ReviewCommentMatchMode, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetReviewCommentMatchMode() *CommandWordMatchMode {
+	return v.ReviewCommentMatchMode
 }
 
 // GetSeparatePullRequestStatuses returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.SeparatePullRequestStatuses, and is useful for accessing the field via an interface.
@@ -26185,6 +26255,9 @@ fragment RepositoryProviderSettingsFields on Repository {
 				buildCreateEvent
 				buildDeploymentStatusCreated
 				buildPullRequestConvertedToDraft
+				buildPullRequestDequeued
+				buildPullRequestReopened
+				buildPullRequestReviewCommentCreated
 				buildPullRequestReviewRequested
 				buildPullRequestReviewDismissed
 				buildPullRequestReviewSubmitted
@@ -26213,6 +26286,8 @@ fragment RepositoryProviderSettingsFields on Repository {
 				publishCommitStatusPerStep
 				pullRequestBranchFilterConfiguration
 				pullRequestBranchFilterEnabled
+				reviewCommentCommandWord
+				reviewCommentMatchMode
 				separatePullRequestStatuses
 				skipBuildsForExistingCommits
 				skipPullRequestBuildsForExistingCommits
@@ -26228,6 +26303,9 @@ fragment RepositoryProviderSettingsFields on Repository {
 				buildCreateEvent
 				buildDeploymentStatusCreated
 				buildPullRequestConvertedToDraft
+				buildPullRequestDequeued
+				buildPullRequestReopened
+				buildPullRequestReviewCommentCreated
 				buildPullRequestReviewRequested
 				buildPullRequestReviewDismissed
 				buildPullRequestReviewSubmitted
@@ -26256,6 +26334,8 @@ fragment RepositoryProviderSettingsFields on Repository {
 				publishCommitStatusPerStep
 				pullRequestBranchFilterConfiguration
 				pullRequestBranchFilterEnabled
+				reviewCommentCommandWord
+				reviewCommentMatchMode
 				separatePullRequestStatuses
 				skipBuildsForExistingCommits
 				skipPullRequestBuildsForExistingCommits

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -70,6 +70,12 @@ fragment RepositoryProviderSettingsFields on Repository {
                 # @genqlient(pointer: true)
                 buildPullRequestConvertedToDraft
                 # @genqlient(pointer: true)
+                buildPullRequestDequeued
+                # @genqlient(pointer: true)
+                buildPullRequestReopened
+                # @genqlient(pointer: true)
+                buildPullRequestReviewCommentCreated
+                # @genqlient(pointer: true)
                 buildPullRequestReviewRequested
                 # @genqlient(pointer: true)
                 buildPullRequestReviewDismissed
@@ -125,6 +131,10 @@ fragment RepositoryProviderSettingsFields on Repository {
                 pullRequestBranchFilterConfiguration
                 # @genqlient(pointer: true)
                 pullRequestBranchFilterEnabled
+                # @genqlient(pointer: true)
+                reviewCommentCommandWord
+                # @genqlient(pointer: true)
+                reviewCommentMatchMode
                 # @genqlient(pointer: true)
                 separatePullRequestStatuses
                 # @genqlient(pointer: true)
@@ -152,6 +162,12 @@ fragment RepositoryProviderSettingsFields on Repository {
                 # @genqlient(pointer: true)
                 buildPullRequestConvertedToDraft
                 # @genqlient(pointer: true)
+                buildPullRequestDequeued
+                # @genqlient(pointer: true)
+                buildPullRequestReopened
+                # @genqlient(pointer: true)
+                buildPullRequestReviewCommentCreated
+                # @genqlient(pointer: true)
                 buildPullRequestReviewRequested
                 # @genqlient(pointer: true)
                 buildPullRequestReviewDismissed
@@ -207,6 +223,10 @@ fragment RepositoryProviderSettingsFields on Repository {
                 pullRequestBranchFilterConfiguration
                 # @genqlient(pointer: true)
                 pullRequestBranchFilterEnabled
+                # @genqlient(pointer: true)
+                reviewCommentCommandWord
+                # @genqlient(pointer: true)
+                reviewCommentMatchMode
                 # @genqlient(pointer: true)
                 separatePullRequestStatuses
                 # @genqlient(pointer: true)

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1079,7 +1079,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					"build_pull_request_review_comment_created": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds when an inline review comment is created on a pull request.",
+						MarkdownDescription: "Whether to create builds when an inline review comment is created on a pull request. Requires `build_pull_requests` to be enabled.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
@@ -1106,7 +1106,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					"build_pull_request_dequeued": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds when a pull request is removed from a merge queue.",
+						MarkdownDescription: "Whether to create builds when a pull request is removed from a merge queue. Requires `build_pull_requests` to be enabled.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
@@ -1114,7 +1114,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					"build_pull_request_reopened": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
-						MarkdownDescription: "Whether to create builds when a pull request is reopened.",
+						MarkdownDescription: "Whether to create builds when a pull request is reopened. Requires `build_pull_requests` to be enabled.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -135,6 +135,11 @@ type providerSettingsModel struct {
 	BuildIssueCommentCreated                types.Bool   `tfsdk:"build_issue_comment_created"`
 	IssueCommentCommandWord                 types.String `tfsdk:"issue_comment_command_word"`
 	IssueCommentMatchMode                   types.String `tfsdk:"issue_comment_match_mode"`
+	BuildPullRequestReviewCommentCreated    types.Bool   `tfsdk:"build_pull_request_review_comment_created"`
+	ReviewCommentCommandWord                types.String `tfsdk:"review_comment_command_word"`
+	ReviewCommentMatchMode                  types.String `tfsdk:"review_comment_match_mode"`
+	BuildPullRequestDequeued                types.Bool   `tfsdk:"build_pull_request_dequeued"`
+	BuildPullRequestReopened                types.Bool   `tfsdk:"build_pull_request_reopened"`
 	BuildCheckRunCompleted                  types.Bool   `tfsdk:"build_check_run_completed"`
 	BuildCreateEvent                        types.Bool   `tfsdk:"build_create_event"`
 	BuildDeploymentStatusCreated            types.Bool   `tfsdk:"build_deployment_status_created"`
@@ -1071,6 +1076,49 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							stringvalidator.OneOf("exact", "contains"),
 						},
 					},
+					"build_pull_request_review_comment_created": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create builds when an inline review comment is created on a pull request.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"review_comment_command_word": schema.StringAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "The command word used to trigger builds from inline pull request review comments (e.g. \"/bk\"). Only review comments starting with or containing this word will trigger builds.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"review_comment_match_mode": schema.StringAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "The match mode for the review comment command word. Valid values are \"exact\" and \"contains\".",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseNonNullStateForUnknown(),
+						},
+						Validators: []validator.String{
+							stringvalidator.OneOf("exact", "contains"),
+						},
+					},
+					"build_pull_request_dequeued": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create builds when a pull request is removed from a merge queue.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
+					"build_pull_request_reopened": schema.BoolAttribute{
+						Computed:            true,
+						Optional:            true,
+						MarkdownDescription: "Whether to create builds when a pull request is reopened.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
 					"build_check_run_completed": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
@@ -1532,6 +1580,11 @@ type PipelineExtraSettings struct {
 	BuildIssueCommentCreated                *bool   `json:"build_issue_comment_created,omitempty"`
 	IssueCommentCommandWord                 *string `json:"issue_comment_command_word,omitempty"`
 	IssueCommentMatchMode                   *string `json:"issue_comment_match_mode,omitempty"`
+	BuildPullRequestReviewCommentCreated    *bool   `json:"build_pull_request_review_comment_created,omitempty"`
+	ReviewCommentCommandWord                *string `json:"review_comment_command_word,omitempty"`
+	ReviewCommentMatchMode                  *string `json:"review_comment_match_mode,omitempty"`
+	BuildPullRequestDequeued                *bool   `json:"build_pull_request_dequeued,omitempty"`
+	BuildPullRequestReopened                *bool   `json:"build_pull_request_reopened,omitempty"`
 	BuildCheckRunCompleted                  *bool   `json:"build_check_run_completed,omitempty"`
 	BuildCreateEvent                        *bool   `json:"build_create_event,omitempty"`
 	BuildDeploymentStatusCreated            *bool   `json:"build_deployment_status_created,omitempty"`
@@ -1595,6 +1648,11 @@ func updatePipelineExtraInfo(ctx context.Context, slug string, settings *provide
 			BuildIssueCommentCreated:                settings.BuildIssueCommentCreated.ValueBoolPointer(),
 			IssueCommentCommandWord:                 settings.IssueCommentCommandWord.ValueStringPointer(),
 			IssueCommentMatchMode:                   settings.IssueCommentMatchMode.ValueStringPointer(),
+			BuildPullRequestReviewCommentCreated:    settings.BuildPullRequestReviewCommentCreated.ValueBoolPointer(),
+			ReviewCommentCommandWord:                settings.ReviewCommentCommandWord.ValueStringPointer(),
+			ReviewCommentMatchMode:                  settings.ReviewCommentMatchMode.ValueStringPointer(),
+			BuildPullRequestDequeued:                settings.BuildPullRequestDequeued.ValueBoolPointer(),
+			BuildPullRequestReopened:                settings.BuildPullRequestReopened.ValueBoolPointer(),
 			BuildCheckRunCompleted:                  settings.BuildCheckRunCompleted.ValueBoolPointer(),
 			BuildCreateEvent:                        settings.BuildCreateEvent.ValueBoolPointer(),
 			BuildDeploymentStatusCreated:            settings.BuildDeploymentStatusCreated.ValueBoolPointer(),
@@ -1663,6 +1721,11 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
 		IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
 		IssueCommentMatchMode:                   types.StringPointerValue(s.IssueCommentMatchMode),
+		BuildPullRequestReviewCommentCreated:    types.BoolPointerValue(s.BuildPullRequestReviewCommentCreated),
+		ReviewCommentCommandWord:                types.StringPointerValue(s.ReviewCommentCommandWord),
+		ReviewCommentMatchMode:                  types.StringPointerValue(s.ReviewCommentMatchMode),
+		BuildPullRequestDequeued:                types.BoolPointerValue(s.BuildPullRequestDequeued),
+		BuildPullRequestReopened:                types.BoolPointerValue(s.BuildPullRequestReopened),
 		BuildCheckRunCompleted:                  types.BoolPointerValue(s.BuildCheckRunCompleted),
 		BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
 		BuildDeploymentStatusCreated:            types.BoolPointerValue(s.BuildDeploymentStatusCreated),
@@ -1723,6 +1786,11 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
 			IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
 			IssueCommentMatchMode:                   matchModeToString(s.IssueCommentMatchMode),
+			BuildPullRequestReviewCommentCreated:    types.BoolPointerValue(s.BuildPullRequestReviewCommentCreated),
+			ReviewCommentCommandWord:                types.StringPointerValue(s.ReviewCommentCommandWord),
+			ReviewCommentMatchMode:                  matchModeToString(s.ReviewCommentMatchMode),
+			BuildPullRequestDequeued:                types.BoolPointerValue(s.BuildPullRequestDequeued),
+			BuildPullRequestReopened:                types.BoolPointerValue(s.BuildPullRequestReopened),
 			UseStepKeyAsCommitStatus:                types.BoolPointerValue(s.UseStepKeyAsCommitStatus),
 			BuildCheckRunCompleted:                  types.BoolPointerValue(s.BuildCheckRunCompleted),
 			BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
@@ -1766,6 +1834,11 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 			BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
 			IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
 			IssueCommentMatchMode:                   matchModeToString(s.IssueCommentMatchMode),
+			BuildPullRequestReviewCommentCreated:    types.BoolPointerValue(s.BuildPullRequestReviewCommentCreated),
+			ReviewCommentCommandWord:                types.StringPointerValue(s.ReviewCommentCommandWord),
+			ReviewCommentMatchMode:                  matchModeToString(s.ReviewCommentMatchMode),
+			BuildPullRequestDequeued:                types.BoolPointerValue(s.BuildPullRequestDequeued),
+			BuildPullRequestReopened:                types.BoolPointerValue(s.BuildPullRequestReopened),
 			UseStepKeyAsCommitStatus:                types.BoolPointerValue(s.UseStepKeyAsCommitStatus),
 			BuildCheckRunCompleted:                  types.BoolPointerValue(s.BuildCheckRunCompleted),
 			BuildCreateEvent:                        types.BoolPointerValue(s.BuildCreateEvent),
@@ -2129,6 +2202,26 @@ func pipelineSchemaV0() schema.Schema {
 							Optional: true,
 						},
 						"issue_comment_match_mode": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_review_comment_created": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"review_comment_command_word": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"review_comment_match_mode": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_dequeued": schema.BoolAttribute{
+							Computed: true,
+							Optional: true,
+						},
+						"build_pull_request_reopened": schema.BoolAttribute{
 							Computed: true,
 							Optional: true,
 						},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -114,13 +114,15 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	repo := RepositoryProviderSettingsFields{
 		Provider: &RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub{
 			Settings: RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings{
-				TriggerMode:              &triggerMode,
-				BuildPullRequests:        &enabled,
-				BuildBranches:            &disabled,
-				IssueCommentMatchMode:    &matchMode,
-				ReviewCommentMatchMode:   &matchMode,
-				BuildPullRequestReopened: &enabled,
-				UseStepKeyAsCommitStatus: &enabled,
+				TriggerMode:                          &triggerMode,
+				BuildPullRequests:                    &enabled,
+				BuildBranches:                        &disabled,
+				IssueCommentMatchMode:                &matchMode,
+				BuildPullRequestReviewCommentCreated: &enabled,
+				ReviewCommentMatchMode:               &matchMode,
+				BuildPullRequestDequeued:             &enabled,
+				BuildPullRequestReopened:             &enabled,
+				UseStepKeyAsCommitStatus:             &enabled,
 			},
 		},
 	}
@@ -144,6 +146,12 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	}
 	if got.ReviewCommentMatchMode.ValueString() != "exact" {
 		t.Fatalf("review_comment_match_mode: expected \"exact\", got %q", got.ReviewCommentMatchMode.ValueString())
+	}
+	if !got.BuildPullRequestReviewCommentCreated.ValueBool() {
+		t.Fatal("build_pull_request_review_comment_created: expected true")
+	}
+	if !got.BuildPullRequestDequeued.ValueBool() {
+		t.Fatal("build_pull_request_dequeued: expected true")
 	}
 	if !got.BuildPullRequestReopened.ValueBool() {
 		t.Fatal("build_pull_request_reopened: expected true")
@@ -874,9 +882,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "exact"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_command_word", "ci-review-rerun"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_match_mode", "contains"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_dequeued", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_reopened", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.use_step_key_as_commit_status", "true"),
 					),
 				},

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -118,6 +118,8 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 				BuildPullRequests:        &enabled,
 				BuildBranches:            &disabled,
 				IssueCommentMatchMode:    &matchMode,
+				ReviewCommentMatchMode:   &matchMode,
+				BuildPullRequestReopened: &enabled,
 				UseStepKeyAsCommitStatus: &enabled,
 			},
 		},
@@ -139,6 +141,12 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	// CommandWordMatchMode enum (EXACT) must be lowercased to match the schema validator.
 	if got.IssueCommentMatchMode.ValueString() != "exact" {
 		t.Fatalf("issue_comment_match_mode: expected \"exact\", got %q", got.IssueCommentMatchMode.ValueString())
+	}
+	if got.ReviewCommentMatchMode.ValueString() != "exact" {
+		t.Fatalf("review_comment_match_mode: expected \"exact\", got %q", got.ReviewCommentMatchMode.ValueString())
+	}
+	if !got.BuildPullRequestReopened.ValueBool() {
+		t.Fatal("build_pull_request_reopened: expected true")
 	}
 	// use_step_key_as_commit_status is now exposed via GraphQL and mapped directly.
 	if !got.UseStepKeyAsCommitStatus.ValueBool() {
@@ -772,6 +780,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					build_issue_comment_created = true
 					issue_comment_command_word = "ci-force-rerun"
 					issue_comment_match_mode = "exact"
+					build_pull_request_review_comment_created = true
+					review_comment_command_word = "ci-review-rerun"
+					review_comment_match_mode = "contains"
+					build_pull_request_dequeued = true
+					build_pull_request_reopened = true
 					build_check_run_completed = true
 					build_create_event = true
 					build_deployment_status_created = true
@@ -830,6 +843,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "exact"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_comment_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_command_word", "ci-review-rerun"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_match_mode", "contains"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_dequeued", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_reopened", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_check_run_completed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),
@@ -856,6 +874,9 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "exact"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_command_word", "ci-review-rerun"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_match_mode", "contains"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_dequeued", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.use_step_key_as_commit_status", "true"),
 					),
 				},
@@ -942,6 +963,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 								build_issue_comment_created = true
 								issue_comment_command_word = "/deploy"
 								issue_comment_match_mode = "contains"
+								build_pull_request_review_comment_created = true
+								review_comment_command_word = "/review"
+								review_comment_match_mode = "exact"
+								build_pull_request_dequeued = true
+								build_pull_request_reopened = true
 								build_check_run_completed = true
 								build_create_event = true
 								build_deployment_status_created = true
@@ -977,6 +1003,11 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "/deploy"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode", "contains"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_review_comment_created", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_command_word", "/review"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_match_mode", "exact"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_dequeued", "true"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_reopened", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_check_run_completed", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_create_event", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_deployment_status_created", "true"),

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -218,13 +218,13 @@ Optional:
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.
-- `build_pull_request_dequeued` (Boolean) Whether to create builds when a pull request is removed from a merge queue.
+- `build_pull_request_dequeued` (Boolean) Whether to create builds when a pull request is removed from a merge queue. Requires `build_pull_requests` to be enabled.
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_merge_commits` (Boolean) Whether to build the test merge commit (the merged result of a pull request with its base branch).
 - `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review".
-- `build_pull_request_reopened` (Boolean) Whether to create builds when a pull request is reopened.
-- `build_pull_request_review_comment_created` (Boolean) Whether to create builds when an inline review comment is created on a pull request.
+- `build_pull_request_reopened` (Boolean) Whether to create builds when a pull request is reopened. Requires `build_pull_requests` to be enabled.
+- `build_pull_request_review_comment_created` (Boolean) Whether to create builds when an inline review comment is created on a pull request. Requires `build_pull_requests` to be enabled.
 - `build_pull_request_review_dismissed` (Boolean) Whether to create a build when a pull request review is dismissed.
 - `build_pull_request_review_requested` (Boolean) Whether to create a build when a review is requested on a pull request.
 - `build_pull_request_review_submitted` (Boolean) Whether to create a build when a pull request review is submitted.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -218,10 +218,13 @@ Optional:
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.
+- `build_pull_request_dequeued` (Boolean) Whether to create builds when a pull request is removed from a merge queue.
 - `build_pull_request_forks` (Boolean) Whether to create builds for pull requests from third-party forks.
 - `build_pull_request_labels_changed` (Boolean) Whether to create builds for pull requests when labels are added or removed.
 - `build_pull_request_merge_commits` (Boolean) Whether to build the test merge commit (the merged result of a pull request with its base branch).
 - `build_pull_request_ready_for_review` (Boolean) Whether to create a build when a pull request changes to "Ready for review".
+- `build_pull_request_reopened` (Boolean) Whether to create builds when a pull request is reopened.
+- `build_pull_request_review_comment_created` (Boolean) Whether to create builds when an inline review comment is created on a pull request.
 - `build_pull_request_review_dismissed` (Boolean) Whether to create a build when a pull request review is dismissed.
 - `build_pull_request_review_requested` (Boolean) Whether to create a build when a review is requested on a pull request.
 - `build_pull_request_review_submitted` (Boolean) Whether to create a build when a pull request review is submitted.
@@ -243,6 +246,8 @@ Optional:
 - `publish_commit_status_per_step` (Boolean) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.
 - `pull_request_branch_filter_configuration` (String) Filter pull requests builds by the branch filter.
 - `pull_request_branch_filter_enabled` (Boolean) Filter pull request builds.
+- `review_comment_command_word` (String) The command word used to trigger builds from inline pull request review comments (e.g. "/bk"). Only review comments starting with or containing this word will trigger builds.
+- `review_comment_match_mode` (String) The match mode for the review comment command word. Valid values are "exact" and "contains".
 - `separate_pull_request_statuses` (Boolean) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://help.github.com/en/articles/enabling-required-status-checks) in GitHub.
 - `skip_builds_for_existing_commits` (Boolean) Whether to skip creating a new build if an existing build for the commit and branch already exists. This option is only valid if the pipeline uses a GitHub repository.
 - `skip_pull_request_builds_for_existing_commits` (Boolean) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.


### PR DESCRIPTION
Adds the remaining GitHub / GitHub Enterprise [trigger settings](https://buildkite.com/docs/apis/rest-api/pipelines) that can be set in the UI and REST API but not yet in `provider_settings`:

- `build_pull_request_review_comment_created`
- `review_comment_command_word`
- `review_comment_match_mode` (`exact` / `contains`, like `issue_comment_match_mode`)
- `build_pull_request_dequeued`
- `build_pull_request_reopened`

They are written through the existing REST `provider_settings` PATCH and read back through the GraphQL fragment like their siblings; `generated.go` is regenerated from the vendored schema, no `schema.graphql` change. Left out: `build_pull_request_edited` (covered by #1181) and `build_pull_request_stacks` (accepted by REST but not in the vendored schema yet, so it can't be read back without a schema refresh).

Extended the "setting all attributes" acceptance subtests and `TestMapProviderSettingsFromGraphQLGitHub`, and ran create + refresh + import locally against a test organization; the update subtest starts from a pipeline without `cluster_id`, which my organization rejects, so I couldn't run that one.

## PR checklist:
- [x] `docs/` updated
- [x] tests added