### PR TITLE
fix(pipeline): no perpetual diff for unset issue/review comment match…

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1810,10 +1810,10 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		UseMergeGroupBaseCommitForGitDiffBase:   types.BoolPointerValue(s.UseMergeGroupBaseCommitForGitDiffBase),
 		BuildIssueCommentCreated:                types.BoolPointerValue(s.BuildIssueCommentCreated),
 		IssueCommentCommandWord:                 types.StringPointerValue(s.IssueCommentCommandWord),
-		IssueCommentMatchMode:                   types.StringPointerValue(s.IssueCommentMatchMode),
+		IssueCommentMatchMode:                   matchModeFromREST(s.IssueCommentMatchMode),
 		BuildPullRequestReviewCommentCreated:    types.BoolPointerValue(s.BuildPullRequestReviewCommentCreated),
 		ReviewCommentCommandWord:                types.StringPointerValue(s.ReviewCommentCommandWord),
-		ReviewCommentMatchMode:                  types.StringPointerValue(s.ReviewCommentMatchMode),
+		ReviewCommentMatchMode:                  matchModeFromREST(s.ReviewCommentMatchMode),
 		BuildPullRequestDequeued:                types.BoolPointerValue(s.BuildPullRequestDequeued),
 		BuildPullRequestReopened:                types.BoolPointerValue(s.BuildPullRequestReopened),
 		BuildCheckRunCompleted:                  types.BoolPointerValue(s.BuildCheckRunCompleted),
@@ -1827,6 +1827,14 @@ func updatePipelineResourceExtraInfo(state *pipelineResourceModel, pipeline *Pip
 		BuildReleasePublished:                   types.BoolPointerValue(s.BuildReleasePublished),
 		BuildReleaseReleased:                    types.BoolPointerValue(s.BuildReleaseReleased),
 	}
