### PR TITLE
Preserve Buildkite macOS queue defaults

### DIFF
--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -221,6 +221,9 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 								Optional:    true,
 								Computed:    true,
 								Description: "The macOS version available to jobs in this queue. Buildkite selects the current default when this is omitted. This setting is experimental and may not work as expected.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 					},

--- a/buildkite/resource_cluster_queue.go
+++ b/buildkite/resource_cluster_queue.go
@@ -219,7 +219,8 @@ func (clusterQueueResource) Schema(ctx context.Context, req resource.SchemaReque
 							},
 							"macos_version": resource_schema.StringAttribute{
 								Optional:    true,
-								Description: "Optional selection of a specific macOS version to be selected for jobs in the queue to have available. Please note that this value is currently experimental and may not function as expected.",
+								Computed:    true,
+								Description: "The macOS version available to jobs in this queue. Buildkite selects the current default when this is omitted. This setting is experimental and may not work as expected.",
 							},
 						},
 					},
@@ -282,21 +283,15 @@ func (cq *clusterQueueResource) Create(ctx context.Context, req resource.CreateR
 				},
 			}
 		} else if plan.HostedAgents.Mac != nil {
-			if plan.HostedAgents.Mac.MacosVersion.IsNull() {
-				hosted.PlatformSettings = HostedAgentsPlatformSettingsInput{
-					Macos: &HostedAgentsMacosPlatformSettingsInput{
-						XcodeVersion: plan.HostedAgents.Mac.XcodeVersion.ValueStringPointer(),
-					},
-				}
-			} else {
-				version := HostedAgentMacOSVersion(plan.HostedAgents.Mac.MacosVersion.ValueString())
+			hosted.PlatformSettings = HostedAgentsPlatformSettingsInput{
+				Macos: &HostedAgentsMacosPlatformSettingsInput{
+					XcodeVersion: plan.HostedAgents.Mac.XcodeVersion.ValueStringPointer(),
+				},
+			}
 
-				hosted.PlatformSettings = HostedAgentsPlatformSettingsInput{
-					Macos: &HostedAgentsMacosPlatformSettingsInput{
-						XcodeVersion: plan.HostedAgents.Mac.XcodeVersion.ValueStringPointer(),
-						MacosVersion: &version,
-					},
-				}
+			if !plan.HostedAgents.Mac.MacosVersion.IsNull() && !plan.HostedAgents.Mac.MacosVersion.IsUnknown() {
+				version := HostedAgentMacOSVersion(plan.HostedAgents.Mac.MacosVersion.ValueString())
+				hosted.PlatformSettings.Macos.MacosVersion = &version
 			}
 		}
 	}
@@ -521,7 +516,7 @@ func (cq *clusterQueueResource) Update(ctx context.Context, req resource.UpdateR
 				XcodeVersion: plan.HostedAgents.Mac.XcodeVersion.ValueStringPointer(),
 			}
 
-			if !plan.HostedAgents.Mac.MacosVersion.IsNull() {
+			if !plan.HostedAgents.Mac.MacosVersion.IsNull() && !plan.HostedAgents.Mac.MacosVersion.IsUnknown() {
 				version := HostedAgentMacOSVersion(plan.HostedAgents.Mac.MacosVersion.ValueString())
 				hosted.PlatformSettings.Macos.MacosVersion = &version
 			}

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -401,17 +401,34 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 		})
 	})
 
-	t.Run("creates a hosted mac queue", func(t *testing.T) {
+	t.Run("preserves the API-selected macOS version during unrelated updates", func(t *testing.T) {
 		var cq clusterQueueResourceModel
 		clusterName := acctest.RandString(10)
 		queueKey := acctest.RandString(10)
 		queueDesc := acctest.RandString(10)
+		updatedQueueDesc := acctest.RandString(10)
+		var macosVersion string
 
-		check := resource.ComposeAggregateTestCheckFunc(
+		checkCreated := resource.ComposeAggregateTestCheckFunc(
 			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
 			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.instance_shape", "MACOS_ARM64_M4_6X28"),
 			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.mac.xcode_version", "14.3.1"),
-			resource.TestCheckResourceAttrSet("buildkite_cluster_queue.foobar", "hosted_agents.mac.macos_version"),
+			resource.TestCheckResourceAttrWith("buildkite_cluster_queue.foobar", "hosted_agents.mac.macos_version", func(value string) error {
+				macosVersion = value
+				return nil
+			}),
+		)
+
+		checkUpdated := resource.ComposeAggregateTestCheckFunc(
+			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
+			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "description", fmt.Sprintf("Acceptance test %s", updatedQueueDesc)),
+			resource.TestCheckResourceAttrWith("buildkite_cluster_queue.foobar", "hosted_agents.mac.macos_version", func(value string) error {
+				if value != macosVersion {
+					return fmt.Errorf("macOS version changed from %q to %q after an unrelated update", macosVersion, value)
+				}
+
+				return nil
+			}),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{
@@ -421,7 +438,11 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: configHostedMac(clusterName, queueKey, queueDesc),
-					Check:  check,
+					Check:  checkCreated,
+				},
+				{
+					Config: configHostedMac(clusterName, queueKey, updatedQueueDesc),
+					Check:  checkUpdated,
 				},
 			},
 		})

--- a/buildkite/resource_cluster_queue_test.go
+++ b/buildkite/resource_cluster_queue_test.go
@@ -411,6 +411,7 @@ func TestAccBuildkiteClusterQueueResource(t *testing.T) {
 			testAccCheckClusterQueueExists("buildkite_cluster_queue.foobar", &cq),
 			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.instance_shape", "MACOS_ARM64_M4_6X28"),
 			resource.TestCheckResourceAttr("buildkite_cluster_queue.foobar", "hosted_agents.mac.xcode_version", "14.3.1"),
+			resource.TestCheckResourceAttrSet("buildkite_cluster_queue.foobar", "hosted_agents.mac.macos_version"),
 		)
 
 		resource.ParallelTest(t, resource.TestCase{

--- a/docs/resources/cluster_queue.md
+++ b/docs/resources/cluster_queue.md
@@ -131,7 +131,7 @@ Required:
 
 Optional:
 
-- `macos_version` (String) Optional selection of a specific macOS version to be selected for jobs in the queue to have available. Please note that this value is currently experimental and may not function as expected.
+- `macos_version` (String) The macOS version available to jobs in this queue. Buildkite selects the current default when this is omitted. This setting is experimental and may not work as expected.
 
 ## Import
 


### PR DESCRIPTION
Buildkite now selects a default `macos_version` when creating hosted macOS queues. 
The provider planned null, then rejected the API-populated value as inconsistent after apply.

Treat `macos_version` as optional and computed, and store Buildkite's selected version in Terraform state.


Context: SUP-7848 and PB-2968.