### PR TITLE
Group Go updates across mise and Docker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,14 @@
       "groupName": "golang-x"
     },
     {
+      "description": "Keep Go toolchain versions in mise and Docker in sync",
+      "matchManagers": ["mise", "dockerfile"],
+      "matchDepNames": ["go", "golang"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "go-toolchain",
+      "minimumGroupSize": 2
+    },
+    {
       "description": "Group test and dev tooling",
       "matchPackageNames": [
         "github.com/stretchr/testify",


### PR DESCRIPTION
Renovate currently opens separate PRs when Go changes in `mise.toml` and `Dockerfile`.

This groups version updates into one `go-toolchain` PR, created only when both files can be updated. Docker digest-only updates remain separate.