+}
+
+// matchModeFromREST reads an unset match mode, which the REST API returns as "", as null so it agrees with the GraphQL read
+func matchModeFromREST(m *string) types.String {
+	if m == nil || *m == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(*m)
 }
 
 // matchModeToString converts a GraphQL CommandWordMatchMode enum (EXACT/CONTAINS) into the

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -1114,7 +1114,8 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						MarkdownDescription: "The match mode for the issue comment command word. Valid values are \"exact\" and \"contains\". Defaults to \"exact\".",
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseNonNullStateForUnknown(),
+							// state written before "" was read as null must not be planned as ""
+							custom_modifier.UseNonEmptyStateForUnknown(),
 						},
 						Validators: []validator.String{
 							stringvalidator.OneOf("exact", "contains"),
@@ -1141,7 +1142,7 @@ func (*pipelineResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						MarkdownDescription: "The match mode for the review comment command word. Valid values are \"exact\" and \"contains\".",
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseNonNullStateForUnknown(),
+							custom_modifier.UseNonEmptyStateForUnknown(),
 						},
 						Validators: []validator.String{
 							stringvalidator.OneOf("exact", "contains"),

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -134,6 +134,24 @@ func TestUpdatePipelineResourceExtraInfoBuildIssues(t *testing.T) {
 	}
 }
 
+func TestUpdatePipelineResourceExtraInfoMatchModes(t *testing.T) {
+	empty, contains := "", "contains"
+	extraInfo := PipelineExtraInfo{}
+	extraInfo.Provider.Settings.IssueCommentMatchMode = &empty
+	extraInfo.Provider.Settings.ReviewCommentMatchMode = &contains
+
+	state := pipelineResourceModel{}
+	updatePipelineResourceExtraInfo(&state, &extraInfo)
+
+	// the REST API returns "" for an unset match mode while GraphQL returns null
+	if !state.ProviderSettings.IssueCommentMatchMode.IsNull() {
+		t.Fatalf("issue_comment_match_mode: expected null, got %q", state.ProviderSettings.IssueCommentMatchMode.ValueString())
+	}
+	if state.ProviderSettings.ReviewCommentMatchMode.ValueString() != "contains" {
+		t.Fatalf("review_comment_match_mode: expected \"contains\", got %q", state.ProviderSettings.ReviewCommentMatchMode.ValueString())
+	}
+}
+
 func TestMapProviderSettingsFromGraphQLGitHub(t *testing.T) {
 	triggerMode := "code"
 	enabled := true
@@ -1027,6 +1045,44 @@ func TestAccBuildkitePipelineResource(t *testing.T) {
 					ResourceName:      "buildkite_pipeline.pipeline",
 					ImportState:       true,
 					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("provider_settings without comment match modes settles after apply", func(t *testing.T) {
+		pipelineName := acctest.RandString(12)
+		clusterName := acctest.RandString(12)
+
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: protoV6ProviderFactories(),
+			CheckDestroy:             testAccCheckPipelineDestroy,
+			Steps: []resource.TestStep{
+				{
+					// the REST API returns "" for an unset match mode while a refresh reads null, so the
+					// output below turned into a change on every plan that followed an apply
+					Config: fmt.Sprintf(`
+						resource "buildkite_cluster" "cluster" {
+							name = "%s"
+						}
+						resource "buildkite_pipeline" "pipeline" {
+							name = "%s"
+							repository = "https://github.com/buildkite/terraform-provider-buildkite.git"
+							cluster_id = buildkite_cluster.cluster.id
+							provider_settings = {
+								trigger_mode = "code"
+								build_pull_requests = true
+							}
+						}
+						output "provider_settings" {
+							value = buildkite_pipeline.pipeline.provider_settings
+						}
+					`, clusterName, pipelineName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.issue_comment_match_mode"),
+						resource.TestCheckNoResourceAttr("buildkite_pipeline.pipeline", "provider_settings.review_comment_match_mode"),
+					),
 				},
 			},
 		})

--- a/internal/planmodifier/use_non_empty_state_for_unknown.go
+++ b/internal/planmodifier/use_non_empty_state_for_unknown.go
@@ -1,0 +1,44 @@
+package planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+type useNonEmptyStateForUnknownModifier struct{}
+
+// Description implements planmodifier.String.
+func (useNonEmptyStateForUnknownModifier) Description(context.Context) string {
+	return "Once set to a non-empty value, the value of this attribute in state will not change. An empty string in state is treated like null and planned as unknown."
+}
+
+// MarkdownDescription implements planmodifier.String.
+func (useNonEmptyStateForUnknownModifier) MarkdownDescription(context.Context) string {
+	return "Once set to a non-empty value, the value of this attribute in state will not change. An empty string in state is treated like null and planned as unknown."
+}
+
+// PlanModifyString implements planmodifier.String.
+func (useNonEmptyStateForUnknownModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// "" is what older versions stored when the API had no value, so it must not be copied into the plan
+	// either or an apply that returns null would be inconsistent with it
+	if req.StateValue.IsNull() || req.StateValue.ValueString() == "" {
+		return
+	}
+
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}
+
+// UseNonEmptyStateForUnknown behaves like UseNonNullStateForUnknown but also leaves the plan unknown when the
+// prior state holds an empty string.
+func UseNonEmptyStateForUnknown() planmodifier.String {
+	return useNonEmptyStateForUnknownModifier{}
+}

--- a/internal/planmodifier/use_non_empty_state_for_unknown_test.go
+++ b/internal/planmodifier/use_non_empty_state_for_unknown_test.go
@@ -1,0 +1,102 @@
+package planmodifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestUseNonEmptyStateForUnknownModifier(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  planmodifier.StringRequest
+		expected *planmodifier.StringResponse
+	}{
+		"null-state": {
+			// on create there is nothing to copy
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringNull(),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"empty-state": {
+			// a legacy "" in state stays unknown so an apply that reads null is accepted
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue(""),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"non-empty-state": {
+			// a real value in state is kept, like UseNonNullStateForUnknown
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("exact"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue("exact"),
+			},
+		},
+		"known-plan": {
+			// a configured or already planned value is left alone
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("exact"),
+				PlanValue:   types.StringValue("contains"),
+				ConfigValue: types.StringValue("contains"),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue("contains"),
+			},
+		},
+		"empty-state-no-change": {
+			// with no pending change the plan already equals the state and is not touched
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue(""),
+				PlanValue:   types.StringValue(""),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(""),
+			},
+		},
+		"unknown-config": {
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("exact"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringUnknown(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			resp := &planmodifier.StringResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			UseNonEmptyStateForUnknown().PlanModifyString(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With `provider_settings` configured but the two match modes left out, every plan after a create or update reports

```
Note: Objects have changed outside of Terraform
    - issue_comment_match_mode  = "" -> null
    - review_comment_match_mode = "" -> null
```

and anything referencing `provider_settings` (an output, a module) sees a change on every plan until state is rewritten. The REST create/update responses return `""` for an unset match mode while the GraphQL read returns null; the REST side now reads `""` as null too. Configured values are untouched (the validator never allowed `""`). The "" has been written since the match modes were added in #1156 (v1.35.0), so existing state files carry it; to keep a -refresh=false apply consistent with that state, the two attributes now use a variant of UseNonNullStateForUnknown that treats "" in state like null and leaves the plan unknown when an update is pending.

Added a unit test and an acceptance test (provider_settings without the match modes plus an output, relying on the empty follow-up plan) that fails on main and passes here; ran it locally against a test organization.

## PR checklist:
- [ ] `docs/` updated <-- no schema change
- [x] tests added
- [ ] an example added to `examples/` <-- bug fix
- [ ] `CHANGELOG.md` updated with pending release information <-- left for the release process