### PR TITLE
feat(pipeline): add GitHub issues trigger setting

### DIFF
--- a/buildkite/generated.go
+++ b/buildkite/generated.go
@@ -3196,6 +3196,8 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpr
 type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings struct {
 	// Whether to create builds when branches are pushed.
 	BuildBranches *bool `json:"buildBranches"`
+	// Whether to create builds for GitHub issue activity.
+	BuildIssues *bool `json:"buildIssues"`
 	// Whether to create builds when a check run completes.
 	BuildCheckRunCompleted *bool `json:"buildCheckRunCompleted"`
 	// Whether to create builds when a branch or tag is created.
@@ -3287,6 +3289,11 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseS
 // GetBuildBranches returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildBranches, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildBranches() *bool {
 	return v.BuildBranches
+}
+
+// GetBuildIssues returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildIssues, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings) GetBuildIssues() *bool {
+	return v.BuildIssues
 }
 
 // GetBuildCheckRunCompleted returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpriseSettingsRepositoryProviderGitHubEnterpriseSettings.BuildCheckRunCompleted, and is useful for accessing the field via an interface.
@@ -3511,6 +3518,8 @@ func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubEnterpr
 type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings struct {
 	// Whether to create builds when branches are pushed.
 	BuildBranches *bool `json:"buildBranches"`
+	// Whether to create builds for GitHub issue activity.
+	BuildIssues *bool `json:"buildIssues"`
 	// Whether to create builds when a check run completes.
 	BuildCheckRunCompleted *bool `json:"buildCheckRunCompleted"`
 	// Whether to create builds when a branch or tag is created.
@@ -3602,6 +3611,11 @@ type RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRep
 // GetBuildBranches returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildBranches, and is useful for accessing the field via an interface.
 func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildBranches() *bool {
 	return v.BuildBranches
+}
+
+// GetBuildIssues returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildIssues, and is useful for accessing the field via an interface.
+func (v *RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings) GetBuildIssues() *bool {
+	return v.BuildIssues
 }
 
 // GetBuildCheckRunCompleted returns RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings.BuildCheckRunCompleted, and is useful for accessing the field via an interface.
@@ -26831,6 +26845,7 @@ fragment RepositoryProviderSettingsFields on Repository {
 		... on RepositoryProviderGithub {
 			settings {
 				buildBranches
+				buildIssues
 				buildCheckRunCompleted
 				buildCreateEvent
 				buildDeploymentStatusCreated
@@ -26879,6 +26894,7 @@ fragment RepositoryProviderSettingsFields on Repository {
 		... on RepositoryProviderGithubEnterprise {
 			settings {
 				buildBranches
+				buildIssues
 				buildCheckRunCompleted
 				buildCreateEvent
 				buildDeploymentStatusCreated

--- a/buildkite/graphql/pipeline.graphql
+++ b/buildkite/graphql/pipeline.graphql
@@ -62,6 +62,8 @@ fragment RepositoryProviderSettingsFields on Repository {
                 # @genqlient(pointer: true)
                 buildBranches
                 # @genqlient(pointer: true)
+                buildIssues
+                # @genqlient(pointer: true)
                 buildCheckRunCompleted
                 # @genqlient(pointer: true)
                 buildCreateEvent
@@ -153,6 +155,8 @@ fragment RepositoryProviderSettingsFields on Repository {
             settings {
                 # @genqlient(pointer: true)
                 buildBranches
+                # @genqlient(pointer: true)
+                buildIssues
                 # @genqlient(pointer: true)
                 buildCheckRunCompleted
                 # @genqlient(pointer: true)

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -885,7 +885,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					"build_issues": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
-						MarkdownDescription: "Whether authenticated GitHub `issues` webhook deliveries create builds. Defaults to false.",
+						MarkdownDescription: "Whether authenticated GitHub `issues` webhook deliveries create builds. Supported for GitHub.com pipelines only. Defaults to false.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
@@ -2218,6 +2218,10 @@ func pipelineSchemaV0() schema.Schema {
 							Optional: true,
 						},
 						"build_branches": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+						},
+						"build_issues": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
 						},

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -109,6 +109,7 @@ type pipelineResourceModel struct {
 
 type providerSettingsModel struct {
 	TriggerMode                             types.String `tfsdk:"trigger_mode"`
+	BuildIssues                             types.Bool   `tfsdk:"build_issues"`
 	BuildPullRequests                       types.Bool   `tfsdk:"build_pull_requests"`
 	PullRequestBranchFilterEnabled          types.Bool   `tfsdk:"pull_request_branch_filter_enabled"`
 	PullRequestBranchFilterConfiguration    types.String `tfsdk:"pull_request_branch_filter_configuration"`
@@ -881,6 +882,14 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							boolplanmodifier.UseNonNullStateForUnknown(),
 						},
 					},
+					"build_issues": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Whether authenticated GitHub `issues` webhook deliveries create builds. Defaults to false.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseNonNullStateForUnknown(),
+						},
+					},
 					"pull_request_branch_filter_enabled": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
@@ -1595,6 +1604,7 @@ type PipelineSlug struct {
 
 type PipelineExtraSettings struct {
 	TriggerMode                             *string `json:"trigger_mode,omitempty"`
+	BuildIssues                             *bool   `json:"build_issues,omitempty"`
 	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
 	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
 	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
@@ -1663,6 +1673,7 @@ func updatePipelineExtraInfo(ctx context.Context, slug string, settings *provide
 	payload := map[string]any{
 		"provider_settings": PipelineExtraSettings{
 			TriggerMode:                             settings.TriggerMode.ValueStringPointer(),
+			BuildIssues:                             settings.BuildIssues.ValueBoolPointer(),
 			BuildPullRequests:                       settings.BuildPullRequests.ValueBoolPointer(),
 			PullRequestBranchFilterEnabled:          settings.PullRequestBranchFilterEnabled.ValueBoolPointer(),
 			PullRequestBranchFilterConfiguration:    settings.PullRequestBranchFilterConfiguration.ValueStringPointer(),
@@ -1759,6 +1770,7 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 
 	state.ProviderSettings = &providerSettingsModel{
 		TriggerMode:                             types.StringPointerValue(s.TriggerMode),
+		BuildIssues:                             types.BoolPointerValue(s.BuildIssues),
 		BuildPullRequests:                       types.BoolPointerValue(s.BuildPullRequests),
 		PullRequestBranchFilterEnabled:          types.BoolPointerValue(s.PullRequestBranchFilterEnabled),
 		PullRequestBranchFilterConfiguration:    types.StringPointerValue(s.PullRequestBranchFilterConfiguration),
@@ -1825,6 +1837,7 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 		s := provider.Settings
 		return &providerSettingsModel{
 			TriggerMode:                             types.StringPointerValue(s.TriggerMode),
+			BuildIssues:                             types.BoolPointerValue(s.BuildIssues),
 			BuildPullRequests:                       types.BoolPointerValue(s.BuildPullRequests),
 			PullRequestBranchFilterEnabled:          types.BoolPointerValue(s.PullRequestBranchFilterEnabled),
 			PullRequestBranchFilterConfiguration:    types.StringPointerValue(s.PullRequestBranchFilterConfiguration),
@@ -1873,6 +1886,7 @@ func mapProviderSettingsFromGraphQL(repo RepositoryProviderSettingsFields) *prov
 		s := provider.Settings
 		return &providerSettingsModel{
 			TriggerMode:                             types.StringPointerValue(s.TriggerMode),
+			BuildIssues:                             types.BoolPointerValue(s.BuildIssues),
 			BuildPullRequests:                       types.BoolPointerValue(s.BuildPullRequests),
 			PullRequestBranchFilterEnabled:          types.BoolPointerValue(s.PullRequestBranchFilterEnabled),
 			PullRequestBranchFilterConfiguration:    types.StringPointerValue(s.PullRequestBranchFilterConfiguration),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -88,6 +88,19 @@ func TestPipelineExtraSettingsUseStepKeyAsCommitStatusJSON(t *testing.T) {
 	}
 }
 
+func TestPipelineExtraSettingsBuildIssuesJSON(t *testing.T) {
+	enabled := true
+
+	payload, err := json.Marshal(PipelineExtraSettings{BuildIssues: &enabled})
+	if err != nil {
+		t.Fatalf("failed to marshal provider settings: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"build_issues":true`) {
+		t.Fatalf("expected build_issues in payload, got %s", payload)
+	}
+}
+
 func TestUpdatePipelineResourceExtraInfoUseStepKeyAsCommitStatus(t *testing.T) {
 	enabled := true
 	extraInfo := PipelineExtraInfo{}
@@ -105,6 +118,22 @@ func TestUpdatePipelineResourceExtraInfoUseStepKeyAsCommitStatus(t *testing.T) {
 	}
 }
 
+func TestUpdatePipelineResourceExtraInfoBuildIssues(t *testing.T) {
+	disabled := false
+	extraInfo := PipelineExtraInfo{}
+	extraInfo.Provider.Settings.BuildIssues = &disabled
+
+	state := pipelineResourceModel{}
+	updatePipelineResourceExtraInfo(&state, &extraInfo)
+
+	if state.ProviderSettings == nil {
+		t.Fatal("expected provider settings to be set")
+	}
+	if state.ProviderSettings.BuildIssues.IsNull() || state.ProviderSettings.BuildIssues.ValueBool() {
+		t.Fatal("expected build_issues to be false")
+	}
+}
+
 func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	triggerMode := "code"
 	enabled := true
@@ -115,6 +144,7 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 		Provider: &RepositoryProviderSettingsFieldsProviderRepositoryProviderGithub{
 			Settings: RepositoryProviderSettingsFieldsProviderRepositoryProviderGithubSettingsRepositoryProviderGitHubSettings{
 				TriggerMode:                          &triggerMode,
+				BuildIssues:                          &enabled,
 				BuildPullRequests:                    &enabled,
 				BuildBranches:                        &disabled,
 				IssueCommentMatchMode:                &matchMode,
@@ -136,6 +166,9 @@ func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	}
 	if !got.BuildPullRequests.ValueBool() {
 		t.Fatal("build_pull_requests: expected true")
+	}
+	if !got.BuildIssues.ValueBool() {
+		t.Fatal("build_issues: expected true")
 	}
 	if got.BuildBranches.ValueBool() {
 		t.Fatal("build_branches: expected false")
@@ -731,6 +764,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "tags.#", "0"),
 						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "tags.#"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", ""),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issues", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_pull_request_builds_for_existing_commits", "false"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "false"),
@@ -837,6 +871,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 				tags = ["llama"]
 				provider_settings = {
 					trigger_mode = "code"
+					build_issues = true
 					build_pull_requests = true
 					skip_builds_for_existing_commits = true
 					build_branches = true
@@ -900,6 +935,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "skip_intermediate_builds_branch_filter", "!main"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "code"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issues", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.skip_builds_for_existing_commits", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
@@ -947,6 +983,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					ExpectNonEmptyPlan: false,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.trigger_mode", "code"),
+						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issues", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_merge_commits", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issue_comment_created", "true"),
 						resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_command_word", "ci-force-rerun"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -1396,6 +1396,7 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "repository", "https://github.com/buildkite/terraform-provider-buildkite.git"),
 			// Ensure that v1 pipeline's provider_settings set attributes are nested in state when upgraded from v0
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_branches", "true"),
+			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_issues", "false"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_requests", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_pull_request_ready_for_review", "true"),
 			resource.TestCheckResourceAttr("buildkite_pipeline.pipeline", "provider_settings.build_tags", "true"),

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -219,7 +219,7 @@ Optional:
 - `build_create_event` (Boolean) Whether to create a build when a branch or tag is created on GitHub.
 - `build_deployment_status_created` (Boolean) Whether to create a build when a GitHub deployment status is created.
 - `build_issue_comment_created` (Boolean) Whether to create builds when an issue comment is created on a pull request.
-- `build_issues` (Boolean) Whether authenticated GitHub `issues` webhook deliveries create builds. Defaults to false.
+- `build_issues` (Boolean) Whether authenticated GitHub `issues` webhook deliveries create builds. Supported for GitHub.com pipelines only. Defaults to false.
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -219,6 +219,7 @@ Optional:
 - `build_create_event` (Boolean) Whether to create a build when a branch or tag is created on GitHub.
 - `build_deployment_status_created` (Boolean) Whether to create a build when a GitHub deployment status is created.
 - `build_issue_comment_created` (Boolean) Whether to create builds when an issue comment is created on a pull request.
+- `build_issues` (Boolean) Whether authenticated GitHub `issues` webhook deliveries create builds. Defaults to false.
 - `build_merge_group_checks_requested` (Boolean) Whether to create merge queue builds for a merge queue enabled GitHub repository with required status checks
 - `build_pull_request_base_branch_changed` (Boolean) Whether to create builds for pull requests when its base branch changes.
 - `build_pull_request_converted_to_draft` (Boolean) Whether to create a build when a pull request is converted to a draft.

--- a/schema.graphql
+++ b/schema.graphql
@@ -9337,6 +9337,10 @@ Whether to create builds when branches are pushed.
 """
 	buildBranches: Boolean!
 """
+Whether to create builds for GitHub issue activity.
+"""
+	buildIssues: Boolean!
+"""
 Whether to create builds when a check run completes.
 """
 	buildCheckRunCompleted: Boolean!
@@ -9526,6 +9530,10 @@ type RepositoryProviderGitHubSettings implements RepositoryProviderSettings{
 Whether to create builds when branches are pushed.
 """
 	buildBranches: Boolean!
+"""
+Whether to create builds for GitHub issue activity.
+"""
+	buildIssues: Boolean!
 """
 Whether to create builds when a check run completes.
 """
@@ -12818,5 +12826,4 @@ scalar XML
 A blob of YAML
 """
 scalar YAML
-
 


### PR DESCRIPTION
## Why

Buildkite Pipelines now has a default-off `build_issues` GitHub provider setting, but Terraform cannot configure or retain it. Terraform-managed pipelines would otherwise require a separate UI or API update for native GitHub issue builds.

Related server support: https://github.com/buildkite/buildkite/pull/32958

## What

Add `provider_settings.build_issues` to the pipeline resource, REST update payload, REST and GraphQL state refresh paths, generated GraphQL types, tests, and generated resource documentation. The setting defaults to `false`.

## PR checklist

- [x] `docs/` updated
- [x] tests added
- [ ] an example added to `examples/` — the existing pipeline resource acceptance fixture exercises both enabled and default-off states
- [ ] `CHANGELOG.md` updated — this repository currently updates release changelogs centrally rather than in each feature PR