### PR TITLE
Add API access token settings to buildkite_organization

### DIFF
--- a/buildkite/resource_organization.go
+++ b/buildkite/resource_organization.go
@@ -4,24 +4,30 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type organizationResourceModel struct {
-	AllowedApiIpAddresses types.List   `tfsdk:"allowed_api_ip_addresses"`
-	ID                    types.String `tfsdk:"id"`
-	UUID                  types.String `tfsdk:"uuid"`
-	Enforce2FA            types.Bool   `tfsdk:"enforce_2fa"`
+	AllowedApiIpAddresses        types.List   `tfsdk:"allowed_api_ip_addresses"`
+	ID                           types.String `tfsdk:"id"`
+	UUID                         types.String `tfsdk:"uuid"`
+	Enforce2FA                   types.Bool   `tfsdk:"enforce_2fa"`
+	RevokeInactiveTokensAfter    types.String `tfsdk:"revoke_inactive_tokens_after"`
+	RestrictUserApiTokenCreation types.Bool   `tfsdk:"restrict_user_api_token_creation"`
 }
 
 type organizationResource struct {
@@ -79,13 +85,35 @@ func (*organizationResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Sets whether the organization requires two-factor authentication for all members.",
 			},
+			"revoke_inactive_tokens_after": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "The period of inactivity after which user API access tokens are revoked. Valid values are `NEVER`, `DAYS_30`, `DAYS_60`, `DAYS_90`, `DAYS_180` and `DAYS_365`. " +
+					"If omitted, the current setting is left unchanged. Requires an API token with the `read_organization_settings` and `write_organization_settings` scopes and the inactive API token revocation feature on the organization's plan.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(revokeInactiveTokenPeriods...),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"restrict_user_api_token_creation": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "Whether only organization administrators can create new API access tokens for this organization. " +
+					"If omitted, the current setting is left unchanged. Requires an API token with the `read_organization_settings` and `write_organization_settings` scopes.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
 
 func (o *organizationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan, state organizationResourceModel
+	var config, plan, state organizationResourceModel
 
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
 	if resp.Diagnostics.HasError() {
@@ -137,6 +165,11 @@ func (o *organizationResource) Create(ctx context.Context, req resource.CreateRe
 	state.Enforce2FA = plan.Enforce2FA
 	state.AllowedApiIpAddresses = plan.AllowedApiIpAddresses
 
+	o.updateAPISettings(ctx, &config, &plan, nil, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -178,6 +211,11 @@ func (o *organizationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 	state.AllowedApiIpAddresses = ips
 
+	o.readAPISettings(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -195,8 +233,9 @@ func (o *organizationResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, prior, state organizationResourceModel
+	var config, plan, prior, state organizationResourceModel
 
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 
@@ -235,6 +274,11 @@ func (o *organizationResource) Update(ctx context.Context, req resource.UpdateRe
 	state.UUID = prior.UUID
 	state.AllowedApiIpAddresses = plan.AllowedApiIpAddresses
 
+	o.updateAPISettings(ctx, &config, &plan, &prior, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -265,6 +309,7 @@ func (o *organizationResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	resp.Diagnostics.AddAttributeWarning(path.Root("enforce_2fa"), "Enforce 2FA setting left intact", "Use the web UI if you wish to change the value")
+	resp.Diagnostics.AddWarning("API access token settings left intact", "Use the web UI if you wish to change them")
 }
 
 // updateAllowedApiIpAddresses sets the API IP allowlist, skipping the mutation when it is unchanged
@@ -281,4 +326,127 @@ func (o *organizationResource) updateAllowedApiIpAddresses(ctx context.Context, 
 // allowedApiIpAddressesValue serializes the attribute for the API, where null, [] and [""] are all ""
 func allowedApiIpAddressesValue(cidrs types.List) string {
 	return strings.Join(createCidrSliceFromList(cidrs), " ")
+}
+
+const revokeInactiveTokensNever = "NEVER"
+
+// revokeInactiveTokenPeriods mirrors the RevokeInactiveTokenPeriod GraphQL enum
+var revokeInactiveTokenPeriods = []string{revokeInactiveTokensNever, "DAYS_30", "DAYS_60", "DAYS_90", "DAYS_180", "DAYS_365"}
+
+// revokePeriodFromDays converts the REST revoke_inactive_tokens_after_days (nil = never) to a period
+func revokePeriodFromDays(days *int64) string {
+	if days == nil {
+		return revokeInactiveTokensNever
+	}
+	return fmt.Sprintf("DAYS_%d", *days)
+}
+
+// revokePeriodToDays converts a period to the REST revoke_inactive_tokens_after_days (nil = never)
+func revokePeriodToDays(period string) *int64 {
+	var days int64
+	if _, err := fmt.Sscanf(period, "DAYS_%d", &days); err != nil {
+		return nil
+	}
+	return &days
+}
+
+type organizationAPISettings struct {
+	RevokeInactiveTokensAfterDays *int64 `json:"revoke_inactive_tokens_after_days"`
+	RestrictUserApiTokenCreation  bool   `json:"restrict_user_api_token_creation"`
+	Features                      struct {
+		InactiveApiTokenRevocation bool `json:"inactive_api_token_revocation"`
+	} `json:"features"`
+}
+
+func (c *Client) getOrganizationAPISettings(ctx context.Context) (*organizationAPISettings, error) {
+	var settings organizationAPISettings
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/v2/organizations/%s/api-settings", c.organization), nil, &settings)
+	return &settings, err
+}
+
+func (c *Client) updateOrganizationAPISettings(ctx context.Context, payload map[string]any) (*organizationAPISettings, error) {
+	var settings organizationAPISettings
+	err := c.makeRequest(ctx, http.MethodPatch, fmt.Sprintf("/v2/organizations/%s/api-settings", c.organization), payload, &settings)
+	return &settings, err
+}
+
+// apiSettingsFromModel returns the api-settings recorded in state, or the API defaults
+func apiSettingsFromModel(model *organizationResourceModel) *organizationAPISettings {
+	settings := &organizationAPISettings{}
+	if model != nil {
+		settings.RevokeInactiveTokensAfterDays = revokePeriodToDays(model.RevokeInactiveTokensAfter.ValueString())
+		settings.RestrictUserApiTokenCreation = model.RestrictUserApiTokenCreation.ValueBool()
+	}
+	return settings
+}
+
+// apiSettingsPatch returns the configured api-settings that differ from current, or all of them when current isn't known
+func apiSettingsPatch(config, plan *organizationResourceModel, current *organizationAPISettings, currentKnown bool) map[string]any {
+	payload := map[string]any{}
+	// config says whether an attribute is managed, plan holds the value to apply
+	if !config.RevokeInactiveTokensAfter.IsNull() && !plan.RevokeInactiveTokensAfter.IsUnknown() {
+		if revoke := plan.RevokeInactiveTokensAfter.ValueString(); !currentKnown || revoke != revokePeriodFromDays(current.RevokeInactiveTokensAfterDays) {
+			payload["revoke_inactive_tokens_after_days"] = revokePeriodToDays(revoke)
+		}
+	}
+	if !config.RestrictUserApiTokenCreation.IsNull() && !plan.RestrictUserApiTokenCreation.IsUnknown() {
+		if restrict := plan.RestrictUserApiTokenCreation.ValueBool(); !currentKnown || restrict != current.RestrictUserApiTokenCreation {
+			payload["restrict_user_api_token_creation"] = restrict
+		}
+	}
+	return payload
+}
+
+func (o *organizationResource) readAPISettings(ctx context.Context, state *organizationResourceModel, diags *diag.Diagnostics) {
+	settings, err := o.client.getOrganizationAPISettings(ctx)
+	if err != nil {
+		if !isAPIStatus(err, http.StatusForbidden) {
+			diags.AddError("Unable to read organization API settings", fmt.Sprintf("Unable to read organization API settings: %s", err.Error()))
+			return
+		}
+		// tolerate tokens without the read_organization_settings scope
+		diags.AddWarning("Unable to read organization API settings", fmt.Sprintf("Unable to read organization API settings, keeping the last known values. The API token needs the read_organization_settings scope: %s", err.Error()))
+		settings = apiSettingsFromModel(state)
+	}
+	state.RevokeInactiveTokensAfter = types.StringValue(revokePeriodFromDays(settings.RevokeInactiveTokensAfterDays))
+	state.RestrictUserApiTokenCreation = types.BoolValue(settings.RestrictUserApiTokenCreation)
+}
+
+// updateAPISettings sends the configured api-settings that changed and records the result on state
+func (o *organizationResource) updateAPISettings(ctx context.Context, config, plan, prior, state *organizationResourceModel, diags *diag.Diagnostics) {
+	current, err := o.client.getOrganizationAPISettings(ctx)
+	currentKnown := err == nil
+	if err != nil {
+		if !isAPIStatus(err, http.StatusForbidden) {
+			diags.AddError("Unable to read organization API settings", fmt.Sprintf("Unable to read organization API settings: %s", err.Error()))
+			return
+		}
+		// without the read scope every configured value is sent, and the rest keeps its last known value
+		diags.AddWarning("Unable to read organization API settings", fmt.Sprintf("Unable to read organization API settings, keeping the last known values. The API token needs the read_organization_settings scope: %s", err.Error()))
+		current = apiSettingsFromModel(prior)
+	}
+
+	// attributes that are not configured are left as they are
+	state.RevokeInactiveTokensAfter = plan.RevokeInactiveTokensAfter
+	if state.RevokeInactiveTokensAfter.IsNull() || state.RevokeInactiveTokensAfter.IsUnknown() {
+		state.RevokeInactiveTokensAfter = types.StringValue(revokePeriodFromDays(current.RevokeInactiveTokensAfterDays))
+	}
+	state.RestrictUserApiTokenCreation = plan.RestrictUserApiTokenCreation
+	if state.RestrictUserApiTokenCreation.IsNull() || state.RestrictUserApiTokenCreation.IsUnknown() {
+		state.RestrictUserApiTokenCreation = types.BoolValue(current.RestrictUserApiTokenCreation)
+	}
+
+	payload := apiSettingsPatch(config, plan, current, currentKnown)
+	if len(payload) == 0 {
+		return
+	}
+
+	log.Printf("Updating API settings for organization %s ...", o.client.organization)
+	if _, err := o.client.updateOrganizationAPISettings(ctx, payload); err != nil {
+		detail := fmt.Sprintf("Unable to update organization API settings: %s", err.Error())
+		if _, ok := payload["revoke_inactive_tokens_after_days"]; ok && currentKnown && !current.Features.InactiveApiTokenRevocation {
+			detail += " Inactive API token revocation is not available on this organization's plan."
+		}
+		diags.AddError("Unable to update organization API settings", detail)
+	}
 }

--- a/buildkite/resource_organization_test.go
+++ b/buildkite/resource_organization_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -91,6 +92,83 @@ func TestAllowedApiIpAddressesValue(t *testing.T) {
 			}
 			if planned != tc.value {
 				t.Errorf("planned value = %q, want %q", planned, tc.value)
+			}
+		})
+	}
+}
+
+func TestRevokePeriodDays(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		period string
+		days   int64
+	}{
+		{"NEVER", 0},
+		{"DAYS_30", 30},
+		{"DAYS_60", 60},
+		{"DAYS_90", 90},
+		{"DAYS_180", 180},
+		{"DAYS_365", 365},
+	}
+	if len(testCases) != len(revokeInactiveTokenPeriods) {
+		t.Fatalf("expected a case for each of %v", revokeInactiveTokenPeriods)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.period, func(t *testing.T) {
+			var days *int64
+			if tc.days != 0 {
+				days = &tc.days
+			}
+			if got := revokePeriodFromDays(days); got != tc.period {
+				t.Errorf("revokePeriodFromDays(%v) = %s, want %s", days, got, tc.period)
+			}
+			got := revokePeriodToDays(tc.period)
+			if (got == nil) != (days == nil) || (got != nil && *got != tc.days) {
+				t.Errorf("revokePeriodToDays(%s) = %v, want %v", tc.period, got, days)
+			}
+		})
+	}
+}
+
+func TestApiSettingsPatch(t *testing.T) {
+	t.Parallel()
+
+	days := func(d int64) *int64 { return &d }
+	model := func(revoke types.String, restrict types.Bool) organizationResourceModel {
+		return organizationResourceModel{RevokeInactiveTokensAfter: revoke, RestrictUserApiTokenCreation: restrict}
+	}
+	unset := model(types.StringNull(), types.BoolNull())
+	testCases := []struct {
+		name         string
+		config       organizationResourceModel
+		plan         organizationResourceModel
+		current      organizationAPISettings
+		currentKnown bool
+		want         string
+	}{
+		{"unset attributes are not sent", unset, model(types.StringUnknown(), types.BoolUnknown()), organizationAPISettings{RevokeInactiveTokensAfterDays: days(30), RestrictUserApiTokenCreation: true}, true, `{}`},
+		{"values kept from state for unset attributes are not sent", unset, model(types.StringValue("DAYS_90"), types.BoolValue(true)), organizationAPISettings{}, true, `{}`},
+		{"unchanged values are not sent", model(types.StringValue("DAYS_90"), types.BoolValue(true)), model(types.StringValue("DAYS_90"), types.BoolValue(true)), organizationAPISettings{RevokeInactiveTokensAfterDays: days(90), RestrictUserApiTokenCreation: true}, true, `{}`},
+		{"changed period is sent", model(types.StringValue("DAYS_60"), types.BoolNull()), model(types.StringValue("DAYS_60"), types.BoolValue(false)), organizationAPISettings{RevokeInactiveTokensAfterDays: days(90)}, true, `{"revoke_inactive_tokens_after_days":60}`},
+		{"never is sent as null", model(types.StringValue("NEVER"), types.BoolValue(false)), model(types.StringValue("NEVER"), types.BoolValue(false)), organizationAPISettings{RevokeInactiveTokensAfterDays: days(90)}, true, `{"revoke_inactive_tokens_after_days":null}`},
+		{"changed restriction is sent", model(types.StringNull(), types.BoolValue(false)), model(types.StringValue("NEVER"), types.BoolValue(false)), organizationAPISettings{RestrictUserApiTokenCreation: true}, true, `{"restrict_user_api_token_creation":false}`},
+		{"both are sent", model(types.StringValue("DAYS_365"), types.BoolValue(true)), model(types.StringValue("DAYS_365"), types.BoolValue(true)), organizationAPISettings{}, true, `{"restrict_user_api_token_creation":true,"revoke_inactive_tokens_after_days":365}`},
+		// when the current settings can't be read, configured values are always sent
+		{"unknown current and explicit false", model(types.StringNull(), types.BoolValue(false)), model(types.StringUnknown(), types.BoolValue(false)), organizationAPISettings{}, false, `{"restrict_user_api_token_creation":false}`},
+		{"unknown current and explicit never", model(types.StringValue("NEVER"), types.BoolNull()), model(types.StringValue("NEVER"), types.BoolUnknown()), organizationAPISettings{}, false, `{"revoke_inactive_tokens_after_days":null}`},
+		{"unknown current and nothing configured", unset, model(types.StringValue("DAYS_30"), types.BoolValue(true)), organizationAPISettings{}, false, `{}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(apiSettingsPatch(&tc.config, &tc.plan, &tc.current, tc.currentKnown))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
 			}
 		})
 	}
@@ -326,6 +404,147 @@ func TestAccBuildkiteOrganizationResource(t *testing.T) {
 		})
 	})
 
+	configAPISettings := func(settings string) string {
+		return fmt.Sprintf(`
+		provider "buildkite" {
+			timeouts = {
+				create = "60s"
+				read = "60s"
+				update = "60s"
+				delete = "60s"
+			}
+		}
+
+		resource "buildkite_organization" "let_them_in" {
+			%s
+		}
+		`, settings)
+	}
+
+	t.Run("manages restricting user API token creation", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testCheckOrganizationResourceRemoved,
+			Steps: []resource.TestStep{
+				{
+					// unmanaged: the current values are only read into state
+					Config: configAPISettings(``),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "restrict_user_api_token_creation", "false"),
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "revoke_inactive_tokens_after", "NEVER"),
+						testAccCheckOrganizationAPISettingsRemoteValues("NEVER", false),
+					),
+				},
+				{
+					Config: configAPISettings(`restrict_user_api_token_creation = true`),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "restrict_user_api_token_creation", "true"),
+						testAccCheckOrganizationAPISettingsRemoteValues("NEVER", true),
+					),
+				},
+				{
+					ResourceName:      "buildkite_organization.let_them_in",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					// removing the attribute leaves the setting as it is
+					Config: configAPISettings(``),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "restrict_user_api_token_creation", "true"),
+						testAccCheckOrganizationAPISettingsRemoteValues("NEVER", true),
+					),
+				},
+				{
+					// it has to be lifted explicitly
+					Config: configAPISettings(`restrict_user_api_token_creation = false`),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "restrict_user_api_token_creation", "false"),
+						testAccCheckOrganizationAPISettingsRemoteValues("NEVER", false),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("manages inactive API token revocation", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				// the setting can only be changed on plans with the inactive API token revocation feature
+				if settings, err := getTestClient().getOrganizationAPISettings(context.Background()); err != nil {
+					t.Skipf("unable to read organization api-settings (needs the read_organization_settings scope): %v", err)
+				} else if !settings.Features.InactiveApiTokenRevocation {
+					t.Skip("inactive API token revocation is not available on this organization's plan")
+				}
+			},
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testCheckOrganizationResourceRemoved,
+			Steps: []resource.TestStep{
+				{
+					Config: configAPISettings(`revoke_inactive_tokens_after = "DAYS_30"`),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "revoke_inactive_tokens_after", "DAYS_30"),
+						testAccCheckOrganizationAPISettingsRemoteValues("DAYS_30", false),
+					),
+				},
+				{
+					Config: configAPISettings(`revoke_inactive_tokens_after = "DAYS_90"`),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "revoke_inactive_tokens_after", "DAYS_90"),
+						testAccCheckOrganizationAPISettingsRemoteValues("DAYS_90", false),
+					),
+				},
+				{
+					ResourceName:      "buildkite_organization.let_them_in",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					// removing the attribute leaves the setting as it is
+					Config: configAPISettings(``),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "revoke_inactive_tokens_after", "DAYS_90"),
+						testAccCheckOrganizationAPISettingsRemoteValues("DAYS_90", false),
+					),
+				},
+				{
+					// NEVER disables revocation again
+					Config: configAPISettings(`revoke_inactive_tokens_after = "NEVER"`),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("buildkite_organization.let_them_in", "revoke_inactive_tokens_after", "NEVER"),
+						testAccCheckOrganizationAPISettingsRemoteValues("NEVER", false),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("rejects an unsupported inactive token revocation period", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config:      configAPISettings(`revoke_inactive_tokens_after = "DAYS_45"`),
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`(?s)revoke_inactive_tokens_after.*value must be one of`),
+				},
+			},
+		})
+	})
+
 	t.Run("imports an organization", func(t *testing.T) {
 		check := resource.ComposeAggregateTestCheckFunc(
 			// Confirm that the allowed IP addresses are set correctly in Buildkite's system
@@ -376,6 +595,22 @@ func testCheckOrganizationResourceRemoved(s *terraform.State) error {
 		return nil
 	}
 	return nil
+}
+
+func testAccCheckOrganizationAPISettingsRemoteValues(revokeAfter string, restrictTokenCreation bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		settings, err := getTestClient().getOrganizationAPISettings(context.Background())
+		if err != nil {
+			return err
+		}
+		if got := revokePeriodFromDays(settings.RevokeInactiveTokensAfterDays); got != revokeAfter {
+			return fmt.Errorf("Remote revoke_inactive_tokens_after does not match. Expected: %s, got: %s", revokeAfter, got)
+		}
+		if settings.RestrictUserApiTokenCreation != restrictTokenCreation {
+			return fmt.Errorf("Remote restrict_user_api_token_creation does not match. Expected: %t, got: %t", restrictTokenCreation, settings.RestrictUserApiTokenCreation)
+		}
+		return nil
+	}
 }
 
 func testAccCheckOrganizationRemoteValues(ip_addresses []string) resource.TestCheckFunc {

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -20,6 +20,10 @@ The user of your API token must be an organization administrator to manage organ
 resource "buildkite_organization" "settings" {
   allowed_api_ip_addresses = ["1.1.1.1/32"]
   enforce_2fa              = true
+
+  # only let administrators create API access tokens and revoke tokens unused for 90 days
+  restrict_user_api_token_creation = true
+  revoke_inactive_tokens_after     = "DAYS_90"
 }
 ```
 
@@ -32,6 +36,8 @@ resource "buildkite_organization" "settings" {
 
 -> The "Allowed API IP Addresses" feature must be enabled on your organization in order to manage the `allowed_api_ip_addresses` attribute.
 - `enforce_2fa` (Boolean) Sets whether the organization requires two-factor authentication for all members.
+- `restrict_user_api_token_creation` (Boolean) Whether only organization administrators can create new API access tokens for this organization. If omitted, the current setting is left unchanged. Requires an API token with the `read_organization_settings` and `write_organization_settings` scopes.
+- `revoke_inactive_tokens_after` (String) The period of inactivity after which user API access tokens are revoked. Valid values are `NEVER`, `DAYS_30`, `DAYS_60`, `DAYS_90`, `DAYS_180` and `DAYS_365`. If omitted, the current setting is left unchanged. Requires an API token with the `read_organization_settings` and `write_organization_settings` scopes and the inactive API token revocation feature on the organization's plan.
 
 ### Read-Only
 

--- a/examples/resources/buildkite_organization/resource.tf
+++ b/examples/resources/buildkite_organization/resource.tf
@@ -2,4 +2,8 @@
 resource "buildkite_organization" "settings" {
   allowed_api_ip_addresses = ["1.1.1.1/32"]
   enforce_2fa              = true
+
+  # only let administrators create API access tokens and revoke tokens unused for 90 days
+  restrict_user_api_token_creation = true
+  revoke_inactive_tokens_after     = "DAYS_90"
 }


### PR DESCRIPTION
Adds the two [API access token settings](https://buildkite.com/docs/apis/rest-api/organizations/api-settings) to `buildkite_organization`, so restricting token creation to admins and revoking inactive tokens can be declared and drift-detected instead of set in the UI. Follow-up to #1207.

```hcl
resource "buildkite_organization" "settings" {
  restrict_user_api_token_creation = true
  revoke_inactive_tokens_after     = "DAYS_90"
}
```

Both attributes are optional and computed: when omitted the current value is only read into state, so upgrading the provider never changes an organization, and only values that differ are sent in the PATCH. `revoke_inactive_tokens_after` mirrors the `RevokeInactiveTokenPeriod` enum (`NEVER`, `DAYS_30` … `DAYS_365`) and is translated to the endpoint's nullable `revoke_inactive_tokens_after_days`; happy to switch to the REST integer if you prefer. The endpoint needs the `read_organization_settings`/`write_organization_settings` scopes, so a 403 on read only warns and keeps the last known values (as `retry_agent_affinity` does), and changing the revocation period on a plan without that feature returns the API error plus a one-line hint. When the api-settings read is forbidden but the write isn't, every configured value is sent rather than compared, so an explicit `false`/`NEVER` still applies.

Added table tests for the enum mapping and the PATCH payload, extended `TestAccBuildkiteOrganizationResource` (create, update, import, attribute removed, reset) and ran it locally against a test organization.

## PR checklist:
- [x] `docs/` updated
- [x] tests added
- [x] an example added to `examples/`
- [ ] `CHANGELOG.md` updated with pending release information <-- left for the release process